### PR TITLE
Fix stripe webhook raw body typing

### DIFF
--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -1,4 +1,5 @@
 import { onRequest } from 'firebase-functions/v2/https';
+import type { Request } from 'firebase-functions/v2/https';
 import Stripe from 'stripe';
 
 import { grantCredits, refreshCreditsSummary, setSubscriptionStatus } from "./credits.js";
@@ -29,9 +30,10 @@ export const stripeWebhook = onRequest({ region: "us-central1" }, async (req, re
     return;
   }
 
+  const rawBody = (req as Request & { rawBody: Buffer }).rawBody;
   let event: Stripe.Event;
   try {
-    event = stripe.webhooks.constructEvent(req.rawBody, signature, STRIPE_WEBHOOK_SECRET);
+    event = stripe.webhooks.constructEvent(rawBody, signature, STRIPE_WEBHOOK_SECRET);
   } catch (err: any) {
     console.error("stripeWebhook", err?.message);
     res.status(400).send(`invalid: ${err.message}`);


### PR DESCRIPTION
## Summary
- import the HTTPS Request type and narrow the webhook request to access the raw body buffer
- keep the webhook options limited to supported HTTPS configuration

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68cf1d4620d083258198912677cb42d6