### PR TITLE
Add fallback Firebase config for Lovable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ Create a `.env.local` for development based on `.env.example` and a `.env.produc
 
 Cloud Functions read Stripe credentials from secrets named `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`. Configure them with `firebase functions:secrets:set` (see Deployment).
 
+## Firebase Web config (Lovable without env vars)
+We first try Vite env vars (VITE_FIREBASE_*). If they are absent (e.g., Lovable has no Environment panel), we fall back to `src/config/firebase.public.ts` which contains your **public** Web config.
+
+Authorized domains (Firebase Console → Auth → Settings):
+- localhost
+- 127.0.0.1
+- mybodyscan-f3daf.web.app
+- mybodyscan-f3daf.firebaseapp.com
+- your Lovable preview domain (copy from the preview URL)
+- your custom domain(s)
+
+Notes:
+- The Storage bucket must be `mybodyscan-f3daf.appspot.com` (the canonical bucket), not `...firebasestorage.app` which is a download host.
+
 ## Testing rules
 
 Run Firestore security rules tests using the emulator suite:

--- a/src/config/firebase.public.ts
+++ b/src/config/firebase.public.ts
@@ -1,0 +1,17 @@
+const API_KEY = "AIzaSyDA90cwKTCQ9tGfUx66PDmfGwUoiTbhafE";
+const AUTH_DOMAIN = "mybodyscan-f3daf.firebaseapp.com";
+const PROJECT_ID = "mybodyscan-f3daf";
+const STORAGE_BUCKET = "mybodyscan-f3daf.appspot.com";
+const MESSAGING_SENDER_ID = "157018993008";
+const APP_ID = "1:157018993008:web:8bed67e098ca04dc4b1fb5";
+const MEASUREMENT_ID = "G-TV8M3PY1X3";
+
+export const FIREBASE_PUBLIC_CONFIG = {
+  apiKey: API_KEY,
+  authDomain: AUTH_DOMAIN,
+  projectId: PROJECT_ID,
+  storageBucket: STORAGE_BUCKET,
+  messagingSenderId: MESSAGING_SENDER_ID,
+  appId: APP_ID,
+  ...(MEASUREMENT_ID ? { measurementId: MEASUREMENT_ID } : {}),
+} as const;

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,30 +3,43 @@ import { getAuth } from "firebase/auth";
 import { getFirestore } from "firebase/firestore";
 import { getStorage } from "firebase/storage";
 import { getFunctions } from "firebase/functions";
+import { FIREBASE_PUBLIC_CONFIG } from "@/config/firebase.public";
 
-function requiredEnv(name: string): string {
-  const val = (import.meta as any).env?.[name];
-  if (!val || String(val).trim() === "") {
-    throw new Error(
-      `Missing Firebase env configuration: ${name}. ` +
-      `Add VITE_FIREBASE_* keys to your environment (see .env.example).`
-    );
-  }
-  return val;
+/**
+ * Prefer Vite env vars when present; otherwise fall back to committed public config.
+ * This allows Lovable preview to run without an Environment UI.
+ */
+function env(name: string): string | undefined {
+  return (import.meta as any)?.env?.[name];
 }
 
-export const firebaseConfig: FirebaseOptions = {
-  apiKey: requiredEnv("VITE_FIREBASE_API_KEY"),
-  authDomain: requiredEnv("VITE_FIREBASE_AUTH_DOMAIN"),
-  projectId: requiredEnv("VITE_FIREBASE_PROJECT_ID"),
-  storageBucket: requiredEnv("VITE_FIREBASE_STORAGE_BUCKET"),
-  messagingSenderId: requiredEnv("VITE_FIREBASE_MESSAGING_SENDER_ID"),
-  appId: requiredEnv("VITE_FIREBASE_APP_ID"),
-  // measurementId is optional
-  ...((import.meta as any).env?.VITE_FIREBASE_MEASUREMENT_ID
-      ? { measurementId: (import.meta as any).env.VITE_FIREBASE_MEASUREMENT_ID }
-      : {}),
-};
+function mergedConfig(): FirebaseOptions {
+  const envConfig = {
+    apiKey: env("VITE_FIREBASE_API_KEY"),
+    authDomain: env("VITE_FIREBASE_AUTH_DOMAIN"),
+    projectId: env("VITE_FIREBASE_PROJECT_ID"),
+    storageBucket: env("VITE_FIREBASE_STORAGE_BUCKET"),
+    messagingSenderId: env("VITE_FIREBASE_MESSAGING_SENDER_ID"),
+    appId: env("VITE_FIREBASE_APP_ID"),
+    measurementId: env("VITE_FIREBASE_MEASUREMENT_ID"),
+  };
+
+  // If apiKey (required) is missing, use the committed public config.
+  if (!envConfig.apiKey) return FIREBASE_PUBLIC_CONFIG;
+
+  const cfg: FirebaseOptions = {
+    apiKey: envConfig.apiKey!,
+    authDomain: envConfig.authDomain!,
+    projectId: envConfig.projectId!,
+    storageBucket: envConfig.storageBucket!,
+    messagingSenderId: envConfig.messagingSenderId!,
+    appId: envConfig.appId!,
+  };
+  if (envConfig.measurementId) cfg.measurementId = envConfig.measurementId;
+  return cfg;
+}
+
+export const firebaseConfig = mergedConfig();
 
 export const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);


### PR DESCRIPTION
## Summary
- add committed Firebase public config for Lovable preview environments
- update firebase initialization to prefer env vars but fall back to the committed config while keeping existing exports
- document the fallback behavior and required authorized domains in the README

## Testing
- `npm run build` *(fails: vite not found because dependencies are unavailable prior to npm install)*
- `npm install` *(fails: npm registry returns 403 for @opentelemetry/semantic-conventions)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e8aa9adc8325a5f97c0bfcb63009