### PR TITLE
fix: configure shadcn tokens for Tailwind

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,12 +1,50 @@
 import type { Config } from "tailwindcss";
 import defaultTheme from "tailwindcss/defaultTheme";
 import tailwindcssAnimate from "tailwindcss-animate";
+
 export default {
   darkMode: ["class"],
   content: ["./index.html", "./src/**/*.{ts,tsx}"],
   theme: {
     container: { center: true, padding: "2rem", screens: { "2xl": "1400px" } },
-    extend: { fontFamily: { sans: ["Inter", ...defaultTheme.fontFamily.sans] } }
+    extend: {
+      fontFamily: { sans: ["Inter", ...defaultTheme.fontFamily.sans] },
+      colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))"
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))"
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))"
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))"
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))"
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))"
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))"
+        }
+      }
+    }
   },
   plugins: [tailwindcssAnimate]
 } satisfies Config;


### PR DESCRIPTION
## Summary
- extend Tailwind with shadcn color tokens and animation plugin

## Testing
- `npm run build` (fails: vite: not found)
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)


------
https://chatgpt.com/codex/tasks/task_e_68c60f6a53808325b35526cce1c46010