### PR TITLE
Implement nutrition v1 with real providers

### DIFF
--- a/functions/src/nutrition/search.ts
+++ b/functions/src/nutrition/search.ts
@@ -6,56 +6,89 @@ import { softVerifyAppCheck } from "../middleware/appCheck";
 import { requireAuth, verifyAppCheckSoft } from "../http";
 
 const USDA_KEY = defineSecret("USDA_FDC_API_KEY");
+const SEARCH_CACHE_TTL = 1000 * 60 * 5; // ~5 minutes
 
-export interface NormalizedItem {
-  id: string;
-  name: string;
-  brand?: string;
-  upc?: string;
-  serving: string | null;
-  per_serving: Nutrients;
-  per_100g?: Nutrients;
-  source: "USDA" | "OFF";
-}
-
-export interface Nutrients {
+interface Nutrients {
   kcal?: number | null;
   protein_g?: number | null;
   carbs_g?: number | null;
   fat_g?: number | null;
 }
 
-export function parseNumber(value: any): number | null {
+export interface NormalizedItem {
+  id: string;
+  name: string;
+  brand?: string;
+  gtin?: string;
+  serving: {
+    qty: number | null;
+    unit: string | null;
+    text?: string | null;
+  };
+  per_serving: Nutrients;
+  per_100g?: Nutrients;
+  source: "USDA" | "OFF";
+  fdcId?: number;
+}
+
+interface CacheEntry {
+  expires: number;
+  value: NormalizedItem[];
+}
+
+const cache = new Map<string, CacheEntry>();
+
+function parseNumber(value: unknown): number | null {
   const num = Number(value);
   return Number.isFinite(num) ? Number(num.toFixed(2)) : null;
+}
+
+function normalizeServing(qty: unknown, unit: unknown, fallbackText?: string | null) {
+  const numeric = parseNumber(qty);
+  const unitText = typeof unit === "string" && unit.trim().length ? unit.trim() : null;
+  return {
+    qty: numeric,
+    unit: unitText,
+    text: fallbackText ?? (numeric && unitText ? `${numeric} ${unitText}` : fallbackText ?? null),
+  };
 }
 
 export function fromUsdaFood(food: any): NormalizedItem | null {
   if (!food) return null;
   const label = food.labelNutrients || {};
-  const perServing: Nutrients = {
-    kcal: parseNumber(label.calories?.value ?? food.foodNutrients?.find((n: any) => n.nutrientName === "Energy")?.value),
+  const nutrients: Nutrients = {
+    kcal: parseNumber(
+      label.calories?.value ??
+        food.foodNutrients?.find((n: any) => n.nutrientName === "Energy" && n.unitName === "KCAL")?.value,
+    ),
     protein_g: parseNumber(label.protein?.value),
     carbs_g: parseNumber(label.carbohydrates?.value),
     fat_g: parseNumber(label.fat?.value),
   };
+
   const per100g: Nutrients = {
-    kcal: parseNumber(food.foodNutrients?.find((n: any) => n.nutrientName === "Energy" && n.unitName === "KCAL")?.value),
+    kcal: parseNumber(
+      food.foodNutrients?.find((n: any) => n.nutrientName === "Energy" && n.unitName === "KCAL")?.value,
+    ),
     protein_g: parseNumber(food.foodNutrients?.find((n: any) => n.nutrientName === "Protein")?.value),
-    carbs_g: parseNumber(food.foodNutrients?.find((n: any) => n.nutrientName === "Carbohydrate, by difference")?.value),
+    carbs_g: parseNumber(
+      food.foodNutrients?.find((n: any) => n.nutrientName === "Carbohydrate, by difference")?.value,
+    ),
     fat_g: parseNumber(food.foodNutrients?.find((n: any) => n.nutrientName === "Total lipid (fat)")?.value),
   };
-  const servingSize = parseNumber(food.servingSize);
-  const servingUnit = food.servingSizeUnit ? String(food.servingSizeUnit).toLowerCase() : null;
-  const serving = servingSize && servingUnit ? `${servingSize} ${servingUnit}` : null;
+
+  const serving = normalizeServing(food.servingSize, food.servingSizeUnit, food.householdServingFullText);
+
   return {
     id: `usda-${food.fdcId}`,
+    fdcId: Number(food.fdcId) || undefined,
     name: food.description || "USDA Food",
-    brand: food.brandName || undefined,
-    upc: food.gtinUpc || undefined,
+    brand: food.brandName || food.brandOwner || undefined,
+    gtin: food.gtinUpc || undefined,
     serving,
-    per_serving: perServing,
-    per_100g: per100g,
+    per_serving: nutrients,
+    per_100g:
+      per100g.kcal || per100g.protein_g || per100g.carbs_g || per100g.fat_g ? per100g : undefined,
     source: "USDA",
   };
 }
@@ -63,34 +96,42 @@ export function fromUsdaFood(food: any): NormalizedItem | null {
 export function fromOpenFoodFacts(product: any): NormalizedItem | null {
   if (!product) return null;
   const nutriments = product.nutriments || {};
-  const serving = typeof product.serving_size === "string" ? product.serving_size : null;
   const perServing: Nutrients = {
-    kcal: parseNumber(nutriments["energy-kcal_serving"] ?? (nutriments.energy_serving ? nutriments.energy_serving / 4.184 : null)),
+    kcal: parseNumber(
+      nutriments["energy-kcal_serving"] ??
+        (nutriments.energy_serving ? nutriments.energy_serving / 4.184 : undefined),
+    ),
     protein_g: parseNumber(nutriments.proteins_serving),
     carbs_g: parseNumber(nutriments.carbohydrates_serving),
     fat_g: parseNumber(nutriments.fat_serving),
   };
   const per100g: Nutrients = {
-    kcal: parseNumber(nutriments["energy-kcal_100g"] ?? (nutriments.energy_100g ? nutriments.energy_100g / 4.184 : null)),
+    kcal: parseNumber(
+      nutriments["energy-kcal_100g"] ??
+        (nutriments.energy_100g ? nutriments.energy_100g / 4.184 : undefined),
+    ),
     protein_g: parseNumber(nutriments.proteins_100g),
     carbs_g: parseNumber(nutriments.carbohydrates_100g),
     fat_g: parseNumber(nutriments.fat_100g),
   };
+
+  const serving = normalizeServing(product.serving_quantity, product.serving_size_unit, product.serving_size);
+
   return {
     id: product.id ? `off-${product.id}` : `off-${product.code}`,
     name: product.product_name || product.generic_name || "OpenFoodFacts item",
     brand: product.brands || product.brand_owner || undefined,
-    upc: product.code || undefined,
+    gtin: product.code || product.gtin || undefined,
     serving,
     per_serving: perServing,
-    per_100g: per100g,
+    per_100g:
+      per100g.kcal || per100g.protein_g || per100g.carbs_g || per100g.fat_g ? per100g : undefined,
     source: "OFF",
   };
 }
 
 async function queryUsda(apiKey: string, queryText: string) {
-  const url = "https://api.nal.usda.gov/fdc/v1/foods/search";
-  const response = await fetch(url, {
+  const response = await fetch("https://api.nal.usda.gov/fdc/v1/foods/search", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ query: queryText, pageSize: 20, requireAllWords: false }),
@@ -100,32 +141,55 @@ async function queryUsda(apiKey: string, queryText: string) {
     throw new Error(`usda_${response.status}`);
   }
   const data = await response.json();
-  return Array.isArray(data?.foods) ? data.foods.map(fromUsdaFood).filter(Boolean) : [];
+  if (!Array.isArray(data?.foods)) return [] as NormalizedItem[];
+  return data.foods.map(fromUsdaFood).filter(Boolean) as NormalizedItem[];
 }
 
 async function queryOff(queryText: string) {
-  const url = `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(
-    queryText
-  )}&search_simple=1&json=1&page_size=20`;
-  const response = await fetch(url, { headers: { "User-Agent": "mybodyscan-functions" } });
+  const response = await fetch(
+    `https://world.openfoodfacts.org/cgi/search.pl?search_terms=${encodeURIComponent(queryText)}&search_simple=1&json=1&page_size=20`,
+    { headers: { "User-Agent": "mybodyscan-functions" } },
+  );
   if (!response.ok) {
     throw new Error(`off_${response.status}`);
   }
   const data = await response.json();
-  return Array.isArray(data?.products) ? data.products.map(fromOpenFoodFacts).filter(Boolean) : [];
+  if (!Array.isArray(data?.products)) return [] as NormalizedItem[];
+  return data.products.map(fromOpenFoodFacts).filter(Boolean) as NormalizedItem[];
+}
+
+function dedupeItems(items: NormalizedItem[]) {
+  const seen = new Map<string, NormalizedItem>();
+  for (const item of items) {
+    const key = item.gtin
+      ? item.gtin
+      : `${(item.brand || "").toLowerCase()}|${item.name.toLowerCase()}`;
+    if (!seen.has(key)) {
+      seen.set(key, item);
+    }
+  }
+  return Array.from(seen.values());
 }
 
 async function handler(req: Request, res: any) {
   await softVerifyAppCheck(req as any, res as any);
   await verifyAppCheckSoft(req);
   await requireAuth(req);
+
   const queryText = String(req.query?.q || req.body?.q || "").trim();
   if (!queryText) {
     throw new HttpsError("invalid-argument", "q required");
   }
 
+  const now = Date.now();
+  const cached = cache.get(queryText.toLowerCase());
+  if (cached && cached.expires > now) {
+    res.json({ items: cached.value, q: queryText, cached: true });
+    return;
+  }
+
   const usdaKey = USDA_KEY.value();
-  let usdaResults: (NormalizedItem | null)[] = [];
+  let usdaResults: NormalizedItem[] = [];
   try {
     if (usdaKey) {
       usdaResults = await queryUsda(usdaKey, queryText);
@@ -134,7 +198,7 @@ async function handler(req: Request, res: any) {
     console.error("usda_search_error", error);
   }
 
-  let offResults: (NormalizedItem | null)[] = [];
+  let offResults: NormalizedItem[] = [];
   if (!usdaResults.length || usdaResults.length < 5) {
     try {
       offResults = await queryOff(queryText);
@@ -143,16 +207,9 @@ async function handler(req: Request, res: any) {
     }
   }
 
-  const dedup = new Map<string, NormalizedItem>();
-  for (const item of [...usdaResults, ...offResults]) {
-    if (!item) continue;
-    const key = `${item.name.toLowerCase()}|${(item.brand || "").toLowerCase()}|${item.upc || ""}`;
-    if (!dedup.has(key)) {
-      dedup.set(key, item);
-    }
-  }
-
-  res.json({ items: Array.from(dedup.values()) });
+  const merged = dedupeItems([...usdaResults, ...offResults]);
+  cache.set(queryText.toLowerCase(), { value: merged, expires: now + SEARCH_CACHE_TTL });
+  res.json({ items: merged, q: queryText, cached: false });
 }
 
 export const nutritionSearch = onRequest({ secrets: [USDA_KEY] }, withCors(async (req, res) => {
@@ -160,7 +217,12 @@ export const nutritionSearch = onRequest({ secrets: [USDA_KEY] }, withCors(async
     await handler(req as Request, res);
   } catch (error: any) {
     if (error instanceof HttpsError) {
-      const status = error.code === "unauthenticated" ? 401 : error.code === "invalid-argument" ? 400 : 400;
+      const status =
+        error.code === "unauthenticated"
+          ? 401
+          : error.code === "invalid-argument"
+          ? 400
+          : 400;
       res.status(status).json({ error: error.message });
       return;
     }

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -11,6 +11,40 @@ export interface ScanDocument {
   mock?: boolean;
 }
 
+export interface NutritionItemSnapshot {
+  id?: string;
+  name: string;
+  brand?: string | null;
+  source?: "USDA" | "OFF" | string;
+  serving?: {
+    qty?: number | null;
+    unit?: string | null;
+    text?: string | null;
+  } | null;
+  per_serving?: {
+    kcal?: number | null;
+    protein_g?: number | null;
+    carbs_g?: number | null;
+    fat_g?: number | null;
+  } | null;
+  per_100g?: {
+    kcal?: number | null;
+    protein_g?: number | null;
+    carbs_g?: number | null;
+    fat_g?: number | null;
+  } | null;
+  fdcId?: number | null;
+  gtin?: string | null;
+}
+
+export interface MealServingSelection {
+  qty?: number;
+  unit?: string;
+  grams?: number | null;
+  originalQty?: number | null;
+  originalUnit?: string | null;
+}
+
 export interface MealRecord {
   id: string;
   name: string;
@@ -22,6 +56,9 @@ export interface MealRecord {
   caloriesFromMacros?: number;
   caloriesInput?: number;
   notes?: string | null;
+  serving?: MealServingSelection | null;
+  item?: NutritionItemSnapshot | null;
+  entrySource?: "search" | "barcode" | "manual" | string;
 }
 
 export interface DailyLogDocument {

--- a/src/components/nutrition/ServingEditor.tsx
+++ b/src/components/nutrition/ServingEditor.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import type { NormalizedItem } from "@/lib/nutritionShim";
+import {
+  SERVING_UNITS,
+  type ServingUnit,
+  calculateSelection,
+  gramsToOunces,
+  buildMealEntry,
+  estimateServingWeight,
+} from "@/lib/nutritionMath";
+import type { MealEntry } from "@/lib/nutrition";
+
+interface ServingEditorProps {
+  item: NormalizedItem;
+  defaultQty?: number;
+  defaultUnit?: ServingUnit;
+  confirmLabel?: string;
+  onConfirm: (payload: { qty: number; unit: ServingUnit; result: ReturnType<typeof calculateSelection>; meal: MealEntry }) => void;
+  onCancel?: () => void;
+  busy?: boolean;
+  entrySource?: MealEntry["entrySource"];
+}
+
+export function ServingEditor({
+  item,
+  defaultQty = 1,
+  defaultUnit = "serving",
+  confirmLabel = "Add",
+  onConfirm,
+  onCancel,
+  busy,
+  entrySource = "search",
+}: ServingEditorProps) {
+  const [quantity, setQuantity] = useState<number>(defaultQty);
+  const [unit, setUnit] = useState<ServingUnit>(defaultUnit);
+  const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    setQuantity(defaultQty);
+    setUnit(defaultUnit);
+    setNotes("");
+  }, [item, defaultQty, defaultUnit]);
+
+  const result = useMemo(() => calculateSelection(item, quantity, unit), [item, quantity, unit]);
+  const servingWeight = useMemo(() => estimateServingWeight(item), [item]);
+
+  const submit = () => {
+    const meal = buildMealEntry(item, quantity, unit, result, entrySource);
+    if (notes.trim()) {
+      meal.notes = notes.trim();
+    }
+    onConfirm({ qty: quantity, unit, result, meal });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <Label htmlFor="serving-qty">Quantity</Label>
+          <Input
+            id="serving-qty"
+            type="number"
+            min="0"
+            step="0.1"
+            value={quantity}
+            onChange={(event) => setQuantity(Number(event.target.value) || 0)}
+          />
+        </div>
+        <div>
+          <Label htmlFor="serving-unit">Unit</Label>
+          <Select value={unit} onValueChange={(value) => setUnit(value as ServingUnit)}>
+            <SelectTrigger id="serving-unit">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SERVING_UNITS.map((option) => (
+                <SelectItem key={option} value={option}>
+                  {option === "serving" && item.serving.text
+                    ? `serving (${item.serving.text})`
+                    : option}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <Label>Calories</Label>
+          <div className="text-lg font-semibold">{result.calories ?? "—"} kcal</div>
+        </div>
+        <div>
+          <Label>Macros</Label>
+          <div className="text-sm text-muted-foreground">
+            {result.protein ?? "—"}g P • {result.carbs ?? "—"}g C • {result.fat ?? "—"}g F
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {result.grams ? `${result.grams} g` : ""}
+            {result.grams ? ` (${gramsToOunces(result.grams) ?? "?"} oz)` : ""}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="serving-notes">Notes (optional)</Label>
+        <Textarea
+          id="serving-notes"
+          value={notes}
+          onChange={(event) => setNotes(event.target.value)}
+          placeholder="Add preparation notes"
+          rows={2}
+        />
+        <p className="text-xs text-muted-foreground">
+          Database serving: {item.serving.text || `${item.serving.qty ?? "?"} ${item.serving.unit ?? "unit"}`} ·
+          approx {servingWeight ? `${servingWeight} g / ${gramsToOunces(servingWeight) ?? "?"} oz` : "weight unknown"}
+        </p>
+      </div>
+
+      <div className="flex justify-end gap-2">
+        {onCancel && (
+          <Button type="button" variant="ghost" onClick={onCancel} disabled={busy}>
+            Cancel
+          </Button>
+        )}
+        <Button type="button" onClick={submit} disabled={busy || quantity <= 0}>
+          {busy ? "Adding…" : confirmLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/locale.ts
+++ b/src/lib/locale.ts
@@ -1,31 +1,41 @@
-const FALLBACK_COUNTRY = "US";
+const FALLBACK_COUNTRY: DefaultCountry = "US";
 
-const SPECIFIC_LOCALE_MAP: Record<string, string> = {
+const SPECIFIC_LOCALE_MAP: Record<string, DefaultCountry> = {
   "en-us": "US",
   "en-gb": "GB",
-  "en-ca": "CA",
   "en-au": "AU",
+  "en-ca": "CA",
   "fr-fr": "FR",
   "fr-ca": "CA",
-  "es-us": "US",
-  "es-mx": "MX",
-  "es-es": "ES",
   "de-de": "DE",
-  "it-it": "IT",
+  "es-mx": "MX",
+  "es-us": "US",
   "pt-br": "BR",
 };
 
-export function defaultCountryFromLocale(locale?: string | null): string {
+const REGION_MAP: Record<string, DefaultCountry> = {
+  us: "US",
+  ca: "CA",
+  gb: "GB",
+  uk: "GB",
+  au: "AU",
+  fr: "FR",
+  de: "DE",
+  mx: "MX",
+  br: "BR",
+};
+
+export type DefaultCountry = "US" | "GB" | "FR" | "DE" | "MX" | "BR" | "CA" | "AU" | "EU";
+
+export function defaultCountryFromLocale(locale?: string | null): DefaultCountry {
   const raw = (locale || (typeof navigator !== "undefined" ? navigator.language : undefined) || FALLBACK_COUNTRY).toLowerCase();
   if (SPECIFIC_LOCALE_MAP[raw]) {
     return SPECIFIC_LOCALE_MAP[raw];
   }
   const parts = raw.split(/[-_]/);
-  if (parts.length > 1) {
-    return parts[1].toUpperCase();
+  const region = parts[1] || parts[0];
+  if (region && REGION_MAP[region]) {
+    return REGION_MAP[region];
   }
-  if (parts[0].length === 2) {
-    return parts[0].toUpperCase();
-  }
-  return FALLBACK_COUNTRY;
+  return "EU";
 }

--- a/src/lib/nutrition.ts
+++ b/src/lib/nutrition.ts
@@ -4,6 +4,35 @@ import { track } from "./analytics";
 
 const FUNCTIONS_URL = import.meta.env.VITE_FUNCTIONS_URL as string;
 
+export interface MealServingSelection {
+  qty?: number;
+  unit?: string;
+  grams?: number | null;
+  originalQty?: number | null;
+  originalUnit?: string | null;
+}
+
+export interface MealItemSnapshot {
+  id?: string;
+  name: string;
+  brand?: string | null;
+  source?: string;
+  serving?: {
+    qty?: number | null;
+    unit?: string | null;
+    text?: string | null;
+  } | null;
+  per_serving?: {
+    kcal?: number | null;
+    protein_g?: number | null;
+    carbs_g?: number | null;
+    fat_g?: number | null;
+  } | null;
+  per_100g?: MealItemSnapshot["per_serving"] | null;
+  fdcId?: number | null;
+  gtin?: string | null;
+}
+
 export interface MealEntry {
   id?: string;
   name: string;
@@ -13,6 +42,9 @@ export interface MealEntry {
   alcohol?: number;
   calories?: number;
   notes?: string;
+  serving?: MealServingSelection | null;
+  item?: MealItemSnapshot | null;
+  entrySource?: "search" | "barcode" | "manual" | string;
 }
 
 export interface NutritionHistoryDay {

--- a/src/lib/nutritionCollections.ts
+++ b/src/lib/nutritionCollections.ts
@@ -1,0 +1,118 @@
+import {
+  collection,
+  deleteDoc,
+  doc,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+} from "firebase/firestore";
+import { db, auth } from "@/lib/firebase";
+import type { NormalizedItem } from "@/lib/nutritionShim";
+
+export interface FavoriteDoc {
+  name: string;
+  brand?: string;
+  item: NormalizedItem;
+  updatedAt?: any;
+}
+
+export interface TemplateItem {
+  item: NormalizedItem;
+  qty: number;
+  unit: string;
+}
+
+export interface TemplateDoc {
+  name: string;
+  items: TemplateItem[];
+  updatedAt?: any;
+}
+
+function assertUid(): string {
+  const uid = auth.currentUser?.uid;
+  if (!uid) throw new Error("auth");
+  return uid;
+}
+
+export function favoritesQuery(uid?: string) {
+  const userId = uid ?? assertUid();
+  return query(collection(db, `users/${userId}/nutrition/favorites`), orderBy("updatedAt", "desc"));
+}
+
+export function templatesQuery(uid?: string) {
+  const userId = uid ?? assertUid();
+  return query(collection(db, `users/${userId}/nutrition/templates`), orderBy("updatedAt", "desc"));
+}
+
+export function subscribeFavorites(callback: (items: FavoriteDocWithId[]) => void) {
+  const uid = assertUid();
+  return onSnapshot(favoritesQuery(uid), (snap) => {
+    const list: FavoriteDocWithId[] = [];
+    snap.forEach((docSnap) => {
+      const data = docSnap.data() as FavoriteDoc;
+      list.push({ id: docSnap.id, ...data });
+    });
+    callback(list);
+  });
+}
+
+export function subscribeTemplates(callback: (items: TemplateDocWithId[]) => void) {
+  const uid = assertUid();
+  return onSnapshot(templatesQuery(uid), (snap) => {
+    const list: TemplateDocWithId[] = [];
+    snap.forEach((docSnap) => {
+      const data = docSnap.data() as TemplateDoc;
+      list.push({ id: docSnap.id, ...data });
+    });
+    callback(list);
+  });
+}
+
+export async function saveFavorite(item: NormalizedItem) {
+  const uid = assertUid();
+  const ref = doc(db, `users/${uid}/nutrition/favorites/${item.id}`);
+  const payload: FavoriteDoc = {
+    name: item.name,
+    brand: item.brand,
+    item,
+    updatedAt: serverTimestamp(),
+  };
+  await setDoc(ref, payload, { merge: true });
+}
+
+export async function removeFavorite(id: string) {
+  const uid = assertUid();
+  await deleteDoc(doc(db, `users/${uid}/nutrition/favorites/${id}`));
+}
+
+export interface FavoriteDocWithId extends FavoriteDoc {
+  id: string;
+}
+
+export interface TemplateDocWithId extends TemplateDoc {
+  id: string;
+}
+
+export async function saveTemplate(id: string | null, name: string, items: TemplateItem[]) {
+  const uid = assertUid();
+  const templateId =
+    id ??
+    (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `template-${Math.random().toString(36).slice(2, 10)}`);
+  const ref = doc(db, `users/${uid}/nutrition/templates/${templateId}`);
+  const payload: TemplateDoc = {
+    name,
+    items,
+    updatedAt: serverTimestamp(),
+  };
+  await setDoc(ref, payload, { merge: true });
+  return templateId;
+}
+
+export async function deleteTemplate(id: string) {
+  const uid = assertUid();
+  await deleteDoc(doc(db, `users/${uid}/nutrition/templates/${id}`));
+}

--- a/src/lib/nutritionMath.ts
+++ b/src/lib/nutritionMath.ts
@@ -1,0 +1,190 @@
+import type { NormalizedItem } from "@/lib/nutritionShim";
+import type { MealEntry, MealItemSnapshot } from "@/lib/nutrition";
+
+export const SERVING_UNITS = ["serving", "g", "oz", "cups", "slices", "pieces"] as const;
+export type ServingUnit = (typeof SERVING_UNITS)[number];
+
+const GRAMS_PER_OUNCE = 28.3495;
+
+function round(value: number | null | undefined, places = 2) {
+  if (value == null) return null;
+  const factor = 10 ** places;
+  return Math.round(value * factor) / factor;
+}
+
+export function gramsToOunces(grams?: number | null) {
+  if (!grams) return null;
+  return round(grams / GRAMS_PER_OUNCE, 2);
+}
+
+function normalizeUnit(unit: string | null | undefined) {
+  if (!unit) return null;
+  const clean = unit.toLowerCase();
+  if (clean.includes("gram")) return "g";
+  if (clean === "g") return "g";
+  if (clean.includes("ounce") || clean === "oz") return "oz";
+  if (clean.includes("cup")) return "cups";
+  if (clean.includes("slice")) return "slices";
+  if (clean.includes("piece")) return "pieces";
+  if (clean.includes("serv")) return "serving";
+  return clean;
+}
+
+export function estimateServingWeight(item: NormalizedItem): number | null {
+  const servingUnit = normalizeUnit(item.serving?.unit || item.serving?.text || null);
+  const servingQty = typeof item.serving?.qty === "number" ? item.serving.qty : null;
+  if (servingQty && servingUnit === "g") {
+    return servingQty;
+  }
+  if (servingQty && servingUnit === "oz") {
+    return servingQty * GRAMS_PER_OUNCE;
+  }
+  const perServing = item.per_serving;
+  const per100 = item.per_100g;
+  if (!per100) return null;
+  const ratios: number[] = [];
+  if (perServing.protein_g && per100.protein_g) {
+    ratios.push((perServing.protein_g / per100.protein_g) * 100);
+  }
+  if (perServing.carbs_g && per100.carbs_g) {
+    ratios.push((perServing.carbs_g / per100.carbs_g) * 100);
+  }
+  if (perServing.fat_g && per100.fat_g) {
+    ratios.push((perServing.fat_g / per100.fat_g) * 100);
+  }
+  if (perServing.kcal && per100.kcal) {
+    ratios.push((perServing.kcal / per100.kcal) * 100);
+  }
+  if (!ratios.length) return null;
+  const grams = ratios.reduce((sum, value) => sum + value, 0) / ratios.length;
+  return round(grams, 2);
+}
+
+function gramsForSelection(item: NormalizedItem, qty: number, unit: ServingUnit): number | null {
+  switch (unit) {
+    case "g":
+      return qty;
+    case "oz":
+      return qty * GRAMS_PER_OUNCE;
+    case "serving":
+    case "cups":
+    case "slices":
+    case "pieces": {
+      const est = estimateServingWeight(item);
+      return est ? est * qty : null;
+    }
+    default:
+      return null;
+  }
+}
+
+export interface SelectionResult {
+  calories: number | null;
+  protein: number | null;
+  carbs: number | null;
+  fat: number | null;
+  grams: number | null;
+}
+
+export function calculateSelection(
+  item: NormalizedItem,
+  qty: number,
+  unit: ServingUnit,
+): SelectionResult {
+  const grams = gramsForSelection(item, qty, unit);
+  const perServing = item.per_serving;
+  const per100 = item.per_100g;
+  const servingsFactor = unit === "g" || unit === "oz" ? qty : qty;
+
+  if (grams != null && per100) {
+    const factor = grams / 100;
+    return {
+      grams: round(grams, 2),
+      calories: per100.kcal != null ? round(per100.kcal * factor, 0) : null,
+      protein: per100.protein_g != null ? round(per100.protein_g * factor, 2) : null,
+      carbs: per100.carbs_g != null ? round(per100.carbs_g * factor, 2) : null,
+      fat: per100.fat_g != null ? round(per100.fat_g * factor, 2) : null,
+    };
+  }
+
+  return {
+    grams: grams != null ? round(grams, 2) : null,
+    calories: perServing.kcal != null ? round(perServing.kcal * servingsFactor, 0) : null,
+    protein: perServing.protein_g != null ? round(perServing.protein_g * servingsFactor, 2) : null,
+    carbs: perServing.carbs_g != null ? round(perServing.carbs_g * servingsFactor, 2) : null,
+    fat: perServing.fat_g != null ? round(perServing.fat_g * servingsFactor, 2) : null,
+  };
+}
+
+export function snapshotFromItem(item: NormalizedItem): MealItemSnapshot {
+  return {
+    id: item.id,
+    name: item.name,
+    brand: item.brand,
+    source: item.source,
+    serving: {
+      qty: item.serving.qty,
+      unit: item.serving.unit,
+      text: item.serving.text,
+    },
+    per_serving: { ...item.per_serving },
+    per_100g: item.per_100g ? { ...item.per_100g } : null,
+    fdcId: item.fdcId ?? null,
+    gtin: item.gtin ?? null,
+  };
+}
+
+export function normalizedFromSnapshot(snapshot: MealItemSnapshot): NormalizedItem {
+  return {
+    id: snapshot.id || `snapshot-${Math.random().toString(36).slice(2, 8)}`,
+    name: snapshot.name,
+    brand: snapshot.brand || undefined,
+    source: snapshot.source === "OFF" ? "OFF" : "USDA",
+    serving: {
+      qty: snapshot.serving?.qty ?? null,
+      unit: snapshot.serving?.unit ?? null,
+      text: snapshot.serving?.text ?? undefined,
+    },
+    per_serving: {
+      kcal: snapshot.per_serving?.kcal ?? null,
+      protein_g: snapshot.per_serving?.protein_g ?? null,
+      carbs_g: snapshot.per_serving?.carbs_g ?? null,
+      fat_g: snapshot.per_serving?.fat_g ?? null,
+    },
+    per_100g: snapshot.per_100g
+      ? {
+          kcal: snapshot.per_100g.kcal ?? null,
+          protein_g: snapshot.per_100g.protein_g ?? null,
+          carbs_g: snapshot.per_100g.carbs_g ?? null,
+          fat_g: snapshot.per_100g.fat_g ?? null,
+        }
+      : undefined,
+    gtin: snapshot.gtin ?? undefined,
+    fdcId: snapshot.fdcId ?? undefined,
+  };
+}
+
+export function buildMealEntry(
+  item: NormalizedItem,
+  qty: number,
+  unit: ServingUnit,
+  result: SelectionResult,
+  entrySource: MealEntry["entrySource"] = "search",
+): MealEntry {
+  return {
+    name: item.name,
+    protein: result.protein ?? undefined,
+    carbs: result.carbs ?? undefined,
+    fat: result.fat ?? undefined,
+    calories: result.calories ?? undefined,
+    serving: {
+      qty,
+      unit,
+      grams: result.grams,
+      originalQty: item.serving.qty ?? null,
+      originalUnit: item.serving.unit ?? null,
+    },
+    item: snapshotFromItem(item),
+    entrySource,
+  };
+}

--- a/src/pages/MealsSearch.tsx
+++ b/src/pages/MealsSearch.tsx
@@ -1,201 +1,361 @@
-import { FormEvent, useMemo, useState } from "react";
-import { Search, Plus, Barcode } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Search, Plus, Barcode, Loader2, Star, StarOff, ListPlus, Check, Trash } from "lucide-react";
 import { AppHeader } from "@/components/AppHeader";
 import { BottomNav } from "@/components/BottomNav";
 import { Seo } from "@/components/Seo";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { toast } from "@/hooks/use-toast";
-import { searchFoods, type NutritionItem } from "@/lib/nutritionShim";
+import { searchFoods, type NormalizedItem } from "@/lib/nutritionShim";
 import { addMeal } from "@/lib/nutrition";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import {
+  saveFavorite,
+  removeFavorite,
+  subscribeFavorites,
+  type FavoriteDocWithId,
+} from "@/lib/nutritionCollections";
+import { ServingEditor } from "@/components/nutrition/ServingEditor";
+import { type ServingUnit, calculateSelection } from "@/lib/nutritionMath";
 
-const UNITS = ["serving", "g", "oz", "cups", "slices", "pieces"] as const;
+const RECENTS_KEY = "mbs_nutrition_recents_v2";
+const MAX_RECENTS = 50;
 
-function scaleNutrition(item: NutritionItem, quantity: number, unit: typeof UNITS[number]) {
-  const perServing = item.perServing;
-  const per100g = item.per100g;
-  const calc = (base: number | null | undefined, factor: number) =>
-    base == null ? undefined : Number((base * factor).toFixed(2));
+interface QueuedEntry {
+  id: string;
+  item: NormalizedItem;
+  qty: number;
+  unit: ServingUnit;
+  macros: ReturnType<typeof calculateSelection>;
+}
 
-  if (unit === "serving" || unit === "cups" || unit === "slices" || unit === "pieces" || !per100g) {
-    return {
-      calories: calc(perServing.kcal ?? null, quantity),
-      protein: calc(perServing.protein_g ?? null, quantity),
-      carbs: calc(perServing.carbs_g ?? null, quantity),
-      fat: calc(perServing.fat_g ?? null, quantity),
-    };
+function readRecents(): NormalizedItem[] {
+  if (typeof window === "undefined") return [];
+  const raw = window.localStorage.getItem(RECENTS_KEY);
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.slice(0, MAX_RECENTS);
+    }
+  } catch (error) {
+    console.warn("recents_parse_error", error);
   }
-  const grams = unit === "g" ? quantity : unit === "oz" ? quantity * 28.3495 : quantity;
-  const factor = grams / 100;
-  return {
-    calories: calc(per100g?.kcal ?? perServing.kcal ?? null, factor),
-    protein: calc(per100g?.protein_g ?? perServing.protein_g ?? null, factor),
-    carbs: calc(per100g?.carbs_g ?? perServing.carbs_g ?? null, factor),
-    fat: calc(per100g?.fat_g ?? perServing.fat_g ?? null, factor),
-  };
+  return [];
+}
+
+function storeRecents(items: NormalizedItem[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(RECENTS_KEY, JSON.stringify(items.slice(0, MAX_RECENTS)));
 }
 
 export default function MealsSearch() {
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
-  const [results, setResults] = useState<NutritionItem[]>([]);
+  const [results, setResults] = useState<NormalizedItem[]>([]);
   const [dialogOpen, setDialogOpen] = useState(false);
-  const [active, setActive] = useState<NutritionItem | null>(null);
-  const [quantity, setQuantity] = useState(1);
-  const [unit, setUnit] = useState<typeof UNITS[number]>("serving");
-
+  const [dialogItem, setDialogItem] = useState<NormalizedItem | null>(null);
+  const [queued, setQueued] = useState<QueuedEntry[]>([]);
+  const [processing, setProcessing] = useState(false);
+  const [recents, setRecents] = useState<NormalizedItem[]>(() => readRecents());
+  const [favorites, setFavorites] = useState<FavoriteDocWithId[]>([]);
   const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
 
-  const handleSearch = async (event: FormEvent) => {
-    event.preventDefault();
-    if (!query.trim()) {
+  useEffect(() => {
+    try {
+      const unsub = subscribeFavorites(setFavorites);
+      return () => {
+        unsub?.();
+      };
+    } catch (error) {
+      console.warn("favorites_subscribe_error", error);
+      setFavorites([]);
+      return undefined;
+    }
+  }, []);
+
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (!trimmed) {
       setResults([]);
       return;
     }
     setLoading(true);
-    try {
-      const items = await searchFoods(query.trim());
-      setResults(items);
-      if (!items.length) {
-        toast({ title: "No matches", description: "Try another food name." });
-      }
-    } catch (error: any) {
-      toast({ title: "Search failed", description: error?.message || "Please try again", variant: "destructive" });
-    } finally {
-      setLoading(false);
-    }
-  };
+    const handle = window.setTimeout(() => {
+      searchFoods(trimmed)
+        .then(setResults)
+        .catch((error) => {
+          console.error(error);
+          toast({ title: "Search failed", description: "Try another food", variant: "destructive" });
+        })
+        .finally(() => setLoading(false));
+    }, 250);
+    return () => window.clearTimeout(handle);
+  }, [query]);
 
-  const openDialog = (item: NutritionItem) => {
-    setActive(item);
-    setQuantity(1);
-    setUnit("serving");
+  const openDialog = (item: NormalizedItem) => {
+    setDialogItem(item);
     setDialogOpen(true);
   };
 
-  const confirmAdd = async () => {
-    if (!active) return;
-    const macros = scaleNutrition(active, quantity, unit);
+  const updateRecents = useCallback(
+    (item: NormalizedItem) => {
+      const next = [item, ...recents.filter((recent) => recent.id !== item.id)].slice(0, MAX_RECENTS);
+      setRecents(next);
+      storeRecents(next);
+    },
+    [recents],
+  );
+
+  const addToQueue = ({ qty, unit, result }: { qty: number; unit: ServingUnit; result: ReturnType<typeof calculateSelection> }) => {
+    if (!dialogItem) return;
+    const id = `${dialogItem.id}-${Date.now()}`;
+    setQueued((prev) => [...prev, { id, item: dialogItem, qty, unit, macros: result }]);
+    setDialogOpen(false);
+  };
+
+  const clearQueue = () => setQueued([]);
+
+  const logEntries = async (entries: QueuedEntry[]) => {
+    if (!entries.length) return;
+    setProcessing(true);
     try {
-      await addMeal(today, {
-        name: active.name,
-        protein: macros.protein,
-        carbs: macros.carbs,
-        fat: macros.fat,
-        calories: macros.calories,
-      });
-      toast({ title: "Meal logged", description: `${active.name} added` });
-      setDialogOpen(false);
+      for (const entry of entries) {
+        await addMeal(today, {
+          name: entry.item.name,
+          protein: entry.macros.protein ?? undefined,
+          carbs: entry.macros.carbs ?? undefined,
+          fat: entry.macros.fat ?? undefined,
+          calories: entry.macros.calories ?? undefined,
+          serving: {
+            qty: entry.qty,
+            unit: entry.unit,
+            grams: entry.macros.grams,
+            originalQty: entry.item.serving.qty ?? null,
+            originalUnit: entry.item.serving.unit ?? null,
+          },
+          item: {
+            id: entry.item.id,
+            name: entry.item.name,
+            brand: entry.item.brand,
+            source: entry.item.source,
+            serving: entry.item.serving,
+            per_serving: entry.item.per_serving,
+            per_100g: entry.item.per_100g ?? null,
+            fdcId: entry.item.fdcId ?? null,
+            gtin: entry.item.gtin ?? null,
+          },
+          entrySource: "search",
+        });
+        updateRecents(entry.item);
+      }
+      toast({ title: "Foods logged", description: `${entries.length} item(s) added` });
+      setQueued((prev) => prev.filter((entry) => !entries.includes(entry)));
     } catch (error: any) {
-      toast({ title: "Unable to add", description: error?.message || "Try again", variant: "destructive" });
+      toast({ title: "Unable to log", description: error?.message || "Try again", variant: "destructive" });
+    } finally {
+      setProcessing(false);
     }
   };
 
+  const toggleFavorite = async (item: NormalizedItem) => {
+    try {
+      const existing = favorites.find((fav) => fav.id === item.id);
+      if (existing) {
+        await removeFavorite(existing.id);
+        toast({ title: "Removed from favorites", description: item.name });
+      } else {
+        await saveFavorite(item);
+        toast({ title: "Favorited", description: item.name });
+      }
+    } catch (error: any) {
+      toast({ title: "Favorite update failed", description: error?.message || "Try again", variant: "destructive" });
+    }
+  };
+
+  const queuedTotal = queued.reduce((sum, entry) => sum + (entry.macros.calories ?? 0), 0);
+
   return (
-    <div className="min-h-screen bg-background pb-16 md:pb-0">
+    <div className="min-h-screen bg-background pb-20 md:pb-0">
       <Seo title="Food Search" description="Find foods from USDA and OpenFoodFacts" />
       <AppHeader />
-      <main className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+      <main className="mx-auto flex max-w-4xl flex-col gap-6 p-6">
         <div className="space-y-2 text-center">
           <Search className="mx-auto h-10 w-10 text-primary" />
           <h1 className="text-2xl font-semibold text-foreground">Search Foods</h1>
-          <p className="text-sm text-muted-foreground">Tap a result to log with adjustable serving sizes.</p>
+          <p className="text-sm text-muted-foreground">Tap a result to adjust servings. Results use kcal and US units.</p>
         </div>
 
-        <form onSubmit={handleSearch} className="flex gap-2">
+        <form className="flex gap-2" onSubmit={(event) => event.preventDefault()}>
           <Input
             value={query}
             onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search chicken breast, oatmeal, whey..."
+            placeholder="Search chicken breast, oatmeal, whey…"
             className="flex-1"
           />
-          <Button type="submit" disabled={loading}>
-            {loading ? "Searching..." : "Search"}
+          <Button type="button" variant="outline" asChild>
+            <a href="/barcode">
+              <Barcode className="mr-1 h-4 w-4" />
+              Scan
+            </a>
           </Button>
         </form>
+
+        {favorites.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Star className="h-4 w-4 text-yellow-500" /> Favorites
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-2">
+              {favorites.map((fav) => (
+                <Button key={fav.id} variant="secondary" size="sm" onClick={() => openDialog(fav.item)}>
+                  {fav.item.name}
+                </Button>
+              ))}
+            </CardContent>
+          </Card>
+        )}
+
+        {recents.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <HistoryIcon /> Recent
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-wrap gap-2">
+              {recents.slice(0, 8).map((item) => (
+                <Button key={item.id} variant="outline" size="sm" onClick={() => openDialog(item)}>
+                  {item.name}
+                </Button>
+              ))}
+            </CardContent>
+          </Card>
+        )}
 
         <Card>
           <CardHeader className="flex items-center justify-between">
             <CardTitle>Results</CardTitle>
-            <Button variant="outline" size="sm" asChild>
-              <a href="/barcode">
-                <Barcode className="mr-2 h-4 w-4" />
-                Scan Barcode
-              </a>
-            </Button>
+            <div className="text-xs text-muted-foreground">USDA primary · OFF fallback</div>
           </CardHeader>
           <CardContent className="space-y-3">
-            {loading && <p className="text-sm text-muted-foreground">Searching databases…</p>}
-            {!loading && !results.length && <p className="text-sm text-muted-foreground">Enter a food name to begin.</p>}
-            {results.map((item) => (
-              <Card key={item.id} className="border">
-                <CardContent className="flex items-center justify-between gap-4 py-4">
-                  <div className="space-y-1 text-sm">
-                    <p className="font-medium text-foreground">{item.name}</p>
-                    <p className="text-xs uppercase tracking-wide text-muted-foreground">{item.brand || item.source}</p>
-                    <p className="text-xs text-muted-foreground">
-                      {item.perServing.kcal ?? "—"} kcal • {item.perServing.protein_g ?? "—"}g P • {item.perServing.carbs_g ?? "—"}g C • {item.perServing.fat_g ?? "—"}g F
-                    </p>
-                  </div>
-                  <Button size="sm" onClick={() => openDialog(item)}>
-                    <Plus className="mr-1 h-4 w-4" />
-                    Add
-                  </Button>
-                </CardContent>
-              </Card>
-            ))}
+            {loading && (
+              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" /> Searching databases…
+              </div>
+            )}
+            {!loading && !results.length && query.trim().length > 0 && (
+              <p className="text-sm text-muted-foreground">
+                No matches. Try alternate spelling or scan the barcode.
+              </p>
+            )}
+            {!loading && !query.trim() && (
+              <p className="text-sm text-muted-foreground">Enter a food name to begin.</p>
+            )}
+            {results.map((item) => {
+              const favorite = favorites.find((fav) => fav.id === item.id);
+              return (
+                <Card key={item.id} className="border">
+                  <CardContent className="flex flex-col gap-2 py-4 text-sm md:flex-row md:items-center md:justify-between">
+                    <div className="space-y-1">
+                      <p className="font-medium text-foreground">{item.name}</p>
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">{item.brand || item.source}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {item.per_serving.kcal ?? "—"} kcal • {item.per_serving.protein_g ?? "—"}g P • {item.per_serving.carbs_g ?? "—"}g C •
+                        {item.per_serving.fat_g ?? "—"}g F
+                      </p>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <Button size="sm" variant="ghost" onClick={() => toggleFavorite(item)}>
+                        {favorite ? (
+                          <Star className="h-4 w-4 fill-yellow-500 text-yellow-500" />
+                        ) : (
+                          <StarOff className="h-4 w-4" />
+                        )}
+                      </Button>
+                      <Button size="sm" onClick={() => openDialog(item)}>
+                        <Plus className="mr-1 h-4 w-4" /> Add
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              );
+            })}
           </CardContent>
         </Card>
+
+        {queued.length > 0 && (
+          <Card>
+            <CardHeader className="flex items-center justify-between">
+              <CardTitle className="flex items-center gap-2 text-base">
+                <ListPlus className="h-4 w-4" /> Queued ({queued.length})
+              </CardTitle>
+              <div className="flex gap-2">
+                <Button variant="outline" size="sm" onClick={clearQueue} disabled={processing}>
+                  Clear
+                </Button>
+                <Button size="sm" onClick={() => logEntries(queued)} disabled={processing}>
+                  {processing ? "Logging…" : `Log all (${Math.round(queuedTotal)} kcal)`}
+                </Button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              {queued.map((entry) => (
+                <div key={entry.id} className="flex items-center justify-between rounded-md border p-3">
+                  <div>
+                    <p className="font-medium text-foreground">{entry.item.name}</p>
+                    <p className="text-xs text-muted-foreground">
+                      {entry.qty} {entry.unit} • {entry.macros.calories ?? "—"} kcal
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => logEntries([entry])}
+                      disabled={processing}
+                    >
+                      <Check className="mr-1 h-4 w-4" /> Log
+                    </Button>
+                    <Button
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => setQueued((prev) => prev.filter((item) => item.id !== entry.id))}
+                      disabled={processing}
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
       </main>
       <BottomNav />
 
       <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-        <DialogContent>
+        <DialogContent className="max-w-xl">
           <DialogHeader>
-            <DialogTitle>Add {active?.name}</DialogTitle>
+            <DialogTitle>Add {dialogItem?.name}</DialogTitle>
           </DialogHeader>
-          <div className="space-y-4">
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <Label htmlFor="quantity">Quantity</Label>
-                <Input
-                  id="quantity"
-                  type="number"
-                  min="0"
-                  step="0.1"
-                  value={quantity}
-                  onChange={(event) => setQuantity(Number(event.target.value) || 0)}
-                />
-              </div>
-              <div>
-                <Label htmlFor="unit">Unit</Label>
-                <Select value={unit} onValueChange={(value) => setUnit(value as typeof UNITS[number])}>
-                  <SelectTrigger id="unit">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {UNITS.map((option) => (
-                      <SelectItem key={option} value={option}>
-                        {option}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-            </div>
-            <p className="text-xs text-muted-foreground">
-              Nutrients based on database serving. Units other than grams/ounces use database serving equivalents.
-            </p>
-          </div>
-          <DialogFooter>
-            <Button onClick={confirmAdd}>Log Food</Button>
-          </DialogFooter>
+          {dialogItem && <ServingEditor item={dialogItem} onConfirm={addToQueue} />}
         </DialogContent>
       </Dialog>
     </div>
+  );
+}
+
+function HistoryIcon() {
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M3 12a9 9 0 1 1 3.89 7.39" />
+      <polyline points="3 12 6 9 9 12" />
+      <line x1="12" y1="7" x2="12" y2="12" />
+      <line x1="12" y1="12" x2="15" y2="15" />
+    </svg>
   );
 }


### PR DESCRIPTION
## Summary
- implement USDA-first food search with OpenFoodFacts fallback, normalized schema, and in-memory caching for the nutrition search endpoint
- add barcode lookup backed by OpenFoodFacts with USDA fallback, long-lived cache, and share normalization across providers
- extend nutrition logging backend to store serving metadata and item snapshots, and surface new client utilities for favorites, templates, and nutrient math
- revamp meals search, barcode, and today pages with serving editor, recents/favorites/templates support, queue-based multi-add, barcode scanner controls, and updated charts

## Testing
- `npm run lint` *(fails: missing @eslint/js in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cee203592c8325b780fad8089b3973