### PR TITLE
Implement scans v1 gating, analysis, and server flows

### DIFF
--- a/functions/src/scan/beginPaidScan.ts
+++ b/functions/src/scan/beginPaidScan.ts
@@ -1,6 +1,6 @@
 import { HttpsError, onRequest } from "firebase-functions/v2/https";
 import type { Request } from "firebase-functions/v2/https";
-import { Timestamp, getFirestore } from "../firebase";
+import { FieldValue, Timestamp, getFirestore } from "../firebase";
 import { withCors } from "../middleware/cors";
 import { softVerifyAppCheck } from "../middleware/appCheck";
 import { requireAuth, verifyAppCheckSoft } from "../http";
@@ -8,38 +8,11 @@ import { consumeCreditBuckets } from "./creditUtils";
 
 const db = getFirestore();
 const MAX_DAILY_FAILS = 3;
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
 
 function todayKey() {
   const now = new Date();
   return `${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, "0")}${String(now.getUTCDate()).padStart(2, "0")}`;
-}
-
-async function ensureDailyLimit(uid: string) {
-  const ref = db.doc(`users/${uid}/gate/${todayKey()}`);
-  const snap = await ref.get();
-  const count = snap.exists ? Number(snap.data()?.failures || 0) : 0;
-  if (count >= MAX_DAILY_FAILS) {
-    throw new HttpsError("resource-exhausted", "too_many_failed_gates");
-  }
-}
-
-async function checkDuplicate(uid: string, hashes: string[]): Promise<boolean> {
-  if (!hashes.length) return false;
-  const recentQuery = await db
-    .collection(`users/${uid}/scans`)
-    .orderBy("completedAt", "desc")
-    .limit(10)
-    .get();
-  for (const docSnap of recentQuery.docs) {
-    const data = docSnap.data() as any;
-    const docHashes: string[] = Array.isArray(data.imageHashes) ? data.imageHashes : [];
-    if (!docHashes.length) continue;
-    const intersection = hashes.some((hash) => docHashes.includes(hash));
-    if (intersection) {
-      return true;
-    }
-  }
-  return false;
 }
 
 async function handler(req: Request, res: any) {
@@ -48,13 +21,42 @@ async function handler(req: Request, res: any) {
   const uid = await requireAuth(req);
   const body = req.body as { scanId?: string; hashes?: string[]; gateScore?: number; mode?: "2" | "4" };
   if (!body?.scanId || !Array.isArray(body.hashes) || typeof body.gateScore !== "number") {
-    throw new HttpsError("invalid-argument", "scanId, hashes, gateScore required");
+    res.status(400).json({ ok: false, reason: "invalid_request" });
+    return;
   }
 
-  await ensureDailyLimit(uid);
-  if (await checkDuplicate(uid, body.hashes)) {
-    res.status(409).json({ error: "duplicate_scan" });
+  const gateRef = db.doc(`users/${uid}/gate/${todayKey()}`);
+  const gateSnap = await gateRef.get();
+  const gateData = gateSnap.exists ? gateSnap.data() as any : {};
+  const failedCount = Number(gateData.failed || 0);
+  if (failedCount >= MAX_DAILY_FAILS) {
+    res.status(429).json({ ok: false, reason: "cap" });
     return;
+  }
+
+  const hashes = body.hashes.filter((hash) => typeof hash === "string" && hash.length > 0);
+  if (!hashes.length) {
+    res.status(400).json({ ok: false, reason: "invalid_hashes" });
+    return;
+  }
+
+  const cutoff = Timestamp.fromMillis(Date.now() - THIRTY_DAYS_MS);
+  const recentQuery = await db
+    .collection(`users/${uid}/scans`)
+    .where("charged", "==", true)
+    .where("status", "==", "completed")
+    .where("completedAt", ">=", cutoff)
+    .get();
+
+  for (const docSnap of recentQuery.docs) {
+    const data = docSnap.data() as any;
+    const docHashes: string[] = Array.isArray(data.imageHashes) ? data.imageHashes : [];
+    if (!docHashes.length) continue;
+    const duplicate = hashes.some((hash) => docHashes.includes(hash));
+    if (duplicate) {
+      res.status(409).json({ ok: false, reason: "duplicate" });
+      return;
+    }
   }
 
   const scanRef = db.doc(`users/${uid}/scans/${body.scanId}`);
@@ -62,42 +64,66 @@ async function handler(req: Request, res: any) {
   const now = Timestamp.now();
   let remainingCredits = 0;
 
-  await db.runTransaction(async (tx) => {
-    const scanSnap = await tx.get(scanRef);
-    if (!scanSnap.exists) {
-      throw new HttpsError("not-found", "scan_not_found");
+  try {
+    await db.runTransaction(async (tx) => {
+      const scanSnap = await tx.get(scanRef);
+      if (!scanSnap.exists) {
+        throw new HttpsError("not-found", "scan_not_found");
+      }
+
+      const { buckets, consumed, total } = await consumeCreditBuckets(tx, creditRef, 1);
+      if (!consumed) {
+        throw new HttpsError("failed-precondition", "no_credits");
+      }
+      remainingCredits = total;
+
+      tx.set(
+        creditRef,
+        {
+          creditBuckets: buckets,
+          creditsSummary: { totalAvailable: total, lastUpdated: now },
+        },
+        { merge: true }
+      );
+
+      tx.set(
+        scanRef,
+        {
+          status: "authorized",
+          charged: true,
+          authorizedAt: now,
+          updatedAt: now,
+          gateScore: body.gateScore,
+          mode: body.mode || "2",
+          imageHashes: hashes,
+          gate: { clientScore: body.gateScore, authorizedAt: now },
+        },
+        { merge: true }
+      );
+    });
+  } catch (error: any) {
+    if (error instanceof HttpsError) {
+      if (error.code === "failed-precondition") {
+        res.status(402).json({ ok: false, reason: "no_credits" });
+        return;
+      }
+      if (error.code === "not-found") {
+        res.status(404).json({ ok: false, reason: "missing_scan" });
+        return;
+      }
     }
+    res.status(500).json({ ok: false, reason: "server_error" });
+    return;
+  }
 
-    const { buckets, consumed, total } = await consumeCreditBuckets(tx, creditRef, 1);
-    if (!consumed) {
-      throw new HttpsError("failed-precondition", "no_credits");
-    }
-    remainingCredits = total;
-
-    tx.set(
-      creditRef,
-      {
-        creditBuckets: buckets,
-        creditsSummary: { totalAvailable: total, lastUpdated: now },
-      },
-      { merge: true }
-    );
-
-    tx.set(
-      scanRef,
-      {
-        status: "authorized",
-        charged: true,
-        authorizedAt: now,
-        updatedAt: now,
-        gateScore: body.gateScore,
-        mode: body.mode || "2",
-        imageHashes: body.hashes,
-        gate: { clientScore: body.gateScore, authorizedAt: now },
-      },
-      { merge: true }
-    );
-  });
+  await gateRef.set(
+    {
+      failed: failedCount,
+      passed: FieldValue.increment(1),
+      updatedAt: now,
+    },
+    { merge: true }
+  );
 
   res.json({ ok: true, remainingCredits });
 }
@@ -108,20 +134,11 @@ export const beginPaidScan = onRequest(
       await handler(req as Request, res);
     } catch (error: any) {
       if (error instanceof HttpsError) {
-        const status =
-          error.code === "unauthenticated"
-            ? 401
-            : error.code === "invalid-argument"
-            ? 400
-            : error.code === "resource-exhausted"
-            ? 429
-            : error.code === "failed-precondition"
-            ? 402
-            : 400;
-        res.status(status).json({ error: error.message });
+        const status = error.code === "unauthenticated" ? 401 : 400;
+        res.status(status).json({ ok: false, reason: error.code });
         return;
       }
-      res.status(500).json({ error: error?.message || "error" });
+      res.status(500).json({ ok: false, reason: "server_error" });
     }
   })
 );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -84,7 +84,7 @@ export async function recordGateFailure() {
   if (!response.ok) {
     throw new Error(data?.error || "gate_failure_not_recorded");
   }
-  return data as { ok: boolean; remainingAttempts?: number };
+  return data as { ok: boolean; remaining?: number };
 }
 
 export async function refundIfNoResult(scanId: string) {
@@ -96,6 +96,6 @@ export async function refundIfNoResult(scanId: string) {
   if (!response.ok) {
     throw new Error(data?.error || "refund_failed");
   }
-  return data as { ok: boolean };
+  return data as { ok: boolean; refunded: boolean };
 }
 export { authedFetch };

--- a/src/lib/scan/__tests__/anthro.test.ts
+++ b/src/lib/scan/__tests__/anthro.test.ts
@@ -1,20 +1,14 @@
 import { describe, expect, it } from "vitest";
-import {
-  bmiFromKgCm,
-  computeBodyFat,
-  reconcileBodyFat,
-  usNavyFemale,
-  usNavyMale,
-} from "../anthro";
+import { bmiFromKgCm, computeBodyFat, reconcileBodyFat, bfUsNavyFemale, bfUsNavyMale } from "../anthro";
 
 describe("anthropometric estimators", () => {
   it("computes US Navy male estimate within expected bounds", () => {
-    const bf = usNavyMale(90, 40, 180);
+    const bf = bfUsNavyMale(90, 40, 180);
     expect(bf).toBeCloseTo(25.1, 1);
   });
 
   it("computes US Navy female estimate within expected bounds", () => {
-    const bf = usNavyFemale(80, 34, 95, 165);
+    const bf = bfUsNavyFemale(80, 34, 95, 165);
     expect(bf).toBeCloseTo(55.9, 1);
   });
 
@@ -29,15 +23,15 @@ describe("anthropometric estimators", () => {
   });
 
   it("derives circumference-based body-fat results when data is available", () => {
-    const result = computeBodyFat({ sex: "male", height_cm: 180, neck_cm: 40, waist_cm: 90, weight_kg: 82 });
-    expect(result.method).toBe("circumference");
-    expect(result.bfPercent).not.toBeNull();
+    const result = computeBodyFat({ sex: "male", heightCm: 180, neckCm: 40, waistCm: 90, weightKg: 82 });
+    expect(result.method).toBe("photo");
+    expect(Number.isFinite(result.bfPercent)).toBe(true);
     expect(result.confidence).toBeGreaterThan(0.6);
   });
 
   it("falls back to BMI estimate when circumferences missing", () => {
-    const result = computeBodyFat({ sex: "female", height_cm: 165, weight_kg: 70 });
-    expect(result.method).toBe("bmi");
+    const result = computeBodyFat({ sex: "female", heightCm: 165, weightKg: 70 });
+    expect(result.method).toBe("bmi_fallback");
     expect(result.confidence).toBeLessThan(0.5);
     expect(result.bfPercent).toBeGreaterThan(0);
   });

--- a/src/lib/scan/__tests__/gates.test.ts
+++ b/src/lib/scan/__tests__/gates.test.ts
@@ -28,7 +28,7 @@ describe("scan quality gate", () => {
   it("flags low-resolution images", () => {
     const result = evaluateGateMetrics({ ...baseMetrics, longEdge: 400, imageIndex: 1 });
     expect(result.score).toBeLessThan(1);
-    expect(result.reasons).toContain("Resolution too low — retake photo at higher quality");
+    expect(result.reasons).toContain("Use a higher-resolution photo (long edge ≥1080px)");
   });
 
   it("detects arms resting against torso", () => {

--- a/src/lib/scan/anthro.ts
+++ b/src/lib/scan/anthro.ts
@@ -1,30 +1,12 @@
-const DEG_TO_LOG = Math.log(10);
+const LOG10 = Math.log(10);
 
 function log10(value: number) {
-  return Math.log(value) / DEG_TO_LOG;
+  return Math.log(value) / LOG10;
 }
 
 function clamp(value: number, min: number, max: number) {
-  if (Number.isNaN(value)) return min;
+  if (!Number.isFinite(value)) return min;
   return Math.min(Math.max(value, min), max);
-}
-
-export function usNavyMale(waistCm: number, neckCm: number, heightCm: number): number {
-  if (!waistCm || !neckCm || !heightCm || waistCm <= neckCm) return NaN;
-  const bf =
-    86.010 * log10(waistCm - neckCm) -
-    70.041 * log10(heightCm) +
-    36.76;
-  return clamp(Number(bf.toFixed(1)), 3, 65);
-}
-
-export function usNavyFemale(waistCm: number, neckCm: number, hipCm: number, heightCm: number): number {
-  if (!waistCm || !neckCm || !hipCm || !heightCm || waistCm + hipCm <= neckCm) return NaN;
-  const bf =
-    163.205 * log10(waistCm + hipCm - neckCm) -
-    97.684 * log10(heightCm) -
-    78.387;
-  return clamp(Number(bf.toFixed(1)), 8, 65);
 }
 
 export function bmiFromKgCm(weightKg: number, heightCm: number): number {
@@ -34,102 +16,69 @@ export function bmiFromKgCm(weightKg: number, heightCm: number): number {
   return Number(bmi.toFixed(1));
 }
 
-export function reconcileBodyFat(primary: number, secondary: number): number {
-  const values = [primary, secondary].filter((v) => Number.isFinite(v));
+export function bfUsNavyMale(waistCm: number, neckCm: number, heightCm: number): number {
+  if (!waistCm || !neckCm || !heightCm || waistCm <= neckCm) return NaN;
+  const bf = 86.010 * log10(waistCm - neckCm) - 70.041 * log10(heightCm) + 36.76;
+  return clamp(Number(bf.toFixed(1)), 3, 65);
+}
+
+export function bfUsNavyFemale(waistCm: number, neckCm: number, hipCm: number, heightCm: number): number {
+  if (!waistCm || !neckCm || !hipCm || !heightCm || waistCm + hipCm <= neckCm) return NaN;
+  const bf = 163.205 * log10(waistCm + hipCm - neckCm) - 97.684 * log10(heightCm) - 78.387;
+  return clamp(Number(bf.toFixed(1)), 3, 65);
+}
+
+export function reconcileBodyFat(primary: number, secondary?: number): number {
+  const values = [primary, secondary].filter((value) => Number.isFinite(value)) as number[];
   if (!values.length) return NaN;
-  const avg = values.reduce((acc, value) => acc + value, 0) / values.length;
+  const avg = values.reduce((sum, value) => sum + value, 0) / values.length;
   return clamp(Number(avg.toFixed(1)), 3, 65);
 }
 
-export interface BodyFatInput {
-  sex?: "male" | "female";
-  height_cm: number;
-  neck_cm?: number;
-  waist_cm?: number;
-  hip_cm?: number;
-  weight_kg?: number;
+function waistHeightEstimate(waistCm?: number, heightCm?: number, sex?: "male" | "female") {
+  if (!waistCm || !heightCm) return NaN;
+  const ratio = waistCm / heightCm;
+  const base = ratio * 100;
+  const adjustment = sex === "female" ? 6 : 2.2;
+  const bf = base * 1.1 + adjustment;
+  return clamp(Number(bf.toFixed(1)), 5, 60);
 }
 
-export interface BodyFatResult {
-  bfPercent: number | null;
-  method: "circumference" | "bmi" | "unknown";
-  confidence: number;
-  sources: string[];
-  notes: string[];
-}
-
-function alternateEstimator(input: BodyFatInput): number {
-  const { waist_cm, hip_cm, neck_cm, height_cm, sex } = input;
-  if (!waist_cm || !height_cm) return NaN;
-  const waistToHeight = waist_cm / height_cm;
-  const hipAdj = hip_cm ? hip_cm / height_cm : waistToHeight;
-  const neckAdj = neck_cm ? neck_cm / height_cm : waistToHeight * 0.6;
-  let base = 100 * waistToHeight * 0.9 + 100 * hipAdj * 0.15 - 100 * neckAdj * 0.2;
-  base += sex === "female" ? 5.5 : -2.2;
-  return clamp(Number(base.toFixed(1)), 5, 60);
-}
-
-export function computeBodyFat(input: BodyFatInput): BodyFatResult {
-  const notes: string[] = [];
-  const sources: string[] = [];
-  const { sex, height_cm, neck_cm, waist_cm, hip_cm, weight_kg } = input;
-  if (!height_cm) {
-    return { bfPercent: null, method: "unknown", confidence: 0, sources, notes: ["missing_height"] };
+export function computeBodyFat(params: {
+  sex: "male" | "female";
+  heightCm: number;
+  neckCm?: number;
+  waistCm?: number;
+  hipCm?: number;
+  weightKg?: number;
+}): { bfPercent: number; method: "photo" | "photo+measure" | "bmi_fallback"; confidence: number } {
+  const { sex, heightCm, neckCm, waistCm, hipCm, weightKg } = params;
+  if (!heightCm) {
+    return { bfPercent: NaN, method: "photo", confidence: 0 };
   }
 
-  let bfFromCircumference: number | undefined;
-  let bfSecondary: number | undefined;
+  const circumferenceCount = [neckCm, waistCm, hipCm].filter((value) => Number.isFinite(value)).length;
+  let primary = NaN;
+  if (sex === "female") {
+    primary = bfUsNavyFemale(waistCm ?? NaN, neckCm ?? NaN, hipCm ?? NaN, heightCm);
+  } else {
+    primary = bfUsNavyMale(waistCm ?? NaN, neckCm ?? NaN, heightCm);
+  }
+  const secondary = waistHeightEstimate(waistCm, heightCm, sex);
 
-  if (waist_cm && height_cm) {
-    if (sex === "female") {
-      const navy = usNavyFemale(waist_cm, neck_cm ?? NaN, hip_cm ?? NaN, height_cm);
-      if (Number.isFinite(navy)) {
-        bfFromCircumference = navy;
-        sources.push("us_navy_female");
-      }
-    } else {
-      const navy = usNavyMale(waist_cm, neck_cm ?? NaN, height_cm);
-      if (Number.isFinite(navy)) {
-        bfFromCircumference = navy;
-        sources.push("us_navy_male");
-      }
-    }
-    const alt = alternateEstimator(input);
-    if (Number.isFinite(alt)) {
-      bfSecondary = alt;
-      sources.push("waist_height_ratio");
-    }
+  if (Number.isFinite(primary)) {
+    const bfPercent = reconcileBodyFat(primary, secondary);
+    const spread = Number.isFinite(secondary) ? Math.abs(primary - (secondary as number)) : 0;
+    const confidence = spread > 6 ? 0.72 : spread > 3 ? 0.82 : 0.9;
+    const method: "photo" | "photo+measure" = circumferenceCount >= 3 ? "photo+measure" : "photo";
+    return { bfPercent, method, confidence };
   }
 
-  if (bfFromCircumference != null && Number.isFinite(bfFromCircumference)) {
-    const reconciled = reconcileBodyFat(bfFromCircumference, bfSecondary ?? NaN);
-    const hasSecondary = Number.isFinite(bfSecondary ?? NaN);
-    const spread = hasSecondary ? Math.abs(bfFromCircumference - (bfSecondary as number)) : 0;
-    const confidence = spread > 6 ? 0.65 : spread > 3 ? 0.78 : 0.88;
-    if (spread > 6) notes.push("estimators_diverged");
-    return {
-      bfPercent: Number.isFinite(reconciled) ? reconciled : null,
-      method: "circumference",
-      confidence,
-      sources,
-      notes,
-    };
-  }
-
-  const bmi = bmiFromKgCm(weight_kg ?? NaN, height_cm);
+  const bmi = bmiFromKgCm(weightKg ?? NaN, heightCm);
   if (Number.isFinite(bmi)) {
-    sources.push("bmi");
-    const bfEstimate = sex === "female" ? 1.2 * bmi + 0.23 * 30 - 5.4 : 1.2 * bmi + 0.23 * 30 - 16.2;
-    notes.push("circumference_missing");
-    return {
-      bfPercent: clamp(Number(bfEstimate.toFixed(1)), 5, 60),
-      method: "bmi",
-      confidence: 0.45,
-      sources,
-      notes,
-    };
+    const bf = sex === "female" ? 1.2 * bmi + 0.23 * 30 - 5.4 : 1.2 * bmi + 0.23 * 30 - 16.2;
+    return { bfPercent: clamp(Number(bf.toFixed(1)), 3, 65), method: "bmi_fallback", confidence: 0.5 };
   }
 
-  notes.push("insufficient_data");
-  return { bfPercent: null, method: "unknown", confidence: 0, sources, notes };
+  return { bfPercent: NaN, method: "photo", confidence: 0 };
 }

--- a/src/pages/ScanResult.tsx
+++ b/src/pages/ScanResult.tsx
@@ -38,8 +38,8 @@ const methodCopy: Record<string, string> = {
 
 function confidenceLabel(value?: number) {
   if (value == null) return { label: "Unknown", tone: "secondary" } as const;
-  if (value >= 0.8) return { label: "High", tone: "default" } as const;
-  if (value >= 0.6) return { label: "Medium", tone: "outline" } as const;
+  if (value >= 0.85) return { label: "High", tone: "default" } as const;
+  if (value >= 0.7) return { label: "Medium", tone: "outline" } as const;
   return { label: "Low", tone: "secondary" } as const;
 }
 
@@ -191,6 +191,17 @@ export default function ScanResult() {
               </ul>
             </div>
           ) : null}
+
+          <details className="rounded-lg border p-3 text-sm text-muted-foreground">
+            <summary className="cursor-pointer font-medium text-foreground">Accuracy tips</summary>
+            <p className="mt-2">
+              Bright, even lighting and a neutral background improve confidence. Keep arms slightly away from your torso and
+              stand on a marked spot about 8 ft from the camera.
+            </p>
+            <Link to="/scan/tips" className="mt-2 inline-flex text-xs font-medium text-primary underline">
+              View full tips
+            </Link>
+          </details>
         </CardContent>
       </Card>
 
@@ -210,7 +221,11 @@ export default function ScanResult() {
                 >
                   <div>
                     <p className="font-medium">{formatDate(entry.completedAt?.seconds)}</p>
-                    <p className="text-xs text-muted-foreground">{methodCopy[entry.method || ""] || entry.method || "Photo"}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {(methodCopy[entry.method || ""] || entry.method || "Photo") +
+                        " • " +
+                        (entry.mode === "4" ? "Precise (4 photos)" : "Quick (2 photos)")}
+                    </p>
                   </div>
                   <div className="flex items-center gap-4">
                     <div className="text-right">


### PR DESCRIPTION
## Summary
- add a browser-side quality gate and perceptual hashing to vet scan photos before invoking paid analysis
- wire new server endpoints for paid scan authorization, gate failure tracking, and refunds while enforcing duplicate and daily attempt caps
- refresh scan analysis UX (results, history, and settings) to surface method/confidence metadata, photo tips, and weight entry in US units

## Testing
- `npm run lint` *(fails: missing @eslint/js in environment)*
- `npm run test` *(fails: vitest command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ced8ffc15083258274a844972523b5