### PR TITLE
feat(payments): Stripe webhook → credit buckets, nightly expiry, pricing map

### DIFF
--- a/functions/src/credits.ts
+++ b/functions/src/credits.ts
@@ -1,0 +1,85 @@
+import { getFirestore, Timestamp, FieldValue } from "firebase-admin/firestore";
+import { onSchedule } from "firebase-functions/v2/scheduler";
+
+export async function grantCredits(uid: string, amount: number, expiryDays: number, sourcePriceId: string, context: string) {
+  const db = getFirestore();
+  const now = Timestamp.now();
+  const expiresAt = Timestamp.fromMillis(now.toMillis() + expiryDays*24*60*60*1000);
+  const userRef = db.doc(`users/${uid}`);
+  const bucketsRef = userRef.collection("private").doc("credits"); // or keep at users/{uid} root if preferred
+
+  await db.runTransaction(async tx => {
+    const snap = await tx.get(bucketsRef);
+    const data = snap.exists ? snap.data()! : { creditBuckets: [], creditsSummary: { totalAvailable: 0, lastUpdated: now } };
+    data.creditBuckets.push({ amount, grantedAt: now, expiresAt, sourcePriceId, context });
+    const total = (data.creditBuckets as any[]).reduce((sum, b) => sum + (b.amount||0), 0);
+    data.creditsSummary = { totalAvailable: total, lastUpdated: now };
+    tx.set(bucketsRef, data, { merge: true });
+  });
+}
+
+export async function refreshCreditsSummary(uid: string) {
+  const db = getFirestore();
+  const bucketsRef = db.doc(`users/${uid}/private/credits`);
+  const snap = await bucketsRef.get();
+  if (!snap.exists) return;
+  const data = snap.data()!;
+  const total = (data.creditBuckets || []).reduce((s:number, b:any)=> s + (b.amount||0), 0);
+  await bucketsRef.set({ creditsSummary: { totalAvailable: total, lastUpdated: Timestamp.now() }}, { merge: true });
+}
+
+export async function consumeCredit(uid: string): Promise<boolean> {
+  const db = getFirestore();
+  const bucketsRef = db.doc(`users/${uid}/private/credits`);
+  let ok = false;
+  await db.runTransaction(async tx => {
+    const snap = await tx.get(bucketsRef);
+    if (!snap.exists) return;
+    const data = snap.data() as any;
+    const now = Timestamp.now();
+    const buckets = (data.creditBuckets || []).filter((b:any)=> b.expiresAt.toMillis() > now.toMillis());
+    buckets.sort((a:any,b:any)=> a.expiresAt.toMillis() - b.expiresAt.toMillis());
+    for (const b of buckets) {
+      if ((b.amount||0) > 0) { b.amount -= 1; ok = true; break; }
+    }
+    const total = buckets.reduce((s:number, b:any)=> s + (b.amount||0), 0);
+    tx.set(bucketsRef, { creditBuckets: buckets, creditsSummary: { totalAvailable: total, lastUpdated: now } }, { merge: true });
+  });
+  return ok;
+}
+
+// TODO: expose consumeCredit via a secure callable function before running a scan.
+
+export async function setSubscriptionStatus(uid:string, status:"active"|"canceled"|"none", priceId:string|null, renewalUnix:number|null){
+  const db = getFirestore();
+  await db.doc(`users/${uid}`).set({
+    subscription: {
+      status,
+      planPriceId: priceId || null,
+      renewalDate: renewalUnix ? new Date(renewalUnix*1000) : null
+    }
+  }, { merge: true });
+}
+
+// Nightly expiry
+export const expireCreditsDaily = onSchedule("every 24 hours", async () => {
+  const db = getFirestore();
+  const users = await db.collection("users").get();
+  const now = Date.now();
+  for (const u of users.docs) {
+    const creditsDoc = await db.doc(`users/${u.id}/private/credits`).get();
+    if (!creditsDoc.exists) continue;
+    const data = creditsDoc.data() as any;
+    let changed = false;
+    const buckets = (data.creditBuckets||[]).filter((b:any)=>{
+      if (!b.expiresAt) return true;
+      const alive = b.expiresAt.toMillis() > now;
+      if (!alive) changed = true;
+      return alive;
+    });
+    if (changed) {
+      const total = buckets.reduce((s:number, b:any)=> s + (b.amount||0), 0);
+      await creditsDoc.ref.set({ creditBuckets: buckets, creditsSummary: { totalAvailable: total, lastUpdated: new Date() } }, { merge: true });
+    }
+  }
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./stripeWebhook";
+export * from "./credits";

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -1,0 +1,81 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { logger } from "firebase-functions";
+import Stripe from "stripe";
+import { getFirestore } from "firebase-admin/firestore";
+import { grantCredits, refreshCreditsSummary, setSubscriptionStatus } from "./credits";
+
+export const stripeWebhook = onRequest({ secrets: ["STRIPE_SECRET_KEY","STRIPE_WEBHOOK_SECRET"] }, async (req, res) => {
+  try {
+    const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2024-06-20" as any });
+    const sig = req.headers["stripe-signature"] as string;
+    const event = stripe.webhooks.constructEvent(req.rawBody, sig, process.env.STRIPE_WEBHOOK_SECRET!);
+
+    const db = getFirestore();
+    const handleGrant = async (checkoutSession: any, context: string) => {
+      const uid = checkoutSession?.metadata?.uid;  // we will send uid in Checkout metadata
+      const priceId =
+        checkoutSession?.metadata?.price_id ||
+        checkoutSession?.mode === "subscription"
+          ? checkoutSession?.subscription && (await stripe.subscriptions.retrieve(checkoutSession.subscription)).items.data[0]?.price?.id
+          : checkoutSession?.line_items?.data?.[0]?.price?.id;
+
+      if (!uid || !priceId) { logger.warn("Missing uid or priceId"); return; }
+
+      // Look up credits config from Firestore (pricing/{priceId})
+      const pricingDoc = await db.doc(`pricing/${priceId}`).get();
+      if (!pricingDoc.exists) { logger.error("No pricing config for", priceId); return; }
+      const { credits, credit_expiry_days } = pricingDoc.data() as any;
+
+      await grantCredits(uid, credits, credit_expiry_days, priceId, context);
+      await refreshCreditsSummary(uid);
+      await db.collection("payments").add({
+        provider: "stripe",
+        eventType: context,
+        uid, priceId, creditsGranted: credits,
+        ts: new Date(),
+      });
+    };
+
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as any;
+        await handleGrant(session, "checkout.session.completed");
+        break;
+      }
+      case "invoice.paid": {
+        const invoice = event.data.object as any;
+        const subId = invoice.subscription;
+        if (subId) {
+          const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: "2024-06-20" as any });
+          const sub = await stripe.subscriptions.retrieve(subId);
+          const uid = sub.metadata?.uid || invoice.metadata?.uid;
+          const priceId = sub.items.data[0]?.price?.id;
+          if (uid && priceId) {
+            const db = getFirestore();
+            const pricingDoc = await db.doc(`pricing/${priceId}`).get();
+            if (pricingDoc.exists) {
+              const { credits, credit_expiry_days } = pricingDoc.data() as any;
+              await grantCredits(uid, credits, credit_expiry_days, priceId, "invoice.paid");
+              await refreshCreditsSummary(uid);
+              await setSubscriptionStatus(uid, "active", priceId, sub.current_period_end);
+            }
+          }
+        }
+        break;
+      }
+      case "customer.subscription.deleted": {
+        const sub = event.data.object as any;
+        const uid = sub.metadata?.uid;
+        if (uid) await setSubscriptionStatus(uid, "canceled", null, null);
+        break;
+      }
+      default:
+        logger.info(`Unhandled event: ${event.type}`);
+    }
+
+    res.status(200).send({ received: true });
+  } catch (e:any) {
+    logger.error(e);
+    res.status(400).send(`Webhook Error: ${e.message}`);
+  }
+});

--- a/scripts/seedPricing.ts
+++ b/scripts/seedPricing.ts
@@ -1,0 +1,20 @@
+import { initializeApp, applicationDefault } from "firebase-admin/app";
+import { getFirestore } from "firebase-admin/firestore";
+
+const pricing = {
+  "price_1RuOpKQQU5vuhlNjipfFBsR0": { plan:"starter", credits:1, credit_expiry_days:365 },
+  "price_1S4XsVQQU5vuhlNjzdQzeySA": { plan:"pro",     credits:3, credit_expiry_days:365, extra_scan_price:9.99 },
+  "price_1S4Y6YQQU5vuhlNjeJFmshxX": { plan:"elite",  credits:36, credit_expiry_days:365, extra_scan_price:9.99 },
+  "price_1S4Y9JQQU5vuhlNjB7cBfmaW": { plan:"extra_scan", credits:1, credit_expiry_days:365 }
+};
+
+initializeApp({ credential: applicationDefault() });
+const db = getFirestore();
+
+(async () => {
+  for (const [priceId, doc] of Object.entries(pricing)) {
+    await db.doc(`pricing/${priceId}`).set(doc, { merge: true });
+    console.log("Wrote pricing", priceId, doc);
+  }
+  process.exit(0);
+})();


### PR DESCRIPTION
## Summary
- Add Stripe webhook to verify signatures and grant credits based on Firestore pricing
- Track credit buckets, summaries, and subscription status with scheduler for expiry
- Script to seed pricing documents

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcf12e93588325af03f67ca76276ad