### PR TITLE
feat(obs): client telemetry breadcrumbs + diagnostics copy

### DIFF
--- a/src/lib/diagnostics.ts
+++ b/src/lib/diagnostics.ts
@@ -1,0 +1,19 @@
+import { getAuth } from "firebase/auth";
+import { getBreadcrumbs } from "./logger";
+export async function buildDiagnostics(): Promise<string> {
+  const u = getAuth().currentUser;
+  const info = {
+    uid: u?.uid || "signed-out",
+    email: u?.email || "",
+    tz: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    ua: navigator.userAgent,
+    path: window.location.pathname,
+    ts: new Date().toISOString(),
+    breadcrumbs: getBreadcrumbs()
+  };
+  return JSON.stringify(info, null, 2);
+}
+export async function copyDiagnostics() {
+  const text = await buildDiagnostics();
+  await navigator.clipboard.writeText(text);
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,7 @@
+export type Breadcrumb = { t:number; level:"info"|"warn"|"error"; msg:string; ctx?:Record<string,any> };
+const MAX = 50; let Q:Breadcrumb[] = [];
+export function log(level:Breadcrumb["level"], msg:string, ctx?:Record<string,any>) {
+  Q.push({ t:Date.now(), level, msg, ctx }); if (Q.length>MAX) Q.shift();
+  if (import.meta.env.DEV) console[level](msg, ctx||"");
+}
+export function getBreadcrumbs():Breadcrumb[] { return [...Q]; }

--- a/src/lib/payments.ts
+++ b/src/lib/payments.ts
@@ -1,7 +1,9 @@
+import { log } from "./logger";
+
 export async function startCheckout(
-  priceId: string,
-  mode: "payment" | "subscription"
-) {
+    priceId: string,
+    mode: "payment" | "subscription"
+  ) {
   const { getAuth } = await import("firebase/auth");
   const user = getAuth().currentUser;
   if (!user) throw new Error("Not signed in");
@@ -32,11 +34,20 @@ export async function consumeOneCredit(): Promise<number> {
   const user = getAuth().currentUser;
   if (!user) throw new Error("Not signed in");
   const token = await user.getIdToken();
-  const res = await fetch(`${import.meta.env.VITE_FUNCTIONS_URL}/useCredit`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (res.status === 402) throw new Error("No credits available");
-  const json = await res.json();
-  return json.remaining as number;
+  try {
+    const res = await fetch(`${import.meta.env.VITE_FUNCTIONS_URL}/useCredit`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (res.status === 402) {
+      log("warn", "useCredit:no_credits");
+      throw new Error("No credits available");
+    }
+    const json = await res.json();
+    log("info", "useCredit:success", { remaining: json.remaining });
+    return json.remaining as number;
+  } catch (err: any) {
+    log("warn", "useCredit:error", { message: err?.message });
+    throw err;
+  }
 }

--- a/src/pages/Meals.tsx
+++ b/src/pages/Meals.tsx
@@ -11,6 +11,7 @@ import { Seo } from "@/components/Seo";
 import { toast } from "@/hooks/use-toast";
 import { useI18n } from "@/lib/i18n";
 import { addMeal, deleteMeal, getDailyLog, computeCalories, MealEntry } from "@/lib/nutrition";
+import { track } from "@/lib/analytics";
 
 const DAILY_TARGET = 2200;
 
@@ -34,7 +35,8 @@ export default function Meals() {
       return;
     }
     const preview = computeCalories(meal);
-    await addMeal(today, meal);
+      await addMeal(today, meal);
+      track("meal_add");
     const updated = await getDailyLog(today);
     setLog(updated);
     setMeal({ name: "" });
@@ -43,7 +45,8 @@ export default function Meals() {
   }
 
   async function handleDelete(id: string) {
-    await deleteMeal(today, id);
+      await deleteMeal(today, id);
+      track("meal_delete");
     const updated = await getDailyLog(today);
     setLog(updated);
   }

--- a/src/pages/Plans.tsx
+++ b/src/pages/Plans.tsx
@@ -8,11 +8,13 @@ import { startCheckout } from "@/lib/payments";
 import { toast } from "@/hooks/use-toast";
 import { Check } from "lucide-react";
 import { useI18n } from "@/lib/i18n";
+import { track } from "@/lib/analytics";
 
 export default function Plans() {
   const { t } = useI18n();
   const handleCheckout = async (priceId: string, mode: "payment" | "subscription") => {
     try {
+      track("checkout_start", { plan: priceId });
       await startCheckout(priceId, mode);
     } catch (err: any) {
       if (err?.message?.includes("Backend URL not configured")) {

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -10,6 +10,7 @@ import { useNavigate } from "react-router-dom";
 import { consumeOneCredit } from "@/lib/payments";
 import { startScan, uploadScanPhotos, submitScan } from "@/lib/scan";
 import { track } from "@/lib/analytics";
+import { log } from "@/lib/logger";
 
 const checklist = [
   "Good lighting - natural light works best",
@@ -25,18 +26,19 @@ export default function Scan() {
   const navigate = useNavigate();
 
   const handleStartScan = async () => {
-    setIsScanning(true);
-    try {
-      track("start_scan");
-      await consumeOneCredit();
-      const scan = await startScan();
-      // TODO: capture up to 4 images from user
-      const files: File[] = [];
-      const paths = await uploadScanPhotos(scan, files);
-      await submitScan(scan.scanId, paths);
-      toast({ title: "Scan submitted" });
-      navigate("/history");
-    } catch (err: any) {
+      setIsScanning(true);
+      try {
+        await consumeOneCredit();
+        const scan = await startScan();
+        // TODO: capture up to 4 images from user
+        const files: File[] = [];
+        const paths = await uploadScanPhotos(scan, files);
+        await submitScan(scan.scanId, paths);
+        track("scan_submit");
+        log("info", "scan_submit", { scanId: scan.scanId });
+        toast({ title: "Scan submitted" });
+        navigate("/history");
+      } catch (err: any) {
       if (err?.message === "No credits available") {
         toast({ title: "No scan credits", description: "Get more credits to run scans." });
         navigate("/plans");

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -13,6 +13,7 @@ import { toast } from "@/hooks/use-toast";
 import { useCredits } from "@/hooks/useCredits";
 import { openStripePortal } from "@/lib/api";
 import { useNavigate } from "react-router-dom";
+import { copyDiagnostics } from "@/lib/diagnostics";
 
 const Settings = () => {
   const [notifications, setNotifications] = useState(true);
@@ -99,24 +100,31 @@ const Settings = () => {
                 Refund Policy
               </a>
             </div>
-            <div className="space-y-2">
-              <Button
-                variant="destructive"
-                onClick={handleDeleteAccount}
-                className="w-full"
-              >
-                {t('settings.delete_account')}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={handleSignOut}
-                className="w-full"
-              >
-                {t('settings.sign_out')}
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+          <div className="space-y-2">
+            <Button
+              variant="destructive"
+              onClick={handleDeleteAccount}
+              className="w-full"
+            >
+              {t('settings.delete_account')}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleSignOut}
+              className="w-full"
+            >
+              {t('settings.sign_out')}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={async () => { await copyDiagnostics(); toast({ title: "Copied diagnostics" }); }}
+              className="w-full"
+            >
+              Copy diagnostics
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
       </main>
       <BottomNav />
     </div>

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -1,4 +1,7 @@
 import { Seo } from "@/components/Seo";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/hooks/use-toast";
+import { copyDiagnostics } from "@/lib/diagnostics";
 
 const Support = () => {
   return (
@@ -15,6 +18,12 @@ const Support = () => {
             Email: <a className="underline" href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a>
           </p>
           <p className="text-sm text-muted-foreground">Phone: (555) 555-1234</p>
+          <Button
+            className="mt-4"
+            onClick={async () => { await copyDiagnostics(); toast({ title: "Copied diagnostics" }); }}
+          >
+            Copy diagnostics
+          </Button>
         </article>
 
         <article className="rounded-lg border p-4">

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -8,6 +8,7 @@ import { BottomNav } from "@/components/BottomNav";
 import { Seo } from "@/components/Seo";
 import { useI18n } from "@/lib/i18n";
 import { generateWorkoutPlan, getPlan, markExerciseDone, getWeeklyCompletion } from "@/lib/workouts";
+import { track } from "@/lib/analytics";
 import { auth, db } from "@/lib/firebase";
 import { doc, getDoc } from "firebase/firestore";
 
@@ -48,10 +49,11 @@ export default function Workouts() {
   const handleToggle = async (exerciseId: string) => {
     const idx = plan.days.findIndex((d: any) => d.day === todayName);
     const done = !completed.includes(exerciseId);
-    const res = await markExerciseDone(plan.id, idx, exerciseId, done);
-    setCompleted(done ? [...completed, exerciseId] : completed.filter((id) => id !== exerciseId));
-    setRatio(res.ratio);
-  };
+      const res = await markExerciseDone(plan.id, idx, exerciseId, done);
+      setCompleted(done ? [...completed, exerciseId] : completed.filter((id) => id !== exerciseId));
+      setRatio(res.ratio);
+      if (done) track("workout_mark_done", { exerciseId });
+    };
 
   const handleGenerate = async () => {
     const res = await generateWorkoutPlan({ focus: "back" });


### PR DESCRIPTION
## Summary
- add lightweight breadcrumb logger and diagnostics builder
- track key flows and log credit usage
- enable diagnostics copy from Settings and Support

## Testing
- `npm test` *(fails: vitest not found)*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase)*

------
https://chatgpt.com/codex/tasks/task_e_68c035c86efc8325b7ad778bdf0a3e35