### PR TITLE
Fix functions Timestamp type imports

### DIFF
--- a/functions/src/firebase-admin-firestore.d.ts
+++ b/functions/src/firebase-admin-firestore.d.ts
@@ -1,0 +1,15 @@
+declare module "firebase-admin/firestore" {
+  export class Timestamp {
+    static now(): Timestamp;
+    static fromDate(date: Date): Timestamp;
+    static fromMillis(milliseconds: number): Timestamp;
+
+    readonly seconds: number;
+    readonly nanoseconds: number;
+
+    toDate(): Date;
+    toMillis(): number;
+    isEqual(other: Timestamp): boolean;
+    valueOf(): string;
+  }
+}

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -1,0 +1,69 @@
+import type { Timestamp } from "firebase-admin/firestore";
+
+export type ScanStatus =
+  | "awaiting_upload"
+  | "queued"
+  | "processing"
+  | "ready"
+  | "done"
+  | "failed"
+  | "error";
+
+export interface ScanAssets {
+  frontUrl?: string;
+  leftUrl?: string;
+  rightUrl?: string;
+  backUrl?: string;
+  videoUrl?: string;
+}
+
+export interface ScanMeasurements {
+  bodyFat?: number;
+  bmi?: number;
+  weightLb?: number;
+  weightKg?: number;
+  muscleMassKg?: number;
+  visceralFat?: number;
+  [metric: string]: number | undefined;
+}
+
+export interface ScanDocument {
+  uid: string;
+  status: ScanStatus;
+  creditsDebited?: boolean;
+  filesCount?: number;
+  createdAt: Timestamp;
+  updatedAt?: Timestamp;
+  processedAt?: Timestamp;
+  completedAt?: Timestamp;
+  assets?: ScanAssets;
+  measurements?: ScanMeasurements;
+  summary?: string | null;
+  errorMessage?: string | null;
+}
+
+export interface CreditBucket {
+  amount: number;
+  grantedAt: Timestamp;
+  expiresAt?: Timestamp;
+  sourcePriceId: string;
+  context?: string | null;
+}
+
+export interface CreditsSummary {
+  totalAvailable: number;
+  lastUpdated: Timestamp;
+}
+
+export interface CreditsDocument {
+  creditBuckets: CreditBucket[];
+  creditsSummary: CreditsSummary;
+}
+
+export interface LedgerEntry {
+  id?: string;
+  kind: string;
+  creditsDelta: number;
+  createdAt: Timestamp;
+  notes?: string | null;
+}


### PR DESCRIPTION
## Summary
- add Firestore Timestamp type import and use it across the functions document interfaces
- declare a minimal firebase-admin/firestore module so the Timestamp type is available during builds

## Testing
- npx tsc -p functions/tsconfig.json

------
https://chatgpt.com/codex/tasks/task_e_68c9f7a64e5083259e6d48e9ba80ca6e