### PR TITLE
fix: Gen2 Stripe secrets (bind via v2 options + lazy load)

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,28 +1,27 @@
 // Cloud Functions v2 (Node 20, ESM) — Stripe Checkout wired with secrets
 
-import admin from "firebase-admin";
-import Stripe from "stripe";
 import { onCall, onRequest, HttpsError } from "firebase-functions/v2/https";
 import { setGlobalOptions } from "firebase-functions/v2";
+import admin from "firebase-admin";
+import Stripe from "stripe";
 
 admin.initializeApp();
 
-const STRIPE_SECRET = process.env.STRIPE_SECRET;
-const STRIPE_WEBHOOK = process.env.STRIPE_WEBHOOK;
-
-if (!STRIPE_SECRET || !STRIPE_WEBHOOK) {
-  console.error(
-    "Missing Stripe secrets. Need STRIPE_SECRET and STRIPE_WEBHOOK env vars."
-  );
-}
-
-// Pinned Stripe client for deterministic API behaviour.
-const stripe = new Stripe(STRIPE_SECRET, { apiVersion: "2024-06-20" });
-
-// Make region global
 setGlobalOptions({
   region: "us-central1",
 });
+
+const getStripe = () => {
+  const key = process.env.STRIPE_SECRET;
+  if (!key) throw new Error("STRIPE_SECRET not set");
+  return new Stripe(key, { apiVersion: "2024-06-20" });
+};
+
+const getWebhookSecret = () => {
+  const s = process.env.STRIPE_WEBHOOK;
+  if (!s) throw new Error("STRIPE_WEBHOOK not set");
+  return s;
+};
 
 // --- LIVE Stripe Price IDs (keep the ones you showed) ---
 const PRICES = {
@@ -41,57 +40,69 @@ function assertAuthed(auth) {
 }
 
 // ===== Callable: create Stripe Checkout session =====
-export const createCheckoutSession = onCall(async (request) => {
-  const uid = assertAuthed(request.auth);
-  const plan = String(request.data?.plan || "");
+export const createCheckoutSession = onCall(
+  { secrets: ["STRIPE_SECRET"] },
+  async (request) => {
+    const stripe = getStripe();
+    const uid = assertAuthed(request.auth);
+    const plan = String(request.data?.plan || "");
 
-  if (!Object.prototype.hasOwnProperty.call(PRICES, plan)) {
-    throw new HttpsError("invalid-argument", "Invalid plan");
+    if (!Object.prototype.hasOwnProperty.call(PRICES, plan)) {
+      throw new HttpsError("invalid-argument", "Invalid plan");
+    }
+
+    const priceId = PRICES[plan];
+    const price = await stripe.prices.retrieve(priceId);
+    const mode = price?.recurring ? "subscription" : "payment";
+
+    const domain = "https://mybodyscanapp.com";
+
+    const session = await stripe.checkout.sessions.create({
+      mode,
+      line_items: [{ price: priceId, quantity: 1 }],
+      success_url: `${domain}/plans?success=1`,
+      cancel_url: `${domain}/plans?canceled=1`,
+      client_reference_id: uid,
+      metadata: { uid, plan },
+    });
+
+    return { url: session.url };
   }
-
-  const priceId = PRICES[plan];
-  const price = await stripe.prices.retrieve(priceId);
-  const mode = price?.recurring ? "subscription" : "payment";
-
-  const domain = "https://mybodyscanapp.com";
-
-  const session = await stripe.checkout.sessions.create({
-    mode,
-    line_items: [{ price: priceId, quantity: 1 }],
-    success_url: `${domain}/plans?success=1`,
-    cancel_url: `${domain}/plans?canceled=1`,
-    client_reference_id: uid,
-    metadata: { uid, plan },
-  });
-
-  return { url: session.url };
-});
+);
 
 // ===== HTTPS: Stripe Webhook (minimal verify + 200) =====
-export const stripeWebhook = onRequest(async (req, res) => {
-  if (req.method !== "POST") {
-    res.status(405).send("Method not allowed");
-    return;
-  }
-
-  let event;
-  try {
+export const stripeWebhook = onRequest(
+  { secrets: ["STRIPE_SECRET", "STRIPE_WEBHOOK"] },
+  async (req, res) => {
+    if (req.method !== "POST") {
+      res.status(405).send("Method Not Allowed");
+      return;
+    }
     console.log(
-      "hasSig:", !!req.headers["stripe-signature"],
-      "rawIsBuf:", Buffer.isBuffer(req.rawBody),
-      "rawLen:", req.rawBody?.length || 0
+      "hasSig:",
+      !!req.headers["stripe-signature"],
+      "rawIsBuf:",
+      Buffer.isBuffer(req.rawBody),
+      "rawLen:",
+      req.rawBody?.length || 0
     );
-    event = stripe.webhooks.constructEvent(
-      req.rawBody,
-      req.headers["stripe-signature"],
-      STRIPE_WEBHOOK
-    );
-  } catch (e) {
-    console.error("Webhook verify failed:", e?.message);
-    res.status(400).send(`Webhook Error: ${e?.message}`);
-    return;
-  }
+    const stripe = getStripe();
+    const whsec = getWebhookSecret();
+    let event;
+    try {
+      event = stripe.webhooks.constructEvent(
+        req.rawBody,
+        req.headers["stripe-signature"],
+        whsec
+      );
+    } catch (e) {
+      console.error("Webhook verify failed:", e?.message);
+      res.status(400).send(`Webhook Error: ${e?.message}`);
+      return;
+    }
 
-  console.log("Stripe event:", event.type);
-  res.json({ received: true });
-});
+    console.log("Stripe event:", event.type);
+    res.json({ received: true });
+  }
+);
+


### PR DESCRIPTION
## Summary
- bind Stripe secrets to Cloud Functions v2 triggers and lazily read from Secret Manager env vars
- verify webhook requests using rawBody with bound webhook secret

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 50 errors, 12 warnings)*
- `npm --prefix functions test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b3c3a281188325aaa78477bf76ebf8