### PR TITLE
Enable marketing page flag and harden HTML caching

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -10,4 +10,4 @@ VITE_FUNCTIONS_URL=https://us-central1-mybodyscan-f3daf.cloudfunctions.net
 # Optional App Check site key
 VITE_APPCHECK_SITE_KEY=
 # Feature flags
-VITE_ENABLE_PUBLIC_MARKETING_PAGE=false
+VITE_ENABLE_PUBLIC_MARKETING_PAGE=true

--- a/firebase.json
+++ b/firebase.json
@@ -16,7 +16,15 @@
         "headers": [
           {
             "key": "Cache-Control",
+            "value": "no-store, no-cache, must-revalidate"
+          },
+          {
+            "key": "Pragma",
             "value": "no-cache"
+          },
+          {
+            "key": "Expires",
+            "value": "0"
           }
         ]
       },
@@ -25,7 +33,15 @@
         "headers": [
           {
             "key": "Cache-Control",
+            "value": "no-store, no-cache, must-revalidate"
+          },
+          {
+            "key": "Pragma",
             "value": "no-cache"
+          },
+          {
+            "key": "Expires",
+            "value": "0"
           }
         ]
       },


### PR DESCRIPTION
## Summary
- enable the public marketing page feature flag in the production env file
- strengthen Firebase Hosting HTML caching headers to disable storage of stale markup

## Testing
- npm run build *(fails: local npm cannot download dependencies because the corporate proxy at http://proxy:8080 responds 403 to registry.npmjs.org)*
- npx -y firebase-tools@latest deploy --only hosting --project mybodyscan-f3daf *(fails: npm cannot download firebase-tools for the same 403 proxy block)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b988dcc483258dcdba6b1bd8d560