### PR TITLE
chore(pricing): add secure seedPricingOnce function

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./stripeWebhook";
 export * from "./credits";
+export * from "./seedPricing";

--- a/functions/src/seedPricing.ts
+++ b/functions/src/seedPricing.ts
@@ -1,0 +1,21 @@
+import { onRequest } from "firebase-functions/v2/https";
+import { getFirestore } from "firebase-admin/firestore";
+import { logger } from "firebase-functions";
+const PRICING: Record<string, any> = {
+  "price_1RuOpKQQU5vuhlNjipfFBsR0": { plan:"starter",    credits:1,  credit_expiry_days:365 },
+  "price_1S4XsVQQU5vuhlNjzdQzeySA": { plan:"pro",        credits:3,  credit_expiry_days:365, extra_scan_price:9.99 },
+  "price_1S4Y6YQQU5vuhlNjeJFmshxX": { plan:"elite",      credits:36, credit_expiry_days:365, extra_scan_price:9.99 },
+  "price_1S4Y9JQQU5vuhlNjB7cBfmaW": { plan:"extra_scan", credits:1,  credit_expiry_days:365 },
+};
+export const seedPricingOnce = onRequest({ secrets:["SEED_TOKEN"] }, async (req, res) => {
+  const token = req.get("x-seed-token");
+  if (!token || token !== process.env.SEED_TOKEN) return res.status(401).send("Unauthorized");
+  const db = getFirestore();
+  const tasks: Promise<any>[] = [];
+  for (const [id, doc] of Object.entries(PRICING)) {
+    tasks.push(db.doc(`pricing/${id}`).set(doc, { merge: true }));
+  }
+  await Promise.all(tasks);
+  logger.info("Seeded pricing docs");
+  return res.json({ ok:true, count:Object.keys(PRICING).length });
+});


### PR DESCRIPTION
## Summary
- add pricing seed function guarded by secret token
- export seedPricingOnce

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*
- `npm install` *(fails: E403 Forbidden fetching @firebase/rules-unit-testing)*

------
https://chatgpt.com/codex/tasks/task_e_68bcfb70bee08325ad5b6c08bd710b35