### PR TITLE
Enable Firebase Functions v2 Stripe webhook

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -31,5 +31,6 @@ export {
 } from "./workouts";
 
 // Payments & credits
-export { createCheckoutSession, createCheckout, createCustomerPortal, stripeWebhook } from "./payments";
+export { createCheckoutSession, createCheckout, createCustomerPortal } from "./payments";
+export { stripeWebhook } from "./stripeWebhook";
 export { useCredit } from "./useCredit";

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -5,11 +5,9 @@ import { getAuth } from "firebase-admin/auth";
 import { softVerifyAppCheck } from "./middleware/appCheck";
 import { withCors } from "./middleware/cors";
 import { requireAuth, verifyAppCheckSoft } from "./http";
-import { grantCredits, refreshCreditsSummary, setSubscriptionStatus } from "./credits";
 
 const APP_BASE_URL = process.env.APP_BASE_URL || "https://mybodyscanapp.com";
 const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
-const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
 
 function buildStripe(): Stripe | null {
   if (!STRIPE_SECRET_KEY) return null;
@@ -97,69 +95,3 @@ export const createCheckout = withHandler(async (req, res) => {
   await handleCheckoutSession(req, res);
 });
 
-export const stripeWebhook = onRequest(async (req, res) => {
-  if (req.method !== "POST") {
-    res.status(405).send("Method Not Allowed");
-    return;
-  }
-  const stripe = buildStripe();
-  if (!stripe || !STRIPE_WEBHOOK_SECRET) {
-    res.status(200).send("mock-ok");
-    return;
-  }
-  const sig = req.headers["stripe-signature"] as string | undefined;
-  if (!sig) {
-    res.status(400).send("missing-signature");
-    return;
-  }
-  let event: Stripe.Event;
-  try {
-    event = stripe.webhooks.constructEvent(req.rawBody, sig, STRIPE_WEBHOOK_SECRET);
-  } catch (err: any) {
-    console.error("stripeWebhook", err?.message);
-    res.status(400).send(`invalid: ${err.message}`);
-    return;
-  }
-  try {
-    switch (event.type) {
-      case "checkout.session.completed": {
-        const session = event.data.object as Stripe.Checkout.Session;
-        const uid = (session.metadata?.uid as string) || null;
-        const priceId = (session.metadata?.priceId as string) || null;
-        if (uid && priceId) {
-          await grantCredits(uid, 1, 365, priceId, "checkout.session.completed");
-          await refreshCreditsSummary(uid);
-        }
-        break;
-      }
-      case "invoice.payment_succeeded": {
-        const invoice = event.data.object as Stripe.Invoice;
-        const uid = (invoice.metadata?.uid as string) || null;
-        if (uid) {
-          await setSubscriptionStatus(
-            uid,
-            "active",
-            (invoice.lines.data[0]?.price?.id as string) || null,
-            invoice.lines.data[0]?.period?.end || null
-          );
-        }
-        break;
-      }
-      case "customer.subscription.deleted": {
-        const subscription = event.data.object as Stripe.Subscription;
-        const uid = (subscription.metadata?.uid as string) || null;
-        if (uid) {
-          await setSubscriptionStatus(uid, "canceled", null, null);
-        }
-        break;
-      }
-      default:
-        // ignore unsupported events
-        break;
-    }
-    res.status(200).send("ok");
-  } catch (err: any) {
-    console.error("stripeWebhook handler", err?.message);
-    res.status(500).send("error");
-  }
-});

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -1,0 +1,83 @@
+import { onRequest } from "firebase-functions/v2/https";
+import Stripe from "stripe";
+
+import { grantCredits, refreshCreditsSummary, setSubscriptionStatus } from "./credits";
+
+const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
+
+function buildStripe(): Stripe | null {
+  if (!STRIPE_SECRET_KEY) return null;
+  return new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" });
+}
+
+export const stripeWebhook = onRequest(async (req, res) => {
+  if (req.method !== "POST") {
+    res.status(405).send("Method Not Allowed");
+    return;
+  }
+
+  const stripe = buildStripe();
+  if (!stripe || !STRIPE_WEBHOOK_SECRET) {
+    res.status(200).send("mock-ok");
+    return;
+  }
+
+  const signature = req.headers["stripe-signature"];
+  if (typeof signature !== "string") {
+    res.status(400).send("missing-signature");
+    return;
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(req.rawBody, signature, STRIPE_WEBHOOK_SECRET);
+  } catch (err: any) {
+    console.error("stripeWebhook", err?.message);
+    res.status(400).send(`invalid: ${err.message}`);
+    return;
+  }
+
+  try {
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const uid = (session.metadata?.uid as string) || null;
+        const priceId = (session.metadata?.priceId as string) || null;
+        if (uid && priceId) {
+          await grantCredits(uid, 1, 365, priceId, "checkout.session.completed");
+          await refreshCreditsSummary(uid);
+        }
+        break;
+      }
+      case "invoice.payment_succeeded": {
+        const invoice = event.data.object as Stripe.Invoice;
+        const uid = (invoice.metadata?.uid as string) || null;
+        if (uid) {
+          await setSubscriptionStatus(
+            uid,
+            "active",
+            (invoice.lines.data[0]?.price?.id as string) || null,
+            invoice.lines.data[0]?.period?.end || null
+          );
+        }
+        break;
+      }
+      case "customer.subscription.deleted": {
+        const subscription = event.data.object as Stripe.Subscription;
+        const uid = (subscription.metadata?.uid as string) || null;
+        if (uid) {
+          await setSubscriptionStatus(uid, "canceled", null, null);
+        }
+        break;
+      }
+      default:
+        // ignore unsupported events
+        break;
+    }
+    res.status(200).send("ok");
+  } catch (err: any) {
+    console.error("stripeWebhook handler", err?.message);
+    res.status(500).send("error");
+  }
+});


### PR DESCRIPTION
## Summary
- add a dedicated Stripe webhook module that uses the Firebase Functions v2 onRequest API with raw body signature verification
- update the functions index exports now that the webhook lives in its own module

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68ceee3a36208325801bf10b0756b525