### PR TITLE
chore: update Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,20 +1,33 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import path from "path";
-import { componentTagger } from "lovable-tagger";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 
-export default defineConfig(({ mode }) => ({
-  server: {
-    host: "::",
-    port: 8080,
-  },
-  plugins: [
-    react(),
-    mode === 'development' && componentTagger(),
-  ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig(async ({ mode }) => {
+  const plugins = [react()];
+
+  if (mode === "development") {
+    try {
+      const { componentTagger } = await import("lovable-tagger");
+      plugins.push(componentTagger());
+    } catch {
+      // lovable-tagger not installed; ignore in non-Lovable environments
+    }
+  }
+
+  return {
+    server: {
+      host: "::",
+      port: 8080,
     },
-  },
-}));
+    plugins,
+    resolve: {
+      alias: {
+        "@": resolve(__dirname, "./src"),
+      },
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- update Vite config to dynamically import lovable-tagger and resolve src alias

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: A config object is using the "parser" key, which is not supported in flat config system)*

------
https://chatgpt.com/codex/tasks/task_e_68c58bf8475c8325987a0045bb28c142