### PR TITLE
Use Functions v2 configuration for Stripe webhook

### DIFF
--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -11,7 +11,7 @@ function buildStripe(): Stripe | null {
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" });
 }
 
-export const stripeWebhook = onRequest(async (req, res) => {
+export const stripeWebhook = onRequest({ region: "us-central1" }, async (req, res) => {
   if (req.method !== "POST") {
     res.status(405).send("Method Not Allowed");
     return;


### PR DESCRIPTION
## Summary
- configure the Stripe webhook export with an explicit Functions v2 region option while continuing to verify signatures from `req.rawBody`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cefb9118208325815de1a3656e96b5