### PR TITLE
Prod AI (Replicate) + Credits Guard + Ledger + Binary-free CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci --legacy-peer-deps
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build
+      - run: npm run pretest:e2e
+      - run: npx firebase emulators:exec --only firestore,auth,storage,functions "npm run test:e2e"
+      - run: npm run lighthouse
+        env:
+          PREVIEW_URL: http://localhost:5173

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@ node_modules
 dist
 dist-ssr
 *.local
+.firebase/
+*.zip
+*.png
+*.jpg
+*.jpeg
+*.gif
+*.mp4
 
 # Env files
 .env.local

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,18 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    function isOwner(uid) { return request.auth != null && request.auth.uid == uid; }
+    match /users/{uid} {
+      allow read, update: if isOwner(uid);
+      allow create: if isOwner(uid);
+      match /scans/{scanId} {
+        allow read, create, update, delete: if isOwner(uid);
+      }
+      match /ledger/{entryId} {
+        // read by owner; writes are by server only — allow if request.auth.uid == uid, but client code should never write ledger directly
+        allow read: if isOwner(uid);
+        allow create, update, delete: if false;
+      }
+    }
+  }
+}

--- a/functions/aiScan.js
+++ b/functions/aiScan.js
@@ -1,0 +1,112 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { defineSecret } from "firebase-functions/params";
+import admin from "firebase-admin";
+import fetch from "node-fetch";
+
+const REPLICATE_API_TOKEN = defineSecret("REPLICATE_API_TOKEN");
+
+export const runBodyScan = onCall({ secrets: [REPLICATE_API_TOKEN] }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) {
+    throw new HttpsError("unauthenticated", "Authentication required");
+  }
+  const files = Array.isArray(request.data?.files) ? request.data.files : [];
+  if (!files.length) {
+    throw new HttpsError("invalid-argument", "files required");
+  }
+
+  const db = admin.firestore();
+  const userRef = db.doc(`users/${uid}`);
+  const userSnap = await userRef.get();
+  const available = userSnap.get("credits.available") || 0;
+  if (available < 1) {
+    throw new HttpsError("failed-precondition", "Insufficient credits");
+  }
+
+  const scanRef = db.collection(`users/${uid}/scans`).doc();
+  const isEmulator = process.env.FUNCTIONS_EMULATOR === "true" || process.env.NODE_ENV === "test";
+  let result;
+
+  if (isEmulator) {
+    result = { bodyFatPct: 18.7, weightKg: 78.1, bmi: 24.6, mock: true };
+    await scanRef.set({
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      files,
+      provider: "mock",
+      status: "succeeded",
+      result,
+    });
+  } else {
+    const bucket = admin.storage().bucket();
+    const signed = await Promise.all(
+      files.map(async (p) => {
+        const [url] = await bucket.file(p).getSignedUrl({
+          action: "read",
+          expires: Date.now() + 15 * 60 * 1000,
+        });
+        return url;
+      })
+    );
+    const token = REPLICATE_API_TOKEN.value();
+    if (!token) {
+      throw new HttpsError("failed-precondition", "Missing Replicate token");
+    }
+    const createRes = await fetch("https://api.replicate.com/v1/predictions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        version: "TODO", // TODO: specify model version
+        input: { images: signed },
+      }),
+    });
+    const createJson = await createRes.json();
+    let status = createJson.status;
+    let pollUrl = createJson.urls?.get || `https://api.replicate.com/v1/predictions/${createJson.id}`;
+    while (status === "starting" || status === "processing") {
+      await new Promise((r) => setTimeout(r, 1000));
+      const pollRes = await fetch(pollUrl, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const pollJson = await pollRes.json();
+      status = pollJson.status;
+      if (status === "succeeded") {
+        result = {
+          bodyFatPct: pollJson.output?.body_fat_pct,
+          weightKg: pollJson.output?.weight_kg,
+          bmi: pollJson.output?.bmi,
+        };
+      } else if (status === "failed") {
+        throw new HttpsError("internal", "Replicate prediction failed");
+      }
+    }
+    await scanRef.set({
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      files,
+      provider: "replicate",
+      status: "succeeded",
+      result,
+    });
+  }
+
+  await db.runTransaction(async (tx) => {
+    const snap = await tx.get(userRef);
+    const avail = snap.get("credits.available") || 0;
+    if (avail < 1) {
+      throw new HttpsError("failed-precondition", "Insufficient credits");
+    }
+    tx.update(userRef, { "credits.available": admin.firestore.FieldValue.increment(-1) });
+    const ledgerRef = userRef.collection("ledger").doc();
+    tx.set(ledgerRef, {
+      type: "debit",
+      amount: 1,
+      source: "scan",
+      ts: admin.firestore.FieldValue.serverTimestamp(),
+      scanId: scanRef.id,
+    });
+  });
+
+  return { scanId: scanRef.id, result };
+});

--- a/functions/index.js
+++ b/functions/index.js
@@ -10,10 +10,11 @@ import Stripe from "stripe";
 const STRIPE_SECRET = defineSecret("STRIPE_SECRET");
 const STRIPE_WEBHOOK = defineSecret("STRIPE_WEBHOOK");
 const REPLICATE_API_KEY = defineSecret("REPLICATE_API_KEY");
+const REPLICATE_API_TOKEN = defineSecret("REPLICATE_API_TOKEN");
 
 setGlobalOptions({
   region: "us-central1",
-  secrets: [STRIPE_SECRET, STRIPE_WEBHOOK, REPLICATE_API_KEY],
+  secrets: [STRIPE_SECRET, STRIPE_WEBHOOK, REPLICATE_API_KEY, REPLICATE_API_TOKEN],
 });
 
 admin.initializeApp();
@@ -655,3 +656,4 @@ export const computePlan = onCall(async (req) => {
   return { ...plan, weight_kg: weight, height_cm: height, weight_lb: kgToLb(weight), height_ft: ft, height_in: inch };
 });
 
+export { runBodyScan } from './aiScan.js';

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,6 +6,7 @@
     "firebase-admin": "^12.5.0",
     "firebase-functions": "^6.0.0",
     "cors": "^2.8.5",
-    "stripe": "^16.6.0"
+    "stripe": "^16.6.0",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,13 @@
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:unit": "vitest run",
     "test:rules": "vitest run tests/rules.test.ts",
+    "emulators": "firebase emulators:start --only firestore,auth,storage,functions --import ./emulator-data --export-on-exit",
+    "test:e2e": "playwright test",
+    "pretest:e2e": "playwright install --with-deps",
+    "lighthouse": "lhci autorun",
     "check:headers": "bash scripts/check-headers.sh $PREVIEW_URL"
   },
   "dependencies": {
@@ -89,6 +95,14 @@
     "typescript-eslint": "^8.38.0",
     "vite": "^5.4.19",
     "vitest": "^2.1.1",
-    "@firebase/rules-unit-testing": "^3.0.0"
+    "@firebase/rules-unit-testing": "^3.0.0",
+    "@playwright/test": "^1.47.0",
+    "lighthouse": "^12.0.0",
+    "@lhci/cli": "^0.14.0",
+    "firebase-tools": "^13.0.0",
+    "wait-on": "^7.2.0",
+    "ts-node": "^10.9.2",
+    "esbuild": "^0.21.0",
+    "node-fetch": "^3.3.2"
   }
 }

--- a/src/lib/aiProvider.ts
+++ b/src/lib/aiProvider.ts
@@ -1,0 +1,8 @@
+import { runBodyScan } from "./scan";
+
+export async function callBodyScan(files: string[]) {
+  if (import.meta.env.MODE === "test") {
+    return { scanId: "mock-scan", result: { bodyFatPct: 18.7, weightKg: 78.1, bmi: 24.6, mock: true } };
+  }
+  return runBodyScan(files);
+}

--- a/src/lib/scan.ts
+++ b/src/lib/scan.ts
@@ -2,6 +2,8 @@ import { db, storage } from "@/lib/firebase";
 import { doc, setDoc, serverTimestamp, onSnapshot } from "firebase/firestore";
 import { ref, uploadBytes } from "firebase/storage";
 import { authedFetch } from "@/lib/api";
+import { httpsCallable } from "firebase/functions";
+import { functions } from "./firebase";
 
 export interface StartScanResponse {
   scanId: string;
@@ -69,4 +71,10 @@ export function listenToScan(
       onError?.(error);
     }
   );
+}
+
+export async function runBodyScan(files: string[]): Promise<any> {
+  const call = httpsCallable(functions, "runBodyScan");
+  const { data } = await call({ files });
+  return data as any;
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,16 +1,20 @@
 rules_version = '2';
 service firebase.storage {
   match /b/{bucket}/o {
-    function signedIn() { return request.auth != null; }
-    function isOwner(uid) { return signedIn() && request.auth.uid == uid; }
-
-    match /scans/{uid}/{scanId}/{all=**} {
-      allow read: if isOwner(uid);
-      allow write: if isOwner(uid)
+    function isOwnerPath(uid) { return request.auth != null && request.auth.uid == uid; }
+    match /uploads/{uid}/{file=**} {
+      allow read, write: if isOwnerPath(uid)
         && request.resource.size < 50 * 1024 * 1024
         && request.resource.contentType.matches('image/.*|video/.*');
     }
-
-    match /{allPaths=**} { allow read, write: if false; }
+    match /scans/{uid}/{file=**} {
+      allow read: if isOwnerPath(uid);
+      allow write: if isOwnerPath(uid)
+        && request.resource.size < 50 * 1024 * 1024
+        && request.resource.contentType.matches('image/.*|video/.*');
+    }
+    match /{allPaths=**} {
+      allow read, write: if false;
+    }
   }
 }

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+import { ensureFixtures } from './helpers';
+import fs from 'fs';
+
+test('fixtures are created', async ({ page }) => {
+  ensureFixtures();
+  expect(fs.existsSync('tests/fixtures/front.jpg')).toBe(true);
+});

--- a/tests/e2e/helpers.ts
+++ b/tests/e2e/helpers.ts
@@ -1,0 +1,11 @@
+import fs from 'fs';
+
+export function ensureFixtures() {
+  const dir = 'tests/fixtures';
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const base64 = '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDABALDgwODAwQEBAXEBkYFREcHiEfGh0dICQjJC4sKCorNzg3Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O//2wBDAQwMDhAQEB0RGh0eOycnOzs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7Ozs7O//wAARCAABAAEDAREAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAb/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/APH/AP/Z';
+  ['front.jpg', 'left.jpg', 'right.jpg', 'back.jpg'].forEach(f => {
+    const p = `${dir}/${f}`;
+    if (!fs.existsSync(p)) fs.writeFileSync(p, Buffer.from(base64, 'base64'));
+  });
+}


### PR DESCRIPTION
## Summary
- enforce user-owned Firestore and Storage access rules
- add `runBodyScan` callable using Replicate with credit guard & ledger
- wire client and CI helpers for mock scans and runtime fixtures

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test:e2e` *(fails: playwright: not found)*
- `npm run build` *(fails: vite: not found)*

## Checklist
- [ ] Add Firebase Secret: `REPLICATE_API_TOKEN` (firebase functions:secrets:set REPLICATE_API_TOKEN)
- [ ] Ensure GitHub Action secrets already exist: `STRIPE_TEST_SECRET`, `STRIPE_WEBHOOK_SECRET` (and optional `OPENAI_API_KEY`)
- [ ] Deploy updated rules: `firebase deploy --only firestore:rules,storage:rules`
- [ ] Deploy function: `firebase deploy --only functions:runBodyScan`
- [ ] In prod, test: upload → Analyze → result visible → credits decremented → ledger entry written
- [ ] In CI/emulator, tests pass and no binaries in repo

------
https://chatgpt.com/codex/tasks/task_e_68b9bd28d1648325b93ba529c7ef284d