### PR TITLE
Fix stripe webhook export path

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -32,5 +32,5 @@ export {
 
 // Payments & credits
 export { createCheckoutSession, createCheckout, createCustomerPortal } from "./payments";
-export { stripeWebhook } from "./stripeWebhook";
+export { stripeWebhook } from "./stripeWebhook.js";
 export { useCredit } from "./useCredit";


### PR DESCRIPTION
## Summary
- ensure the Cloud Functions index re-exports the Stripe webhook using the `.js` path required for Firebase v2 deployment

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68cef06fefac8325a4246ae60a6d9fa2