### PR TITLE
Fix: firebase.json rules targets for firestore/storage deploy

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -20,5 +20,7 @@
         ]
       }
     ]
-  }
+  },
+  "firestore": { "rules": "firestore.rules" },
+  "storage": { "rules": "storage.rules" }
 }


### PR DESCRIPTION
## Summary
- add firestore and storage rules target declarations to firebase.json
- no code or rules content changes

## Testing
- `jq . firebase.json`
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden to @firebase/rules-unit-testing)*


------
https://chatgpt.com/codex/tasks/task_e_68ba085a902083259369255f4c7f56ca