### PR TITLE
fix: remove legacy firebase-functions import (Gen2 ESM)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,5 @@
 // Cloud Functions v2 (Node 20, ESM) — Stripe Checkout wired with secrets
 
-import functions from "firebase-functions";
 import admin from "firebase-admin";
 import Stripe from "stripe";
 import { onCall, onRequest, HttpsError } from "firebase-functions/v2/https";


### PR DESCRIPTION
## Summary
- remove unused firebase-functions v1 import from functions/index.js

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 62 problems, 50 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a96dea44832590a8dec8edbbb2ab