### PR TITLE
Fix: restore callable triggers (useCredit/runBodyScan/startScan/createCheckoutSession) + secrets

### DIFF
--- a/functions/src/scan.ts
+++ b/functions/src/scan.ts
@@ -194,7 +194,7 @@ async function handleStartRequest(req: Request, res: any) {
   respond(res, session);
 }
 
-export const startScan = onCall({ region: "us-central1", secrets: ["STRIPE_SECRET_KEY"] }, async (request) => {
+export const startScan = onCall({ region: "us-central1" }, async (request) => {
   if (!request.auth?.uid) {
     throw new HttpsError("unauthenticated", "Login required");
   }
@@ -203,7 +203,7 @@ export const startScan = onCall({ region: "us-central1", secrets: ["STRIPE_SECRE
   return { scanId: session.scanId, uploadPathPrefix: session.uploadPathPrefix };
 });
 
-export const runBodyScan = onCall({ region: "us-central1", secrets: ["STRIPE_SECRET_KEY"] }, async (request) => {
+export const runBodyScan = onCall({ region: "us-central1" }, async (request) => {
   if (!request.auth?.uid) {
     throw new HttpsError("unauthenticated", "Login required");
   }

--- a/src/lib/scan.ts
+++ b/src/lib/scan.ts
@@ -1,4 +1,5 @@
-import { auth, db, storage } from "./firebase";
+import { httpsCallable } from "firebase/functions";
+import { auth, db, storage, functions } from "./firebase";
 import { collection, onSnapshot, orderBy, query } from "firebase/firestore";
 import { isDemoGuest } from "./demoFlag";
 import { ref, uploadBytes } from "firebase/storage";
@@ -26,7 +27,9 @@ export async function startScan() {
       status: "queued",
     };
   }
-  return callFn("/startScanSession", {});
+  const startScanFn = httpsCallable(functions, "startScan");
+  const { data } = await startScanFn();
+  return data as { scanId: string; uploadPathPrefix: string; status?: string };
 }
 
 export async function uploadScanPhotos(scan: { uploadPathPrefix: string }, files: File[]) {
@@ -53,7 +56,9 @@ export async function runBodyScan(file: string) {
       result: { bodyFatPct: 18.7, weightKg: 78.1, bmi: 24.6, mock: true },
     };
   }
-  return callFn("/runBodyScan", { file });
+  const runBodyScanFn = httpsCallable(functions, "runBodyScan");
+  const { data } = await runBodyScanFn({ file });
+  return data as { scanId: string; uploadPathPrefix?: string; status?: string };
 }
 
 export async function uploadScanFile(uid: string, scanId: string, file: File) {


### PR DESCRIPTION
## Summary
- drop unnecessary Stripe secret configuration from the callable scan triggers to match production
- switch the web scan helpers back to Firebase callable clients for startScan and runBodyScan

## Testing
- `npm run lint` *(fails: missing @eslint/js because dependencies could not be installed in this environment)*
- `` `grep -R "onCall(" functions/src | sort` ``
- `` `grep -R "onRequest(" functions/src | sort` ``
- `` `grep -R "rawBody:" functions/src` ``
- `` `grep -R "secrets:" functions/src | sort` ``


------
https://chatgpt.com/codex/tasks/task_e_68cf5847f4288325aeaab588a23226b6