### PR TITLE
feat(legal): privacy/terms/refund pages, help center, feedback mail

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,10 @@ import Privacy from "./pages/Privacy";
 import Terms from "./pages/Terms";
 import Support from "./pages/Support";
 import Disclaimer from "./pages/Disclaimer";
+import LegalPrivacy from "./pages/legal/Privacy";
+import LegalTerms from "./pages/legal/Terms";
+import LegalRefund from "./pages/legal/Refund";
+import Help from "./pages/Help";
 import CheckoutSuccess from "./pages/CheckoutSuccess";
 import CheckoutCanceled from "./pages/CheckoutCanceled";
 import ScanNew from "./pages/ScanNew";
@@ -84,6 +88,10 @@ const App = () => {
             <Route path="/terms" element={<PublicLayout><Terms /></PublicLayout>} />
             <Route path="/legal/disclaimer" element={<PublicLayout><Disclaimer /></PublicLayout>} />
             <Route path="/support" element={<PublicLayout><Support /></PublicLayout>} />
+            <Route path="/help" element={<PublicLayout><Help /></PublicLayout>} />
+            <Route path="/legal/privacy" element={<PublicLayout><LegalPrivacy /></PublicLayout>} />
+            <Route path="/legal/terms" element={<PublicLayout><LegalTerms /></PublicLayout>} />
+            <Route path="/legal/refund" element={<PublicLayout><LegalRefund /></PublicLayout>} />
             {/* Checkout result pages (public) */}
             <Route path="/checkout/success" element={<PublicLayout><CheckoutSuccess /></PublicLayout>} />
             <Route path="/checkout/canceled" element={<PublicLayout><CheckoutCanceled /></PublicLayout>} />

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -36,7 +36,7 @@ const translations = {
     'settings.title': 'Settings',
     'settings.notifications': 'Notifications',
     'settings.language': 'Language',
-    'settings.legal': 'Legal & Account',
+    'settings.legal': 'Legal & Support',
     'settings.delete_account': 'Delete my account & data',
     'settings.sign_out': 'Sign out',
     

--- a/src/lib/support.ts
+++ b/src/lib/support.ts
@@ -1,0 +1,34 @@
+import { auth } from "@/lib/firebase";
+
+export function supportMailto(extra?: Record<string, string>) {
+  const lines: string[] = [];
+  const version = (import.meta.env.VITE_APP_VERSION as string) || "0.0.0";
+  lines.push(`version=${version}`);
+
+  const user = auth.currentUser;
+  if (user) {
+    lines.push(`uid=${user.uid}`);
+    if (user.email) lines.push(`email=${user.email}`);
+  }
+
+  lines.push(`route=${window.location.pathname}`);
+  lines.push(`timestamp=${new Date().toISOString()}`);
+  lines.push(`device=${navigator.userAgent}`);
+
+  const crumbs =
+    (window as any).__breadcrumbs ||
+    (window as any).__mbsBreadcrumbs ||
+    (window as any).__mbsLogs || [];
+  if (Array.isArray(crumbs) && crumbs.length) {
+    lines.push("logs=" + crumbs.slice(-5).join(" | "));
+  }
+
+  if (extra) {
+    for (const [k, v] of Object.entries(extra)) {
+      lines.push(`${k}=${v}`);
+    }
+  }
+
+  const body = encodeURIComponent(lines.join("\n"));
+  return `mailto:support@mybodyscanapp.com?subject=MyBodyScan%20Support&body=${body}`;
+}

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,0 +1,33 @@
+import { Seo } from "@/components/Seo";
+import { Button } from "@/components/ui/button";
+import { supportMailto } from "@/lib/support";
+
+const Help = () => {
+  return (
+    <>
+      <Seo
+        title="Help Center – MyBodyScan"
+        description="Answers to common questions and support." 
+        canonical="https://mybodyscanapp.com/help"
+      />
+      <article className="prose prose-neutral dark:prose-invert max-w-none p-6">
+        <h1>Help Center</h1>
+        <h2>Why can’t I scan?</h2>
+        <p>You need an available credit; buy one on the Plans page.</p>
+        <h2>How many scans per plan?</h2>
+        <p>Starter includes 1, Pro 3 per month, and Elite 36 per year. Credits roll over for 12 months.</p>
+        <h2>What photos do I need?</h2>
+        <p>Use good lighting, a plain background, and capture your full body.</p>
+        <h2>Calories look different than I entered</h2>
+        <p>Entries are reconciled to your macro targets so totals may shift slightly.</p>
+        <h2>Delete my data</h2>
+        <p>Use Settings → Delete or email <a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a>.</p>
+        <Button className="mt-4" onClick={() => { window.location.href = supportMailto(); }}>
+          Report a problem
+        </Button>
+      </article>
+    </>
+  );
+};
+
+export default Help;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -12,6 +12,7 @@ import { signOutAll } from "@/lib/auth";
 import { toast } from "@/hooks/use-toast";
 import { useCredits } from "@/hooks/useCredits";
 import { openStripePortal } from "@/lib/api";
+import { supportMailto } from "@/lib/support";
 import { useNavigate } from "react-router-dom";
 
 const Settings = () => {
@@ -82,7 +83,7 @@ const Settings = () => {
           </CardContent>
         </Card>
 
-        {/* Legal & Account */}
+        {/* Legal & Support */}
         <Card>
           <CardHeader>
             <CardTitle>{t('settings.legal')}</CardTitle>
@@ -93,11 +94,21 @@ const Settings = () => {
                 Privacy Policy
               </a>
               <a href="/legal/terms" className="block text-sm underline hover:text-primary">
-                Terms of Service  
+                Terms of Service
               </a>
               <a href="/legal/refund" className="block text-sm underline hover:text-primary">
                 Refund Policy
               </a>
+              <a href="/help" className="block text-sm underline hover:text-primary">
+                Help Center
+              </a>
+              <Button
+                variant="outline"
+                onClick={() => { window.location.href = supportMailto(); }}
+                className="w-full"
+              >
+                Report a problem
+              </Button>
             </div>
             <div className="space-y-2">
               <Button

--- a/src/pages/legal/Privacy.tsx
+++ b/src/pages/legal/Privacy.tsx
@@ -1,0 +1,29 @@
+import { Seo } from "@/components/Seo";
+
+const Privacy = () => {
+  return (
+    <>
+      <Seo
+        title="Privacy Policy – MyBodyScan"
+        description="How MyBodyScan handles your account, credits and scan metadata."
+        canonical="https://mybodyscanapp.com/legal/privacy"
+      />
+      <article className="prose prose-neutral dark:prose-invert max-w-none p-6">
+        <h1>Privacy Policy</h1>
+        <p>
+          We store your account details, credit balances and basic scan metadata only.
+          We do not keep medical information.
+        </p>
+        <p>
+          To remove your data, email <a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a> from your account address.
+        </p>
+        <p>
+          Credits expire 12 months after purchase and transaction logs are kept only as required for payments.
+        </p>
+        <p className="text-sm text-muted-foreground">This app is not medical advice.</p>
+      </article>
+    </>
+  );
+};
+
+export default Privacy;

--- a/src/pages/legal/Refund.tsx
+++ b/src/pages/legal/Refund.tsx
@@ -1,0 +1,23 @@
+import { Seo } from "@/components/Seo";
+
+const Refund = () => {
+  return (
+    <>
+      <Seo
+        title="Refund Policy – MyBodyScan"
+        description="Refund information for digital purchases on MyBodyScan."
+        canonical="https://mybodyscanapp.com/legal/refund"
+      />
+      <article className="prose prose-neutral dark:prose-invert max-w-none p-6">
+        <h1>Refund Policy</h1>
+        <p>All purchases of digital goods are final and non-refundable.</p>
+        <p>
+          For billing issues, contact <a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a>.
+        </p>
+        <p>Consumer rights required by law are not affected.</p>
+      </article>
+    </>
+  );
+};
+
+export default Refund;

--- a/src/pages/legal/Terms.tsx
+++ b/src/pages/legal/Terms.tsx
@@ -1,0 +1,25 @@
+import { Seo } from "@/components/Seo";
+
+const Terms = () => {
+  return (
+    <>
+      <Seo
+        title="Terms of Service – MyBodyScan"
+        description="License and subscription terms for using MyBodyScan."
+        canonical="https://mybodyscanapp.com/legal/terms"
+      />
+      <article className="prose prose-neutral dark:prose-invert max-w-none p-6">
+        <h1>Terms of Service</h1>
+        <p>You receive a personal, non-transferable license to use the app.</p>
+        <p>
+          Subscriptions renew monthly or annually until cancelled. No refunds are offered except where required by law.
+        </p>
+        <p>Keep your account secure and use the service responsibly.</p>
+        <p>We may terminate accounts for misuse or non-payment.</p>
+        <p>These terms are governed by the laws of your jurisdiction.</p>
+      </article>
+    </>
+  );
+};
+
+export default Terms;


### PR DESCRIPTION
## Summary
- add support mailto helper for diagnostics
- add privacy, terms, refund legal pages and help center
- link legal/support routes from settings and router

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run typecheck` *(fails: cannot find module 'react')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c035a7e5b48325bf312079c9381150