### PR TITLE
Refactor feature flag utilities and gate component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -62,7 +62,7 @@ import WorkoutsLibrary from "./pages/WorkoutsLibrary";
 import WorkoutsCompleted from "./pages/WorkoutsCompleted";
 import HealthSync from "./pages/HealthSync";
 import { RouteBoundary } from "./components/RouteBoundary";
-import { FeatureGate } from "./lib/featureFlags";
+import { FeatureGate } from "./components/FeatureGate";
 
 const OnboardingMBS = lazy(() => import("./pages/OnboardingMBS"));
 

--- a/src/components/FeatureGate.tsx
+++ b/src/components/FeatureGate.tsx
@@ -1,0 +1,17 @@
+import { ReactNode } from 'react';
+import { isFeatureEnabled, type FeatureName } from '@/lib/featureFlags';
+
+type FeatureGateProps = {
+  name: FeatureName;
+  fallback?: ReactNode;
+  children?: ReactNode;
+};
+
+export function FeatureGate({ name, fallback = null, children }: FeatureGateProps) {
+  if (!isFeatureEnabled(name)) {
+    return <>{fallback}</>;
+  }
+  return <>{children}</>;
+}
+
+export default FeatureGate;

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -19,7 +19,7 @@ import { isDemoGuest } from "@/lib/demoFlag";
 import { Download, Trash2 } from "lucide-react";
 import { SectionCard } from "@/components/Settings/SectionCard";
 import { ToggleRow } from "@/components/Settings/ToggleRow";
-import { FeatureGate } from "@/lib/featureFlags";
+import { FeatureGate } from "@/components/FeatureGate";
 import { scheduleReminderMock } from "@/lib/remindersShim";
 
 const Settings = () => {


### PR DESCRIPTION
## Summary
- refactor the feature flag utility module to only expose flag helpers and types
- add a dedicated FeatureGate React component in the components directory
- update FeatureGate imports to point at the new component module

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ce040d2d748325b9b2369e818c1021