### PR TITLE
Fix reserved identifier usage in height helpers

### DIFF
--- a/src/components/HeightInputUS.tsx
+++ b/src/components/HeightInputUS.tsx
@@ -14,7 +14,7 @@ export default function HeightInputUS({ valueCm, onChangeCm, disabled }: Props) 
 
   useEffect(() => {
     if (valueCm != null) {
-      const { ft: nextFt, in: nextIn } = inToFtIn(cmToIn(valueCm));
+      const { ft: nextFt, inches: nextIn } = inToFtIn(cmToIn(valueCm));
       setFt(nextFt);
       setInch(nextIn);
     }

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -15,10 +15,10 @@ export function cmToIn(cm: number): number {
   return cm / CM_PER_IN;
 }
 
-export function inToFtIn(totalInches: number): { ft: number; in: number } {
+export function inToFtIn(totalInches: number): { ft: number; inches: number } {
   const ft = Math.floor(totalInches / 12);
   const inches = Math.round(totalInches - ft * 12);
-  return { ft, in: inches };
+  return { ft, inches };
 }
 
 export function ftInToCm(ft: number, inches: number): number {
@@ -33,8 +33,8 @@ export function formatWeightFromKg(kg?: number, digits = 0): string {
 
 export function formatHeightFromCm(cm?: number): string {
   if (cm == null) return "—";
-  const { ft, in } = inToFtIn(cmToIn(cm));
-  return `${ft}′ ${in}″`;
+  const { ft, inches } = inToFtIn(cmToIn(cm));
+  return `${ft}′ ${inches}″`;
 }
 
 export function formatBmi(bmi?: number, digits = 1): string {

--- a/src/pages/CoachOnboarding.tsx
+++ b/src/pages/CoachOnboarding.tsx
@@ -39,7 +39,7 @@ const CoachOnboarding = () => {
     const payload: any = { ...form };
     const heightCm = form.height_cm ?? 0;
     const weightKg = form.weight_kg ?? 0;
-    const { ft, in: inch } = inToFtIn(cmToIn(heightCm));
+    const { ft, inches: inch } = inToFtIn(cmToIn(heightCm));
     payload.units = "us";
     payload.height_ft = ft;
     payload.height_in = inch;


### PR DESCRIPTION
## Summary
- update height conversion helper to return an inches property instead of the reserved identifier `in`
- adjust consumers to destructure the new inches property and format heights accordingly

## Testing
- npm run build *(fails: vite not found because dependencies cannot be installed due to 403 from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cea776409c8325a5a1bb62981a014a