### PR TITLE
feat: Post-scan coach, calorie tracker, Gen2-safe Stripe, + Health integrations (stubs)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -13,8 +13,23 @@ service cloud.firestore {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
       
-      // User reports - users can only access their own reports  
+      // User reports - users can only access their own reports
       match /reports/{reportId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      // Nutrition logs
+      match /nutritionLogs/{logId} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      // Coach profile & plan
+      match /coach/{document=**} {
+        allow read, write: if request.auth != null && request.auth.uid == userId;
+      }
+
+      // Health data
+      match /healthDaily/{day} {
         allow read, write: if request.auth != null && request.auth.uid == userId;
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,12 +25,18 @@ import PublicLanding from "./pages/PublicLanding";
 import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
 import Support from "./pages/Support";
+import Disclaimer from "./pages/Disclaimer";
 import CheckoutSuccess from "./pages/CheckoutSuccess";
 import CheckoutCanceled from "./pages/CheckoutCanceled";
 import ScanNew from "./pages/ScanNew";
 import ScanResult from "./pages/ScanResult";
 import Report from "./pages/Report";
 import DebugCredits from "./pages/DebugCredits";
+import CoachOnboarding from "./pages/CoachOnboarding";
+import CoachTracker from "./pages/CoachTracker";
+import SettingsHealth from "./pages/SettingsHealth";
+import DebugPlan from "./pages/DebugPlan";
+import DebugHealth from "./pages/DebugHealth";
 
 const OnboardingMBS = lazy(() => import("./pages/OnboardingMBS"));
 
@@ -54,6 +60,7 @@ const App = () => {
             <Route path="/" element={<PublicLayout><PublicLanding /></PublicLayout>} />
             <Route path="/privacy" element={<PublicLayout><Privacy /></PublicLayout>} />
             <Route path="/terms" element={<PublicLayout><Terms /></PublicLayout>} />
+            <Route path="/legal/disclaimer" element={<PublicLayout><Disclaimer /></PublicLayout>} />
             <Route path="/support" element={<PublicLayout><Support /></PublicLayout>} />
             {/* Checkout result pages (public) */}
             <Route path="/checkout/success" element={<PublicLayout><CheckoutSuccess /></PublicLayout>} />
@@ -78,6 +85,9 @@ const App = () => {
             <Route path="/history" element={<ProtectedRoute><AuthedLayout><History /></AuthedLayout></ProtectedRoute>} />
             <Route path="/plans" element={<ProtectedRoute><AuthedLayout><Plans /></AuthedLayout></ProtectedRoute>} />
             <Route path="/settings" element={<ProtectedRoute><AuthedLayout><Settings /></AuthedLayout></ProtectedRoute>} />
+            <Route path="/coach/onboarding" element={<ProtectedRoute><AuthedLayout><CoachOnboarding /></AuthedLayout></ProtectedRoute>} />
+            <Route path="/coach/tracker" element={<ProtectedRoute><AuthedLayout><CoachTracker /></AuthedLayout></ProtectedRoute>} />
+            <Route path="/settings/health" element={<ProtectedRoute><AuthedLayout><SettingsHealth /></AuthedLayout></ProtectedRoute>} />
             {/* New scan routes */}
             <Route path="/scan/new" element={<ProtectedRoute><AuthedLayout><ScanNew /></AuthedLayout></ProtectedRoute>} />
             <Route path="/scan/:scanId" element={<ProtectedRoute><AuthedLayout><ScanResult /></AuthedLayout></ProtectedRoute>} />
@@ -85,6 +95,8 @@ const App = () => {
             <Route path="/report" element={<ProtectedRoute><AuthedLayout><Report /></AuthedLayout></ProtectedRoute>} />
             <Route path="/report/:scanId" element={<ProtectedRoute><AuthedLayout><Report /></AuthedLayout></ProtectedRoute>} />
             <Route path="/debug/credits" element={<DebugCredits />} />
+            <Route path="/debug/plan" element={<DebugPlan />} />
+            <Route path="/debug/health" element={<DebugHealth />} />
             {/* MBS Onboarding */}
             <Route
               path="/onboarding-mbs"

--- a/src/components/AuthedLayout.tsx
+++ b/src/components/AuthedLayout.tsx
@@ -22,7 +22,7 @@ export default function AuthedLayout({ children }: { children: ReactNode }) {
             <NavLink to="/report" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Report</NavLink>
             <NavLink to="/plans" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Plans</NavLink>
             <NavLink to="/settings" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Settings</NavLink>
-            <span className="opacity-80">Credits: {credits}</span>
+            <NavLink to="/coach/tracker" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Credits: {credits}</NavLink>
             <Button size="sm" variant="outline" onClick={signOutToAuth}>Sign out</Button>
           </nav>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,6 +13,9 @@ export default function Footer() {
             <a href="/terms" className="hover:text-foreground transition-colors">
               Terms
             </a>
+            <a href="/legal/disclaimer" className="hover:text-foreground transition-colors">
+              Disclaimer
+            </a>
             <a href="mailto:support@mybodyscan.com" className="hover:text-foreground transition-colors">
               Support
             </a>

--- a/src/hooks/useHealthDaily.ts
+++ b/src/hooks/useHealthDaily.ts
@@ -1,0 +1,39 @@
+import { Capacitor } from "@capacitor/core";
+import { useMemo } from "react";
+import { auth, db } from "@/lib/firebase";
+import { doc, setDoc, serverTimestamp } from "firebase/firestore";
+import type { DailySummary, HealthAdapter } from "@/integrations/health/HealthAdapter";
+import { WebMockAdapter } from "@/integrations/health/WebMockAdapter";
+import { IOSHealthKitAdapter } from "@/integrations/health/IOSHealthKitAdapter";
+import { AndroidHealthConnectAdapter } from "@/integrations/health/AndroidHealthConnectAdapter";
+
+export function useHealthDaily() {
+  const platform = Capacitor.getPlatform();
+
+  const adapter: HealthAdapter = useMemo(() => {
+    if (platform === "ios") return new IOSHealthKitAdapter();
+    if (platform === "android") return new AndroidHealthConnectAdapter();
+    return new WebMockAdapter();
+  }, [platform]);
+
+  async function connect() {
+    return adapter.requestPermissions();
+  }
+
+  async function syncDay(date: string): Promise<DailySummary> {
+    const summary = await adapter.getDailySummary(date);
+    const uid = auth.currentUser?.uid;
+    if (uid) {
+      const ref = doc(db, "users", uid, "healthDaily", date);
+      await setDoc(
+        ref,
+        { ...summary, syncedAt: serverTimestamp() },
+        { merge: true }
+      );
+    }
+    return summary;
+  }
+
+  return { platform, connect, syncDay };
+}
+

--- a/src/hooks/useSpendCredit.ts
+++ b/src/hooks/useSpendCredit.ts
@@ -1,0 +1,13 @@
+import { app } from "@/lib/firebase";
+import { getFunctions, httpsCallable } from "firebase/functions";
+
+export function useSpendCredit() {
+  async function spend(reason?: string) {
+    const fn = httpsCallable(getFunctions(app), "useCredit");
+    const { data } = await fn({ reason });
+    return data as { ok: boolean; remaining: number };
+  }
+
+  return { spend };
+}
+

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { auth, db } from "@/lib/firebase";
+import { doc, onSnapshot } from "firebase/firestore";
+
+export interface CoachProfile {
+  sex?: "male" | "female";
+  age?: number;
+  dob?: string;
+  height_cm?: number;
+  weight_kg?: number;
+  activity_level?: "sedentary" | "light" | "moderate" | "very" | "extra";
+  goal?: "lose_fat" | "gain_muscle" | "improve_heart";
+  timeframe_weeks?: number;
+  style?: "ease_in" | "all_in";
+  medical_flags?: Record<string, boolean>;
+}
+
+export interface CoachPlan {
+  tdee: number;
+  target_kcal: number;
+  goal: string;
+  style: string;
+  protein_g: number;
+  fat_g: number;
+  carbs_g: number;
+  [k: string]: unknown;
+}
+
+export function useUserProfile() {
+  const [profile, setProfile] = useState<CoachProfile | null>(null);
+  const [plan, setPlan] = useState<CoachPlan | null>(null);
+  const uid = auth.currentUser?.uid || null;
+
+  useEffect(() => {
+    if (!uid) return;
+    const profileRef = doc(db, "users", uid, "coach", "profile");
+    const unsub1 = onSnapshot(profileRef, (snap) => {
+      setProfile((snap.data() as CoachProfile) || null);
+    });
+    const planRef = doc(db, "users", uid, "coach", "plan", "current");
+    const unsub2 = onSnapshot(planRef, (snap) => {
+      setPlan((snap.data() as CoachPlan) || null);
+    });
+    return () => {
+      unsub1();
+      unsub2();
+    };
+  }, [uid]);
+
+  return { profile, plan };
+}
+

--- a/src/integrations/health/AndroidHealthConnectAdapter.ts
+++ b/src/integrations/health/AndroidHealthConnectAdapter.ts
@@ -1,0 +1,28 @@
+import { Capacitor } from "@capacitor/core";
+import { DailySummary, HealthAdapter } from "./HealthAdapter";
+
+export class AndroidHealthConnectAdapter implements HealthAdapter {
+  platform: "android" = "android";
+
+  async canImport(): Promise<boolean> {
+    return Capacitor.getPlatform() === "android";
+  }
+
+  async requestPermissions(): Promise<boolean> {
+    if (Capacitor.getPlatform() !== "android") return false;
+    try {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - dynamic import placeholder
+      await import("@some/health-connect-plugin");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getDailySummary(date: string): Promise<DailySummary> {
+    // TODO: implement real Health Connect / Google Fit query
+    return { source: "mock" };
+  }
+}
+

--- a/src/integrations/health/HealthAdapter.ts
+++ b/src/integrations/health/HealthAdapter.ts
@@ -1,0 +1,14 @@
+export type DailySummary = {
+  activeEnergyKcal?: number;
+  steps?: number;
+  restingHeartRate?: number;
+  source: "mock" | "healthkit" | "healthconnect" | "googlefit";
+};
+
+export interface HealthAdapter {
+  platform: "web" | "ios" | "android";
+  canImport(): Promise<boolean>;
+  requestPermissions(): Promise<boolean>;
+  getDailySummary(date: string): Promise<DailySummary>;
+}
+

--- a/src/integrations/health/IOSHealthKitAdapter.ts
+++ b/src/integrations/health/IOSHealthKitAdapter.ts
@@ -1,0 +1,35 @@
+import { Capacitor } from "@capacitor/core";
+import { DailySummary, HealthAdapter } from "./HealthAdapter";
+
+export class IOSHealthKitAdapter implements HealthAdapter {
+  platform: "ios" = "ios";
+
+  async canImport(): Promise<boolean> {
+    return Capacitor.getPlatform() === "ios";
+  }
+
+  async requestPermissions(): Promise<boolean> {
+    if (Capacitor.getPlatform() !== "ios") return false;
+    try {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore - dynamic import of potential plugins
+      await import("@capgo/capacitor-healthkit");
+      return true;
+    } catch {
+      try {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        await import("capacitor-plugin-healthkit");
+        return true;
+      } catch {
+        return false;
+      }
+    }
+  }
+
+  async getDailySummary(date: string): Promise<DailySummary> {
+    // TODO: implement real HealthKit query
+    return { source: "mock" };
+  }
+}
+

--- a/src/integrations/health/WebMockAdapter.ts
+++ b/src/integrations/health/WebMockAdapter.ts
@@ -1,0 +1,18 @@
+import { DailySummary, HealthAdapter } from "./HealthAdapter";
+
+export class WebMockAdapter implements HealthAdapter {
+  platform: "web" = "web";
+
+  async canImport(): Promise<boolean> {
+    return false;
+  }
+
+  async requestPermissions(): Promise<boolean> {
+    return false;
+  }
+
+  async getDailySummary(date: string): Promise<DailySummary> {
+    return { source: "mock" };
+  }
+}
+

--- a/src/pages/CoachOnboarding.tsx
+++ b/src/pages/CoachOnboarding.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react";
+import { app } from "@/lib/firebase";
+import { getFunctions, httpsCallable } from "firebase/functions";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useNavigate, Link } from "react-router-dom";
+
+type Step = 1 | 2 | 3 | 4;
+
+const CoachOnboarding = () => {
+  const [step, setStep] = useState<Step>(1);
+  const [form, setForm] = useState<any>({
+    goal: "lose_fat",
+    style: "ease_in",
+    timeframe_weeks: 12,
+    sex: "male",
+    age: 30,
+    height_cm: 170,
+    weight_kg: 70,
+    activity_level: "light",
+    medical_flags: {},
+    ack: { disclaimer: false },
+  });
+  const [plan, setPlan] = useState<any>(null);
+  const navigate = useNavigate();
+
+  const update = (k: string, v: any) => setForm((f: any) => ({ ...f, [k]: v }));
+
+  async function finish() {
+    const functions = getFunctions(app);
+    const save = httpsCallable(functions, "saveOnboarding");
+    const compute = httpsCallable(functions, "computePlan");
+    await save(form);
+    const { data } = await compute({});
+    setPlan(data);
+    setStep(4);
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-4 space-y-4">
+      {step === 1 && (
+        <div className="space-y-3">
+          <h1 className="text-xl font-semibold">Your goals</h1>
+          <label className="block">
+            Goal
+            <select
+              className="mt-1 w-full border p-2"
+              value={form.goal}
+              onChange={(e) => update("goal", e.target.value)}
+            >
+              <option value="lose_fat">Lose fat</option>
+              <option value="gain_muscle">Gain muscle</option>
+              <option value="improve_heart">Improve heart</option>
+            </select>
+          </label>
+          <label className="block">
+            Style
+            <select
+              className="mt-1 w-full border p-2"
+              value={form.style}
+              onChange={(e) => update("style", e.target.value)}
+            >
+              <option value="ease_in">Ease in</option>
+              <option value="all_in">All in</option>
+            </select>
+          </label>
+          <label className="block">
+            Timeframe (weeks)
+            <Input
+              type="number"
+              value={form.timeframe_weeks}
+              onChange={(e) => update("timeframe_weeks", Number(e.target.value))}
+            />
+          </label>
+          <Button onClick={() => setStep(2)}>Next</Button>
+        </div>
+      )}
+
+      {step === 2 && (
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Body stats</h2>
+          <label className="block">
+            Sex
+            <select
+              className="mt-1 w-full border p-2"
+              value={form.sex}
+              onChange={(e) => update("sex", e.target.value)}
+            >
+              <option value="male">Male</option>
+              <option value="female">Female</option>
+            </select>
+          </label>
+          <label className="block">
+            Age
+            <Input
+              type="number"
+              value={form.age}
+              onChange={(e) => update("age", Number(e.target.value))}
+            />
+          </label>
+          <label className="block">
+            Height (cm)
+            <Input
+              type="number"
+              value={form.height_cm}
+              onChange={(e) => update("height_cm", Number(e.target.value))}
+            />
+          </label>
+          <label className="block">
+            Weight (kg)
+            <Input
+              type="number"
+              value={form.weight_kg}
+              onChange={(e) => update("weight_kg", Number(e.target.value))}
+            />
+          </label>
+          <label className="block">
+            Activity level
+            <select
+              className="mt-1 w-full border p-2"
+              value={form.activity_level}
+              onChange={(e) => update("activity_level", e.target.value)}
+            >
+              <option value="sedentary">Sedentary</option>
+              <option value="light">Light</option>
+              <option value="moderate">Moderate</option>
+              <option value="very">Very</option>
+              <option value="extra">Extra</option>
+            </select>
+          </label>
+          <div className="flex justify-between">
+            <Button variant="secondary" onClick={() => setStep(1)}>
+              Back
+            </Button>
+            <Button onClick={() => setStep(3)}>Next</Button>
+          </div>
+        </div>
+      )}
+
+      {step === 3 && (
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Safety & consent</h2>
+          {[
+            "pregnant",
+            "under18",
+            "eating_disorder_history",
+            "heart_condition",
+          ].map((f) => (
+            <label key={f} className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={form.medical_flags[f] || false}
+                onChange={(e) =>
+                  update("medical_flags", {
+                    ...form.medical_flags,
+                    [f]: e.target.checked,
+                  })
+                }
+              />
+              <span>{f.replace(/_/g, " ")}</span>
+            </label>
+          ))}
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form.ack.disclaimer}
+              onChange={(e) =>
+                update("ack", { ...form.ack, disclaimer: e.target.checked })
+              }
+            />
+            <span>
+              I accept the <Link to="/legal/disclaimer" className="underline">disclaimer</Link>
+            </span>
+          </label>
+          <div className="flex justify-between">
+            <Button variant="secondary" onClick={() => setStep(2)}>
+              Back
+            </Button>
+            <Button onClick={finish}>Compute plan</Button>
+          </div>
+        </div>
+      )}
+
+      {step === 4 && plan && (
+        <div className="space-y-3">
+          <h2 className="text-xl font-semibold">Your plan</h2>
+          <div className="text-sm">Target kcal: {plan.target_kcal}</div>
+          <div className="flex gap-2 text-sm">
+            <span>Protein {plan.protein_g}g</span>
+            <span>Fat {plan.fat_g}g</span>
+            <span>Carbs {plan.carbs_g}g</span>
+          </div>
+          {plan.needs_clearance && (
+            <div className="text-red-600 text-sm">{plan.message}</div>
+          )}
+          <Button onClick={() => navigate("/coach/tracker")}>Start tracking</Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CoachOnboarding;
+

--- a/src/pages/CoachTracker.tsx
+++ b/src/pages/CoachTracker.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { auth, db } from "@/lib/firebase";
+import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore";
+import { format, subDays } from "date-fns";
+import { LineChart, Line, XAxis, YAxis, Tooltip } from "recharts";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { useUserProfile } from "@/hooks/useUserProfile";
+
+const CoachTracker = () => {
+  const { plan } = useUserProfile();
+  const uid = auth.currentUser?.uid;
+  const today = format(new Date(), "yyyy-MM-dd");
+  const [log, setLog] = useState({
+    calories: 0,
+    protein_g: 0,
+    carbs_g: 0,
+    fat_g: 0,
+  });
+  const [chart, setChart] = useState<any[]>([]);
+  const [yesterday, setYesterday] = useState<any>(null);
+  const [offset, setOffset] = useState(false);
+
+  useEffect(() => {
+    if (!uid) return;
+    (async () => {
+      const snap = await getDoc(doc(db, "users", uid, "nutritionLogs", today));
+      if (snap.exists()) {
+        setLog({
+          calories: snap.data().calories || 0,
+          protein_g: snap.data().protein_g || 0,
+          carbs_g: snap.data().carbs_g || 0,
+          fat_g: snap.data().fat_g || 0,
+        });
+      }
+    })();
+  }, [uid, today]);
+
+  async function save() {
+    if (!uid) return;
+    const ref = doc(db, "users", uid, "nutritionLogs", today);
+    await setDoc(ref, { ...log, updatedAt: serverTimestamp() }, { merge: true });
+    await loadChart();
+  }
+
+  async function loadChart() {
+    if (!uid) return;
+    const arr: any[] = [];
+    for (let i = 6; i >= 0; i--) {
+      const day = format(subDays(new Date(), i), "yyyy-MM-dd");
+      const snap = await getDoc(doc(db, "users", uid, "nutritionLogs", day));
+      arr.push({ date: day, calories: snap.exists() ? snap.data().calories || 0 : 0 });
+    }
+    setChart(arr);
+    const yDay = format(subDays(new Date(), 1), "yyyy-MM-dd");
+    const ySnap = await getDoc(doc(db, "users", uid, "healthDaily", yDay));
+    if (ySnap.exists()) setYesterday(ySnap.data());
+  }
+
+  useEffect(() => {
+    loadChart().catch(() => {});
+  }, [uid]);
+
+  const total = log.calories || 0;
+  const target = plan?.target_kcal || 0;
+  const adjusted = offset ? target + (yesterday?.activeEnergyKcal || 0) : target;
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Calorie Tracker</h1>
+      <div>Target: {target} kcal {offset && `(adjusted ${adjusted})`}</div>
+      {yesterday?.activeEnergyKcal && (
+        <div className="text-sm">Yesterday burn: {yesterday.activeEnergyKcal} kcal</div>
+      )}
+      <label className="flex items-center gap-2 text-sm">
+        <Switch checked={offset} onCheckedChange={setOffset} />
+        Experimental: offset calories by activity
+      </label>
+      <div className="space-y-2">
+        <Input
+          type="number"
+          value={log.calories}
+          onChange={(e) => setLog({ ...log, calories: Number(e.target.value) })}
+          placeholder="Calories"
+        />
+        <Input
+          type="number"
+          value={log.protein_g}
+          onChange={(e) => setLog({ ...log, protein_g: Number(e.target.value) })}
+          placeholder="Protein g"
+        />
+        <Input
+          type="number"
+          value={log.carbs_g}
+          onChange={(e) => setLog({ ...log, carbs_g: Number(e.target.value) })}
+          placeholder="Carbs g"
+        />
+        <Input
+          type="number"
+          value={log.fat_g}
+          onChange={(e) => setLog({ ...log, fat_g: Number(e.target.value) })}
+          placeholder="Fat g"
+        />
+        <Button onClick={save}>Save</Button>
+      </div>
+      <div>Total today: {total} kcal</div>
+      <div className="h-64">
+        <LineChart data={chart}>
+          <XAxis dataKey="date" hide />
+          <YAxis hide />
+          <Tooltip />
+          <Line type="monotone" dataKey="calories" stroke="#8884d8" />
+        </LineChart>
+      </div>
+    </div>
+  );
+};
+
+export default CoachTracker;
+

--- a/src/pages/DebugHealth.tsx
+++ b/src/pages/DebugHealth.tsx
@@ -1,0 +1,33 @@
+import { useEffect, useState } from "react";
+import { auth, db } from "@/lib/firebase";
+import { doc, getDoc } from "firebase/firestore";
+import { format } from "date-fns";
+import { useHealthDaily } from "@/hooks/useHealthDaily";
+
+const DebugHealth = () => {
+  const { platform, connect } = useHealthDaily();
+  const [perm, setPerm] = useState<boolean | null>(null);
+  const [last, setLast] = useState<any>(null);
+  const uid = auth.currentUser?.uid;
+
+  useEffect(() => {
+    connect().then((v) => setPerm(v));
+  }, []);
+
+  useEffect(() => {
+    if (!uid) return;
+    const today = format(new Date(), "yyyy-MM-dd");
+    getDoc(doc(db, "users", uid, "healthDaily", today)).then((snap) => {
+      if (snap.exists()) setLast(snap.data());
+    });
+  }, [uid]);
+
+  return (
+    <pre className="text-xs whitespace-pre-wrap">
+      {JSON.stringify({ platform, permission: perm, last }, null, 2)}
+    </pre>
+  );
+};
+
+export default DebugHealth;
+

--- a/src/pages/DebugPlan.tsx
+++ b/src/pages/DebugPlan.tsx
@@ -1,0 +1,13 @@
+import { useUserProfile } from "@/hooks/useUserProfile";
+
+const DebugPlan = () => {
+  const { profile, plan } = useUserProfile();
+  return (
+    <pre className="text-xs whitespace-pre-wrap">
+      {JSON.stringify({ profile, plan }, null, 2)}
+    </pre>
+  );
+};
+
+export default DebugPlan;
+

--- a/src/pages/Disclaimer.tsx
+++ b/src/pages/Disclaimer.tsx
@@ -1,0 +1,28 @@
+import { Seo } from "@/components/Seo";
+
+const Disclaimer = () => {
+  return (
+    <>
+      <Seo
+        title="Disclaimer – MyBodyScan"
+        description="Health information notice"
+        canonical="https://mybodyscanapp.com/legal/disclaimer"
+      />
+      <article className="prose prose-neutral dark:prose-invert max-w-none">
+        <h1>Health Disclaimer</h1>
+        <p>
+          Not medical advice; see a doctor if under 18, pregnant or
+          breastfeeding, with eating disorder history, heart/kidney/liver
+          disease, diabetes on medication, or recent surgery.
+        </p>
+        <p>
+          Stop and seek emergency care if chest pain, fainting, or severe
+          dizziness. Calorie bounds are enforced.
+        </p>
+      </article>
+    </>
+  );
+};
+
+export default Disclaimer;
+

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import { auth, db } from "@/lib/firebase";
 import { doc, getDoc, updateDoc, serverTimestamp, collection, query, orderBy, limit, onSnapshot } from "firebase/firestore";
 import { useCredits } from "@/hooks/useCredits";
 import { openStripePortal } from "@/lib/api";
+import { useNavigate } from "react-router-dom";
 
 const Settings = () => {
   const [height, setHeight] = useState<string>("");
@@ -22,6 +23,7 @@ const Settings = () => {
   const [reminderEnabled, setReminderEnabled] = useState<boolean>(false);
   const [lastScanDate, setLastScanDate] = useState<Date | null>(null);
   const [saving, setSaving] = useState<boolean>(false);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const uid = auth.currentUser?.uid;
@@ -188,6 +190,15 @@ const Settings = () => {
             <Button variant="secondary" onClick={() => toast({ title: "Export requested", description: "We'll add this soon." })}>Export my data</Button>
             <Button variant="destructive" onClick={() => toast({ title: "Delete requested", description: "We'll add this soon." })}>Delete my data</Button>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle>Health Integrations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={() => navigate("/settings/health")}>Open health settings</Button>
         </CardContent>
       </Card>
     </main>

--- a/src/pages/SettingsHealth.tsx
+++ b/src/pages/SettingsHealth.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { format, subDays } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { useHealthDaily } from "@/hooks/useHealthDaily";
+import type { DailySummary } from "@/integrations/health/HealthAdapter";
+
+const SettingsHealth = () => {
+  const { platform, connect, syncDay } = useHealthDaily();
+  const [last, setLast] = useState<(DailySummary & { date: string }) | null>(null);
+
+  async function sync(offset: number) {
+    const date = format(subDays(new Date(), offset), "yyyy-MM-dd");
+    const s = await syncDay(date);
+    setLast({ date, ...s });
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-semibold">Health Integrations</h1>
+      {platform === "ios" && (
+        <Button onClick={connect}>Connect Apple Health</Button>
+      )}
+      {platform === "android" && (
+        <Button onClick={connect}>Connect Google Fit</Button>
+      )}
+      {platform === "web" && (
+        <div className="text-sm text-muted-foreground">
+          Connect on mobile to import activity.
+        </div>
+      )}
+      <div className="flex gap-2">
+        <Button onClick={() => sync(1)}>Sync yesterday</Button>
+        <Button onClick={() => sync(0)}>Sync today</Button>
+      </div>
+      {last && (
+        <div className="text-sm">
+          Last sync {last.date}: {last.activeEnergyKcal ?? ""} kcal burn
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SettingsHealth;
+


### PR DESCRIPTION
## Summary
- add callable useCredit, onboarding storage, and computePlan calorie engine
- basic coach onboarding wizard, calorie tracker, and health integration stubs
- expose credits in header and secure new coach/nutrition/health Firestore rules

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68b45be562648325a332ead545a71c2d