### PR TITLE
Add build:dev script and update lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:dev": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext .ts,.tsx --max-warnings 0 -c .eslintrc.cjs",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
     "format": "prettier --write ."
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `build:dev` script to run `vite build`
- simplify `lint` script to use default config

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)

------
https://chatgpt.com/codex/tasks/task_e_68c37035a3648325a1d85dbfa004f502