### PR TITLE
fix: harden firebase config and restore credits UI

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,20 @@
+# Release Guide
+
+## Build
+```
+npm install
+npm run build
+npm run build:dev
+```
+
+## Functions
+```
+npm --prefix functions install
+npm --prefix functions run build
+```
+
+## Deploy
+```
+firebase deploy --only functions:runBodyScan,functions:grantTestCredits --project mybodyscan-f3daf
+VITE_BUILD_TAG=$(date -u +%Y-%m-%dT%H:%M:%SZ) npx -y firebase-tools@latest deploy --only hosting --project mybodyscan-f3daf
+```

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,10 +3,10 @@ import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 import { initializeAppCheck, ReCaptchaEnterpriseProvider } from "firebase/app-check";
-import { envConfig, isValid, fetchHostingConfig } from "./firebaseConfig";
+import { envConfig, isValid, fetchHostingConfig, type FirebaseCfg } from "./firebaseConfig";
 import { getEnv, missingEnvVars } from "./env";
 
-let config = envConfig();
+let config: Partial<FirebaseCfg> | FirebaseCfg = envConfig();
 if (!isValid(config)) {
   const hosting = await fetchHostingConfig();
   if (hosting && isValid(hosting)) {
@@ -25,11 +25,11 @@ if (!isFirebaseConfigured) {
   } as any;
 }
 
-export const app = initializeApp(config);
+export const app = initializeApp(config as FirebaseCfg);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
 export const storage = getStorage(app);
-export const firebaseConfig = config;
+export const firebaseConfig = config as FirebaseCfg;
 
 let warned = false;
 const appCheckKey = getEnv("VITE_APPCHECK_SITE_KEY");
@@ -46,3 +46,8 @@ if (typeof window !== "undefined") {
 }
 
 export { missingEnvVars };
+
+const ready = Promise.resolve({ app, auth, db, storage });
+export function getFirebase() {
+  return ready;
+}

--- a/src/lib/firebaseConfig.ts
+++ b/src/lib/firebaseConfig.ts
@@ -1,6 +1,13 @@
-import type { FirebaseOptions } from "firebase/app";
+export type FirebaseCfg = {
+  apiKey: string;
+  authDomain?: string;
+  projectId: string;
+  storageBucket?: string;
+  messagingSenderId?: string;
+  appId: string;
+};
 
-export function envConfig(): FirebaseOptions {
+export function envConfig(): Partial<FirebaseCfg> {
   return {
     apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
     authDomain: import.meta.env.VITE_FIREBASE_AUTH_DOMAIN,
@@ -8,26 +15,26 @@ export function envConfig(): FirebaseOptions {
     storageBucket: import.meta.env.VITE_FIREBASE_STORAGE_BUCKET,
     messagingSenderId: import.meta.env.VITE_FIREBASE_MESSAGING_SENDER_ID,
     appId: import.meta.env.VITE_FIREBASE_APP_ID,
-  } as FirebaseOptions;
+  };
 }
 
-export function isValid(cfg: FirebaseOptions | null | undefined): boolean {
-  return !!cfg?.apiKey && !!cfg?.appId && !!cfg?.projectId;
+export function isValid(c: any): c is FirebaseCfg {
+  return !!c?.apiKey && !!c?.appId && !!c?.projectId;
 }
 
-export async function fetchHostingConfig(): Promise<FirebaseOptions | null> {
+export async function fetchHostingConfig(): Promise<FirebaseCfg | null> {
   try {
-    const res = await fetch("/__/firebase/init.json", { cache: "no-store" });
-    if (!res.ok) return null;
-    const data = await res.json();
+    const r = await fetch("/__/firebase/init.json", { cache: "no-store" });
+    if (!r.ok) return null;
+    const j = await r.json();
     return {
-      apiKey: data.apiKey,
-      authDomain: data.authDomain,
-      projectId: data.projectId,
-      storageBucket: data.storageBucket,
-      messagingSenderId: data.messagingSenderId,
-      appId: data.appId,
-    } as FirebaseOptions;
+      apiKey: j.apiKey,
+      authDomain: j.authDomain,
+      projectId: j.projectId,
+      storageBucket: j.storageBucket,
+      messagingSenderId: j.messagingSenderId,
+      appId: j.appId,
+    };
   } catch {
     return null;
   }

--- a/src/pages/ScanNew.tsx
+++ b/src/pages/ScanNew.tsx
@@ -151,7 +151,10 @@ export default function ScanNew() {
       )}
 
       <div>
-        <h1 className="text-3xl font-bold mb-2">New Scan</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold mb-2">New Scan</h1>
+          <span className="text-sm text-muted-foreground">Credits: {credits}</span>
+        </div>
         <p className="text-muted-foreground">
           Upload a photo or video to get your body composition analysis
         </p>


### PR DESCRIPTION
## Summary
- guard Firebase init with env/hosting fallbacks and expose async helper
- display available scan credits and maintain test-mode flow
- document release steps

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: vite: not found)*
- `npm run build:dev` *(fails: vite: not found)*
- `npm --prefix functions install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/eslint)*
- `npm --prefix functions run build` *(fails: module type declarations missing)*
- `firebase deploy --only functions:runBodyScan,functions:grantTestCredits --project mybodyscan-f3daf` *(fails: command not found)*
- `VITE_BUILD_TAG=$(date -u +%Y-%m-%dT%H:%M:%SZ) npx -y firebase-tools@latest deploy --only hosting --project mybodyscan-f3daf` *(fails: 403 Forbidden - GET https://registry.npmjs.org/firebase-tools)*

------
https://chatgpt.com/codex/tasks/task_e_68c60954dd64832585469f589c533339