### PR TITLE
Fix onboarding completion and surface scan metrics

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "mybodyscan-f3daf"
+  }
+}

--- a/src/hooks/useNeedsOnboardingMBS.ts
+++ b/src/hooks/useNeedsOnboardingMBS.ts
@@ -11,8 +11,8 @@ export function useNeedsOnboardingMBS() {
     const unsub = onAuthStateChanged(auth, async (u) => {
       if (!u) { setNeeds(false); setLoading(false); return; }
       try {
-        const snap = await getDoc(doc(db, 'users', u.uid, 'onboarding'));
-        const done = snap.exists() && snap.data()?.completedOnboarding === true;
+        const snap = await getDoc(doc(db, 'users', u.uid));
+        const done = snap.exists() && snap.data()?.onboarding?.complete === true;
         setNeeds(!done);
       } catch { setNeeds(false); }
       setLoading(false);

--- a/src/lib/scans.ts
+++ b/src/lib/scans.ts
@@ -1,0 +1,94 @@
+import { kgToLb } from "@/lib/units";
+
+export interface NormalizedScanMetrics {
+  bodyFatPercent: number | null;
+  bmi: number | null;
+  weightKg: number | null;
+  weightLb: number | null;
+  method: string | null;
+  confidence: number | null;
+}
+
+function firstNumber(...candidates: unknown[]): number | null {
+  for (const value of candidates) {
+    if (typeof value === "number" && Number.isFinite(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+export function extractScanMetrics(scan: any): NormalizedScanMetrics {
+  const metrics = scan?.metrics ?? {};
+  const result = scan?.result ?? {};
+  const results = scan?.results ?? result;
+  const measurements = scan?.measurements ?? {};
+  const fallback = scan ?? {};
+
+  const bodyFatPercent = firstNumber(
+    metrics.bf_percent,
+    metrics.bodyFatPct,
+    metrics.body_fat,
+    results.bf_percent,
+    results.bodyFatPct,
+    fallback.bodyFatPercentage,
+    fallback.body_fat,
+    fallback.bodyfat,
+    measurements.bodyFatPct
+  );
+
+  const bmi = firstNumber(
+    metrics.bmi,
+    results.bmi,
+    fallback.bmi,
+    measurements.bmi
+  );
+
+  const weightKg = firstNumber(
+    metrics.weight_kg,
+    metrics.weightKg,
+    results.weight_kg,
+    results.weightKg,
+    fallback.weightKg,
+    fallback.weight_kg,
+    measurements.weightKg,
+    measurements.weight_kg
+  );
+
+  const weightLbDirect = firstNumber(
+    metrics.weight_lb,
+    metrics.weightLb,
+    results.weight_lb,
+    results.weightLb,
+    fallback.weight_lbs,
+    fallback.weightLb,
+    fallback.weight,
+    measurements.weightLb,
+    measurements.weight_lbs
+  );
+
+  const weightLb = weightLbDirect ?? (weightKg != null ? kgToLb(weightKg) : null);
+
+  const method = typeof metrics.method === "string"
+    ? metrics.method
+    : typeof fallback.method === "string"
+      ? fallback.method
+      : typeof results.method === "string"
+        ? results.method
+        : null;
+
+  const confidence = firstNumber(
+    metrics.confidence,
+    fallback.confidence,
+    results.confidence
+  );
+
+  return {
+    bodyFatPercent,
+    bmi,
+    weightKg,
+    weightLb,
+    method,
+    confidence,
+  };
+}

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { Checkbox } from "@/components/ui/checkbox";
 import { AppHeader } from "@/components/AppHeader";
 import { Section } from "@/components/ui/section";
-import { doc, setDoc } from "firebase/firestore";
+import { doc, serverTimestamp, setDoc } from "firebase/firestore";
 import { getAuth } from "firebase/auth";
 import { db } from "@/lib/firebase";
 import { toast } from "@/hooks/use-toast";
@@ -27,7 +27,17 @@ export default function Onboarding() {
     const uid = getAuth().currentUser?.uid;
     if (!uid) return;
     try {
-      await setDoc(doc(db, `users/${uid}/onboarding`), { ...form, completedOnboarding: true }, { merge: true });
+      await setDoc(
+        doc(db, "users", uid),
+        {
+          onboarding: {
+            ...form,
+            complete: true,
+            completedAt: serverTimestamp()
+          }
+        },
+        { merge: true }
+      );
       toast({ title: "Profile complete!", description: "Welcome to MyBodyScan" });
       navigate("/today");
     } catch (err: any) {


### PR DESCRIPTION
## Summary
- write onboarding completion to the root user document with timestamps and read that flag in the onboarding gate
- add a scan metrics adapter that prefers the new metrics payload and update Home, Results, History, and ScanResult to use it
- harden the report page to redirect when scan IDs are missing or invalid and add Firebase CLI defaults for deploys

## Testing
- npm run lint *(fails: missing @eslint/js because dependencies could not be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cf38c13e248325aa25c87a5fa57f7c