### PR TITLE
Restore useCredit callable handler

### DIFF
--- a/functions/src/useCredit.ts
+++ b/functions/src/useCredit.ts
@@ -1,39 +1,36 @@
-import { HttpsError, onRequest } from "firebase-functions/v2/https";
-import type { Request } from "firebase-functions/v2/https";
-import { requireAuth, verifyAppCheckSoft } from "./http.js";
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+import type { CallableRequest, Request } from "firebase-functions/v2/https";
+import { verifyAppCheckSoft } from "./http.js";
 import { softVerifyAppCheck } from "./middleware/appCheck.js";
-import { withCors } from "./middleware/cors.js";
 import { consumeCredit, refreshCreditsSummary } from "./credits.js";
 import { getFirestore } from "./firebase.js";
 
 const db = getFirestore();
 
-async function handler(req: Request, res: any) {
-  await softVerifyAppCheck(req as any, res as any);
-  await verifyAppCheckSoft(req);
-  const uid = await requireAuth(req);
+async function consumeUserCredit(uid: string) {
   const ok = await consumeCredit(uid);
   if (!ok) {
-    res.status(402).json({ error: "no_credits" });
-    return;
+    throw new HttpsError("resource-exhausted", "no_credits");
   }
   await refreshCreditsSummary(uid);
   const snap = await db.doc(`users/${uid}/private/credits`).get();
   const remaining = (snap.data()?.creditsSummary?.totalAvailable as number | undefined) || 0;
-  res.json({ ok: true, remaining });
+  return { ok: true as const, remaining };
 }
 
-export const useCredit = onRequest(
-  withCors(async (req, res) => {
-    try {
-      await handler(req, res);
-    } catch (err: any) {
-      if (err instanceof HttpsError) {
-        const status = err.code === "unauthenticated" ? 401 : 400;
-        res.status(status).json({ error: err.message });
-        return;
-      }
-      res.status(500).json({ error: err?.message || "error" });
+export const useCredit = onCall(
+  async (request: CallableRequest<unknown>) => {
+    const rawRequest = request.rawRequest as Request | undefined;
+    if (rawRequest) {
+      await softVerifyAppCheck(rawRequest as any, {} as any);
+      await verifyAppCheckSoft(rawRequest);
     }
-  })
+
+    const uid = request.auth?.uid;
+    if (!uid) {
+      throw new HttpsError("unauthenticated", "Authentication required");
+    }
+
+    return consumeUserCredit(uid);
+  }
 );


### PR DESCRIPTION
## Summary
- revert the useCredit Cloud Function to a callable handler while preserving App Check soft verification

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68cf48e9d9f08325a84e23e027414ac7