### PR TITLE
feat(ui): Apple sign-in (guarded) and nav polish

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ VITE_FIREBASE_APP_ID=1:1234567890:web:abcdef
 VITE_FIREBASE_MEASUREMENT_ID=G-XXXXXXX
 VITE_FUNCTIONS_BASE_URL=http://localhost:5001/demo-project/us-central1
 VITE_FUNCTIONS_URL=http://localhost:5001/demo-project/us-central1
+# Apple Sign-In
+VITE_APPLE_AUTH_ENABLED=false
 # Optional App Check site key
 VITE_APPCHECK_SITE_KEY=
 # Feature flags

--- a/src/components/AuthedLayout.tsx
+++ b/src/components/AuthedLayout.tsx
@@ -3,26 +3,23 @@ import { useNavigate, NavLink } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { signOutToAuth } from "@/lib/auth";
 import Footer from "./Footer";
-import { useCredits } from "@/hooks/useCredits";
+import { CreditsBadge } from "./CreditsBadge";
 
 export default function AuthedLayout({ children }: { children: ReactNode }) {
   const navigate = useNavigate();
-  const { credits } = useCredits();
   return (
     <div className="min-h-screen flex flex-col">
       <header className="sticky top-0 z-10 bg-background/80 backdrop-blur border-b">
         <div className="mx-auto max-w-2xl px-4 h-12 flex items-center justify-between">
-          <button className="flex items-center gap-2 font-semibold" onClick={() => navigate("/home")}>
+          <button className="flex items-center gap-2 font-semibold" onClick={() => navigate("/today")}> 
             <img src="/logo.svg" alt="MyBodyScan" className="w-6 h-6" />
             MyBodyScan
           </button>
           <nav className="flex items-center gap-2 text-sm">
-            <NavLink to="/home" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Home</NavLink>
-            <NavLink to="/history" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>History</NavLink>
-            <NavLink to="/report" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Report</NavLink>
-            <NavLink to="/plans" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Plans</NavLink>
-            <NavLink to="/settings" className={({ isActive }) => isActive ? "underline" : "opacity-80 hover:opacity-100"}>Settings</NavLink>
-            <span>Credits: {credits}</span>
+            <NavLink to="/today" className={({ isActive }) => (isActive ? "underline" : "opacity-80 hover:opacity-100")}>Today</NavLink>
+            <NavLink to="/plans" className={({ isActive }) => (isActive ? "underline" : "opacity-80 hover:opacity-100")}>Plans</NavLink>
+            <NavLink to="/settings" className={({ isActive }) => (isActive ? "underline" : "opacity-80 hover:opacity-100")}>Settings</NavLink>
+            <CreditsBadge />
             <Button size="sm" variant="outline" onClick={signOutToAuth}>Sign out</Button>
           </nav>
         </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,20 @@
 import { useEffect, useState } from "react";
 import { auth } from "@/lib/firebase";
-import { onAuthStateChanged, setPersistence, browserLocalPersistence, signOut, GoogleAuthProvider, signInWithRedirect, signInWithPopup, signInAnonymously, linkWithCredential, EmailAuthProvider, createUserWithEmailAndPassword, signInWithEmailAndPassword, sendPasswordResetEmail, updateProfile } from "firebase/auth";
+import {
+  onAuthStateChanged,
+  setPersistence,
+  browserLocalPersistence,
+  signOut,
+  GoogleAuthProvider,
+  OAuthProvider,
+  signInWithPopup,
+  linkWithCredential,
+  EmailAuthProvider,
+  createUserWithEmailAndPassword,
+  signInWithEmailAndPassword,
+  sendPasswordResetEmail,
+  updateProfile,
+} from "firebase/auth";
 
 export async function initAuthPersistence() {
   await setPersistence(auth, browserLocalPersistence);
@@ -27,13 +41,19 @@ export async function signOutToAuth(): Promise<void> {
 }
 
 // New helpers
-export function signInGoogle() {
+export function signInWithGoogle() {
   const provider = new GoogleAuthProvider();
   return signInWithPopup(auth, provider);
 }
 
-export function signInGuest() {
-  return signInAnonymously(auth);
+export async function signInWithApple() {
+  if (import.meta.env.VITE_APPLE_AUTH_ENABLED !== "true") {
+    throw new Error("Apple Sign-In not configured");
+  }
+  const provider = new OAuthProvider("apple.com");
+  provider.addScope("name");
+  provider.addScope("email");
+  await signInWithPopup(auth, provider);
 }
 
 export async function createAccountEmail(email: string, password: string, displayName?: string) {
@@ -57,7 +77,7 @@ export function sendReset(email: string) {
   return sendPasswordResetEmail(auth, email);
 }
 
-export function signOutUser() {
+export function signOutAll() {
   return signOut(auth);
 }
 

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -6,7 +6,14 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Seo } from "@/components/Seo";
 import { toast } from "@/hooks/use-toast";
-import { createAccountEmail, signInEmail, signInGoogle, sendReset, signInGuest } from "@/lib/auth";
+import {
+  createAccountEmail,
+  signInEmail,
+  signInWithGoogle,
+  signInWithApple,
+  sendReset,
+  useAuthUser,
+} from "@/lib/auth";
 
 const Auth = () => {
   const navigate = useNavigate();
@@ -16,6 +23,13 @@ const Auth = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
+  const { user } = useAuthUser();
+
+  useEffect(() => {
+    if (user) navigate("/today", { replace: true });
+  }, [user, navigate]);
+
+  const appleEnabled = import.meta.env.VITE_APPLE_AUTH_ENABLED === "true";
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,7 +51,7 @@ const Auth = () => {
   const onGoogle = async () => {
     setLoading(true);
     try {
-      await signInGoogle();
+      await signInWithGoogle();
       navigate(from, { replace: true });
     } catch (err: any) {
       toast({ title: "Google sign in failed", description: err?.message || "Please try again." });
@@ -46,13 +60,13 @@ const Auth = () => {
     }
   };
 
-  const onGuest = async () => {
+  const onApple = async () => {
     setLoading(true);
     try {
-      await signInGuest();
+      await signInWithApple();
       navigate(from, { replace: true });
     } catch (err: any) {
-      toast({ title: "Guest sign in failed", description: err?.message || "Please try again." });
+      toast({ title: "Apple sign in failed", description: err?.message || "Please try again." });
     } finally {
       setLoading(false);
     }
@@ -119,11 +133,40 @@ const Auth = () => {
             </div>
           </form>
           <div className="mt-4 grid gap-2">
-            <Button variant="secondary" className="mbs-btn mbs-btn-ghost" onClick={onGoogle} disabled={loading}>Continue with Google</Button>
-            <Button variant="outline" className="mbs-btn mbs-btn-ghost" onClick={onGuest} disabled={loading}>Continue as guest</Button>
+            {appleEnabled ? (
+              <Button
+                variant="secondary"
+                className="mbs-btn mbs-btn-ghost"
+                onClick={onApple}
+                disabled={loading}
+              >
+                Continue with Apple
+              </Button>
+            ) : (
+              <Button
+                variant="secondary"
+                className="mbs-btn mbs-btn-ghost"
+                disabled
+                title="Available soon"
+              >
+                Continue with Apple
+              </Button>
+            )}
+            <Button
+              variant="secondary"
+              className="mbs-btn mbs-btn-ghost"
+              onClick={onGoogle}
+              disabled={loading}
+            >
+              Continue with Google
+            </Button>
           </div>
         </CardContent>
       </Card>
+      <div className="mt-4 text-center text-xs text-slate-500">
+        <a href="/legal/privacy" className="underline">Privacy</a> ·
+        <a href="/legal/terms" className="underline"> Terms</a>
+      </div>
     </main>
   );
 };


### PR DESCRIPTION
## Summary
- add VITE_APPLE_AUTH_ENABLED env flag
- support Apple OAuth sign-in guarded by env
- surface credits badge in top navigation

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck` *(fails: Cannot find module '@tanstack/react-query')*


------
https://chatgpt.com/codex/tasks/task_e_68bdac8ac9c483258f95393292b870ba