### PR TITLE
Add Firebase Hosting deployment workflow

### DIFF
--- a/.github/workflows/hosting-deploy.yml
+++ b/.github/workflows/hosting-deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy Firebase Hosting (main)
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch: {}
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Install Firebase Tools
+        run: npm i -g firebase-tools
+
+      - name: Deploy Hosting
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: firebase deploy --only hosting --project mybodyscan-f3daf


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy to Firebase Hosting using Node 20 and FIREBASE_TOKEN secret

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c3745bf7b483258f58889f000dc79c