### PR TITLE
chore(pricing): add Firestore pricing seeder

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:e2e": "playwright test",
     "pretest:e2e": "playwright install --with-deps",
     "lighthouse": "lhci autorun",
-    "check:headers": "bash scripts/check-headers.sh $PREVIEW_URL"
+    "check:headers": "bash scripts/check-headers.sh $PREVIEW_URL",
+    "seed:pricing": "node scripts/seedPricing.cjs"
   },
   "dependencies": {
     "@capacitor/android": "^6.2.1",

--- a/scripts/seedPricing.cjs
+++ b/scripts/seedPricing.cjs
@@ -1,0 +1,27 @@
+const admin = require("firebase-admin");
+
+(async () => {
+  try {
+    if (admin.apps.length === 0) {
+      admin.initializeApp(); // uses current gcloud/firebase auth or env creds
+    }
+    const db = admin.firestore();
+
+    const pricing = {
+      "price_1RuOpKQQU5vuhlNjipfFBsR0": { plan:"starter",    credits:1,  credit_expiry_days:365 },
+      "price_1S4XsVQQU5vuhlNjzdQzeySA": { plan:"pro",        credits:3,  credit_expiry_days:365, extra_scan_price:9.99 },
+      "price_1S4Y6YQQU5vuhlNjeJFmshxX": { plan:"elite",      credits:36, credit_expiry_days:365, extra_scan_price:9.99 },
+      "price_1S4Y9JQQU5vuhlNjB7cBfmaW": { plan:"extra_scan", credits:1,  credit_expiry_days:365 },
+    };
+
+    for (const [id, doc] of Object.entries(pricing)) {
+      await db.doc(`pricing/${id}`).set(doc, { merge: true });
+      console.log("Wrote", id, doc);
+    }
+    console.log("✅ Pricing seeded.");
+    process.exit(0);
+  } catch (e) {
+    console.error(e);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add Node.js script `scripts/seedPricing.cjs` to seed Firestore pricing docs
- expose `seed:pricing` npm script for convenient execution

## Testing
- ⚠️ `npm test` (vitest: not found; `npm install` failed with 403 for `@firebase/rules-unit-testing`)
- ⚠️ `npm run lint` (cannot find package `@eslint/js`)


------
https://chatgpt.com/codex/tasks/task_e_68bcf67dc8a48325a8d71364d593ce6c