### PR TITLE
feat: live credits from users/{uid}.credits + debug page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import CheckoutCanceled from "./pages/CheckoutCanceled";
 import ScanNew from "./pages/ScanNew";
 import ScanResult from "./pages/ScanResult";
 import Report from "./pages/Report";
+import DebugCredits from "./pages/DebugCredits";
 
 const OnboardingMBS = lazy(() => import("./pages/OnboardingMBS"));
 
@@ -83,6 +84,7 @@ const App = () => {
             {/* Report routes */}
             <Route path="/report" element={<ProtectedRoute><AuthedLayout><Report /></AuthedLayout></ProtectedRoute>} />
             <Route path="/report/:scanId" element={<ProtectedRoute><AuthedLayout><Report /></AuthedLayout></ProtectedRoute>} />
+            <Route path="/debug/credits" element={<DebugCredits />} />
             {/* MBS Onboarding */}
             <Route
               path="/onboarding-mbs"

--- a/src/components/AuthedLayout.tsx
+++ b/src/components/AuthedLayout.tsx
@@ -3,9 +3,11 @@ import { useNavigate, NavLink } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { signOutToAuth } from "@/lib/auth";
 import Footer from "./Footer";
+import { useCredits } from "@/hooks/useCredits";
 
 export default function AuthedLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
+  const { credits } = useCredits();
   return (
     <div className="min-h-screen flex flex-col">
       <header className="sticky top-0 z-10 bg-background/80 backdrop-blur border-b">
@@ -20,6 +22,7 @@ export default function AuthedLayout({ children }: { children: ReactNode }) {
             <NavLink to="/report" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Report</NavLink>
             <NavLink to="/plans" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Plans</NavLink>
             <NavLink to="/settings" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Settings</NavLink>
+            <span className="opacity-80">Credits: {credits}</span>
             <Button size="sm" variant="outline" onClick={signOutToAuth}>Sign out</Button>
           </nav>
         </div>

--- a/src/hooks/useCredits.ts
+++ b/src/hooks/useCredits.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+import { onAuthStateChanged } from "firebase/auth";
+import { doc, onSnapshot } from "firebase/firestore";
+import { auth, db, firebaseConfig } from "@/lib/firebase";
+
+export function useCredits() {
+  const [credits, setCredits] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [uid, setUid] = useState<string | null>(null);
+  const projectId = firebaseConfig.projectId;
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(
+      auth,
+      (u) => {
+        setUid(u?.uid ?? null);
+        if (!u) {
+          setCredits(0);
+          setLoading(false);
+        }
+      },
+      (err) => {
+        setError(err.message);
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, []);
+
+  useEffect(() => {
+    if (!uid) return;
+
+    setLoading(true);
+    const ref = doc(db, "users", uid);
+    const unsub = onSnapshot(
+      ref,
+      (snap) => {
+        interface UserDoc { credits?: number | { wallet?: number } }
+        const data = snap.data() as UserDoc | undefined;
+        const value = data?.credits;
+        const amount = typeof value === "number" ? value : value?.wallet ?? 0;
+        setCredits(amount ?? 0);
+        setLoading(false);
+      },
+      (err) => {
+        console.error("Error fetching credits:", err);
+        setError(err.message);
+        setLoading(false);
+      }
+    );
+    return () => unsub();
+  }, [uid]);
+
+  return { credits, loading, error, uid, projectId };
+}
+

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,22 +1,22 @@
 // Firebase initialization - single source of truth
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApps } from "firebase/app";
 import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 
-const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY || "AIzaSyDA90cwKTCQ9tGfUx66PDmfGwUoiTbhafE",
   authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN || "mybodyscan-f3daf.firebaseapp.com",
   projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID || "mybodyscan-f3daf",
   storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET || "mybodyscan-f3daf.appspot.com",
   messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID || "157018993008",
   appId: import.meta.env.VITE_FIREBASE_APP_ID || "1:157018993008:web:8bed67e098ca04dc4b1fb5",
-  measurementId: "G-TV8M3PY1X3"
+  measurementId: "G-TV8M3PY1X3",
 };
 
 // Initialize Firebase only once
-import { getApps } from "firebase/app";
 export const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
+

--- a/src/pages/DebugCredits.tsx
+++ b/src/pages/DebugCredits.tsx
@@ -1,0 +1,18 @@
+import { useCredits } from "@/hooks/useCredits";
+
+export default function DebugCredits() {
+  const { credits, uid, projectId } = useCredits();
+  const docPath = uid ? `users/${uid}` : null;
+
+  return (
+    <main className="p-6 space-y-2">
+      <h1 className="text-lg font-semibold">Credits Debug</h1>
+      <div>projectId: {projectId}</div>
+      <div>uid: {uid ?? "(none)"}</div>
+      <div>doc path: {docPath ?? "users/{uid}"}</div>
+      <div>credits: {credits}</div>
+      {!uid && <p className="text-sm text-muted-foreground">Log in to watch live credits.</p>}
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create `useCredits` hook subscribing to `users/{uid}` and exposing projectId
- show live credits in header, settings, and new `/debug/credits` page
- export Firebase config so debug page can confirm project ID

## Testing
- `npm run lint` *(fails: Unexpected any in unrelated files)*
- `npx eslint src/hooks/useCredits.ts src/pages/DebugCredits.tsx src/components/AuthedLayout.tsx src/pages/Settings.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3c99493108325bc4f4a8f6d717b4e