### PR TITLE
Centralize Cloud Functions base URL handling

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -5,7 +5,7 @@ VITE_FIREBASE_STORAGE_BUCKET=demo.appspot.com
 VITE_FIREBASE_MESSAGING_SENDER_ID=1234567890
 VITE_FIREBASE_APP_ID=1:1234567890:web:abcdef123456
 VITE_FIREBASE_MEASUREMENT_ID=G-XXXXXXX
-VITE_FUNCTIONS_BASE_URL=http://localhost:5001/demo-project/us-central1
+VITE_FUNCTIONS_BASE_URL=https://us-central1-mybodyscan-f3daf.cloudfunctions.net
 VITE_FUNCTIONS_URL=http://localhost:5001/demo-project/us-central1
 # Optional App Check site key
 VITE_APPCHECK_SITE_KEY=

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,18 +1,17 @@
 import { auth, app } from "@/lib/firebase";
 import { getFunctions, httpsCallable } from "firebase/functions";
 import { toast } from "@/hooks/use-toast";
-
-const BASE = import.meta.env.VITE_FUNCTIONS_BASE_URL as string | undefined;
+import { fnUrl } from "@/lib/env";
 
 async function authedFetch(path: string, init?: RequestInit) {
-  const base = import.meta.env.VITE_FUNCTIONS_BASE_URL as string | undefined;
-  if (!base) {
+  const url = fnUrl(path);
+  if (!url) {
     toast({ title: "Server not configured" });
     return new Response(null, { status: 503 });
   }
   const t = await auth.currentUser?.getIdToken();
   if (!t) throw new Error("Authentication required");
-  return fetch(`${base}${path}`, {
+  return fetch(url, {
     ...init,
     headers: {
       "Content-Type": "application/json",
@@ -99,4 +98,4 @@ export async function refundIfNoResult(scanId: string) {
   }
   return data as { ok: boolean };
 }
-export { authedFetch, BASE as FUNCTIONS_BASE_URL };
+export { authedFetch };

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,0 +1,13 @@
+const raw = (import.meta as any)?.env?.VITE_FUNCTIONS_BASE_URL ?? '';
+/** Cloud Functions base URL without trailing slash. */
+export const FUNCTIONS_BASE: string = typeof raw === 'string' ? raw.replace(/\/+$/, '') : '';
+
+/** Build a URL to a function path. Returns '' if base is missing. */
+export function fnUrl(path: string): string {
+  if (!FUNCTIONS_BASE) {
+    console.warn('[ENV] VITE_FUNCTIONS_BASE_URL missing; skipping network call for', path);
+    return '';
+  }
+  const p = path.startsWith('/') ? path : `/${path}`;
+  return `${FUNCTIONS_BASE}${p}`;
+}


### PR DESCRIPTION
## Summary
- add src/lib/env.ts to normalize the Cloud Functions base URL and log when missing
- refactor authedFetch and nutrition shims to build URLs through fnUrl and return safe fallbacks when the base is absent
- update .env.development to point VITE_FUNCTIONS_BASE_URL at the deployed Cloud Functions endpoint

## Testing
- npm run lint *(fails: missing @eslint/js package in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced4f8a93883258c6f272f104f43a5