### PR TITLE
Add legal pages + redirects for store submission

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -34,6 +34,23 @@
     ],
     "rewrites": [
       { "source": "**", "destination": "/index.html" }
+    ],
+    "redirects": [
+      {
+        "source": "/legal/privacy",
+        "destination": "/legal/privacy.html",
+        "type": 301
+      },
+      {
+        "source": "/legal/terms",
+        "destination": "/legal/terms.html",
+        "type": 301
+      },
+      {
+        "source": "/legal/refund",
+        "destination": "/legal/refund.html",
+        "type": 301
+      }
     ]
   },
   "functions": { "source": "functions" },

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -1,0 +1,66 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy • MyBodyScan</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
+    h1{font-size:2rem;margin-bottom:0.25rem} small{color:#666}
+    h2{margin-top:2rem} a{color:#0b57d0;text-decoration:none} a:hover{text-decoration:underline}
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy</h1>
+  <small>Last updated: <span id="d"></span></small>
+
+  <p>MyBodyScan (“we”, “us”, “our”) is operated by <strong>ADLR Labs LLC</strong>. This policy explains what we collect, why we collect it, and your choices.</p>
+
+  <h2>Information we collect</h2>
+  <ul>
+    <li><strong>Account & Contact</strong>: email, display name, and support communications.</li>
+    <li><strong>Scan Media You Upload</strong>: photos/videos you choose to submit for body scan results.</li>
+    <li><strong>Wellness Inputs</strong>: goals, preferences, equipment, dietary restrictions, and logs you enter (meals, workouts).</li>
+    <li><strong>Technical</strong>: app analytics, device data, IP (for security & fraud prevention).</li>
+    <li><strong>Payments</strong>: processed by our payment processor; we receive limited billing metadata (no full card details).</li>
+  </ul>
+
+  <h2>How we use information</h2>
+  <ul>
+    <li>Provide body scan results and personalized plans.</li>
+    <li>Operate, secure, and improve the app (analytics, troubleshooting).</li>
+    <li>Process purchases, manage credits/subscriptions, and provide support.</li>
+    <li>Send reminders and service notices you can control in settings.</li>
+  </ul>
+
+  <h2>Sharing</h2>
+  <p>We use service providers (e.g., cloud hosting, analytics, payments) bound by contracts to process data on our behalf. We do not sell personal data.</p>
+
+  <h2>Your choices</h2>
+  <ul>
+    <li>Access, edit, or delete uploads and logs in the app.</li>
+    <li>Delete your account & data in settings or by contacting <a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a>.</li>
+    <li>Control notifications in settings.</li>
+  </ul>
+
+  <h2>Data retention</h2>
+  <p>We retain data while your account is active. You may delete scans at any time. We remove account data upon verified deletion requests, subject to legal obligations.</p>
+
+  <h2>Children & teens</h2>
+  <p>MyBodyScan is for users <strong>13+</strong>. Users 13–17 must have consent from a parent/guardian. Not for children under 13.</p>
+
+  <h2>International (GDPR/UK GDPR)</h2>
+  <p>Depending on your region, you may have rights to access, correct, delete, or export your data and object/restrict certain processing. Contact us to exercise rights.</p>
+
+  <h2>Security</h2>
+  <p>We use technical and organizational measures to protect data. No method is 100% secure; please use a strong, unique password.</p>
+
+  <h2>Contact</h2>
+  <p>ADLR Labs LLC • Support: <a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a></p>
+
+  <h2>Changes</h2>
+  <p>We may update this policy. We’ll post the new date at the top and, when appropriate, notify you in-app.</p>
+
+  <script>document.getElementById("d").textContent=new Date().toLocaleDateString();</script>
+</body>
+</html>

--- a/public/legal/refund.html
+++ b/public/legal/refund.html
@@ -1,0 +1,34 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Refund Policy • MyBodyScan</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
+    h1{font-size:2rem;margin-bottom:0.25rem} small{color:#666} h2{margin-top:2rem}
+    a{color:#0b57d0;text-decoration:none} a:hover{text-decoration:underline}
+  </style>
+</head>
+<body>
+  <h1>Refund Policy</h1>
+  <small>Last updated: <span id="d"></span></small>
+
+  <h2>One-time scans & extra scans</h2>
+  <p>Not refundable once processing has started or completed.</p>
+
+  <h2>Subscriptions</h2>
+  <ul>
+    <li>Cancel anytime in the app or store settings; access continues through the current billing period.</li>
+    <li>No refunds for partial periods once a cycle begins.</li>
+  </ul>
+
+  <h2>Processing issues</h2>
+  <p>If a scan fails due to a service error, contact <a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a> within 48 hours and we’ll investigate.</p>
+
+  <h2>How to contact us</h2>
+  <p><a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a></p>
+
+  <script>document.getElementById("d").textContent=new Date().toLocaleDateString();</script>
+</body>
+</html>

--- a/public/legal/terms.html
+++ b/public/legal/terms.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Terms of Service • MyBodyScan</title>
+  <style>
+    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;max-width:900px;margin:40px auto;padding:0 16px;line-height:1.6}
+    h1{font-size:2rem;margin-bottom:0.25rem} small{color:#666} h2{margin-top:2rem}
+    a{color:#0b57d0;text-decoration:none} a:hover{text-decoration:underline}
+  </style>
+</head>
+<body>
+  <h1>Terms of Service</h1>
+  <small>Last updated: <span id="d"></span></small>
+
+  <p>These Terms govern your use of MyBodyScan, provided by <strong>ADLR Labs LLC</strong> (“we”, “us”). By using the app, you agree to them.</p>
+
+  <h2>Eligibility</h2>
+  <p>You must be <strong>13+</strong>. Users 13–17 require parent/guardian consent. You must comply with applicable laws.</p>
+
+  <h2>Wellness notice (not medical advice)</h2>
+  <p>MyBodyScan provides wellness guidance only. It is not medical advice, diagnosis, or treatment. Consult a qualified professional before beginning any fitness or nutrition plan, especially if you have injuries, conditions, or concerns.</p>
+
+  <h2>Your account</h2>
+  <p>Keep your credentials confidential. You’re responsible for activity under your account and for accurate information.</p>
+
+  <h2>License & content</h2>
+  <p>We grant you a personal, non-transferable, revocable license to use the app. The app, content, and materials are owned by ADLR Labs LLC and our licensors.</p>
+
+  <h2>Payments & credits</h2>
+  <ul>
+    <li>One-time scans and extra scans are consumable items.</li>
+    <li>Subscriptions renew automatically until canceled.</li>
+    <li>Included scan credits roll over and expire 12 months after grant.</li>
+    <li>Pricing, inclusions, and promotions may change prospectively.</li>
+  </ul>
+
+  <h2>Prohibited uses</h2>
+  <p>No unlawful, infringing, harassing, or abusive behavior. Do not attempt to reverse engineer, disrupt, or misuse the service.</p>
+
+  <h2>Termination</h2>
+  <p>We may suspend or terminate access for violations. You may stop using the app at any time and request account deletion.</p>
+
+  <h2>Disclaimers & limitation of liability</h2>
+  <p>The service is provided “as is” and “as available”. To the maximum extent permitted by law, we disclaim warranties and limit liability for indirect or consequential damages.</p>
+
+  <h2>Governing law</h2>
+  <p>These Terms are governed by the laws of the State of Florida, USA.</p>
+
+  <h2>Contact</h2>
+  <p><a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a></p>
+
+  <script>document.getElementById("d").textContent=new Date().toLocaleDateString();</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Privacy, Terms, and Refund static pages under `public/legal`
- wire Firebase Hosting redirects for clean `/legal/*` URLs

## Testing
- `python -m json.tool firebase.json`
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: E403 forbidden fetching @firebase/rules-unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcdfb9dc588325b0f3d2baee0748d8