### PR TITLE
Configure Stripe function secrets

### DIFF
--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -68,6 +68,7 @@ async function handleCustomerPortal(req: Request, res: any) {
 
 function withHandler(handler: (req: Request, res: any) => Promise<void>) {
   return onRequest(
+    { region: "us-central1", secrets: ["STRIPE_SECRET_KEY"] },
     withCors(async (req, res) => {
       try {
         await softVerifyAppCheck(req as any, res as any);

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -12,7 +12,10 @@ function buildStripe(): Stripe | null {
   return new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" });
 }
 
-export const stripeWebhook = onRequest({ region: "us-central1" }, async (req, res) => {
+export const stripeWebhook = onRequest({
+  region: "us-central1",
+  secrets: ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
+}, async (req, res) => {
   if (req.method !== "POST") {
     res.status(405).send("Method Not Allowed");
     return;


### PR DESCRIPTION
## Summary
- ensure the Stripe webhook function registers required secrets alongside its region configuration
- update payments HTTP handlers to request the Stripe secret key so buildStripe can access it at runtime

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68cf239cdfe4832595c6e7e88b9cc870