### PR TITLE
fix: update functions build configuration

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,12 +1,13 @@
 {
   "name": "mybodyscan-functions",
   "private": true,
+  "type": "module",
   "engines": {
     "node": "20"
   },
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc -p tsconfig.json"
+    "build": "tsc -p ."
   },
   "dependencies": {
     "firebase-admin": "^12.6.0",

--- a/functions/src/middleware/cors.ts
+++ b/functions/src/middleware/cors.ts
@@ -1,4 +1,5 @@
-import type { Request, Response } from "express";
+import type { Request } from "firebase-functions/v2/https";
+import type { Response } from "express";
 
 const ALLOWED = new Set([
   "https://mybodyscanapp.com",
@@ -6,8 +7,8 @@ const ALLOWED = new Set([
   "https://mybodyscan-f3daf.firebaseapp.com",
 ]);
 
-export function withCors(handler: (req: Request, res: Response) => unknown) {
-  return (req: Request, res: Response) => {
+export function withCors(handler: (req: Request, res: Response) => Promise<void> | void) {
+  return async (req: Request, res: Response): Promise<void> => {
     const origin = req.headers.origin as string | undefined;
     if (origin && ALLOWED.has(origin)) {
       res.setHeader("Vary", "Origin");
@@ -25,6 +26,6 @@ export function withCors(handler: (req: Request, res: Response) => unknown) {
       return;
     }
 
-    return handler(req, res);
+    await handler(req, res);
   };
 }


### PR DESCRIPTION
## Summary
- add ESM module flag and simplify the TypeScript build script for Cloud Functions
- align the reusable CORS helper with Firebase v2 request typings so rawBody remains available for the Stripe webhook

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68ceea3171a88325931d54de1997b3b7