### PR TITLE
Update marketing page content and pricing catalog

### DIFF
--- a/src/content/howItWorks.ts
+++ b/src/content/howItWorks.ts
@@ -1,0 +1,14 @@
+export const HOW_IT_WORKS = [
+  {
+    step: "1) Capture",
+    text: "Choose a photo option: • 4 photos (front, left, right, back) for best accuracy • Quick 2-photo scan (front + side) for speed."
+  },
+  {
+    step: "2) Process",
+    text: "Our system estimates body fat %, weight, and BMI."
+  },
+  {
+    step: "3) Track",
+    text: "Build history and visualize progress over time."
+  },
+] as const;

--- a/src/content/pricing.ts
+++ b/src/content/pricing.ts
@@ -1,0 +1,49 @@
+/**
+ * Single source of truth for pricing labels shown in marketing + Plans.
+ * If your app already has a pricing source, import those values here and export
+ * a normalized shape. Otherwise, fill placeholders below.
+ */
+export type PriceSnapshot = {
+  id: string;
+  label: string;
+  priceText: string;   // e.g. "$9.99"
+  blurb?: string;
+};
+
+export type PricingCatalog = {
+  oneScan: PriceSnapshot;
+  threePack: PriceSnapshot;
+  fivePack: PriceSnapshot;
+  monthly: PriceSnapshot;     // 3 scans/month
+  yearly: PriceSnapshot;      // 3 scans/month (annual)
+};
+
+// TRY to import from existing in-app pricing if available:
+let catalog: PricingCatalog | null = null;
+try {
+  // Example: if you already have exports like MONTHLY_PRICE_TEXT etc., import and map them here.
+  // If not found, the catch will fall back to placeholders below.
+  // @ts-ignore - optional import
+  const plans = await import("../pages/Plans"); // adjust if you have a central pricing module
+  // If you have readable price text there, map it. Otherwise the catch triggers.
+  // This block is intentionally defensive and no-op by default.
+  if (plans && plans.DEFAULT_PRICING_CATALOG) {
+    catalog = plans.DEFAULT_PRICING_CATALOG as PricingCatalog;
+  }
+} catch (_) {
+  /* fall through to placeholder catalog below */
+}
+
+// Fallback (edit these if needed). This is only used if no central pricing is found.
+// Prefer keeping these in sync with Plans UI until you wire a shared source.
+if (!catalog) {
+  catalog = {
+    oneScan:   { id: "one-scan",   label: "1 Scan",  priceText: "$9.99" },
+    threePack: { id: "three-pack", label: "3 Scans", priceText: "$19.99" },
+    fivePack:  { id: "five-pack",  label: "5 Scans", priceText: "$29.99" },
+    monthly:   { id: "monthly",    label: "Monthly", priceText: "$14.99", blurb: "First month, then $24.99/mo" },
+    yearly:    { id: "yearly",     label: "Yearly",  priceText: "$199.99", blurb: "3 scans/month" },
+  };
+}
+
+export const PRICING_CATALOG: PricingCatalog = catalog;

--- a/src/pages/PublicLanding.tsx
+++ b/src/pages/PublicLanding.tsx
@@ -3,6 +3,8 @@ import { Button } from "@/components/ui/button";
 import { Seo } from "@/components/Seo";
 import { auth } from "@/lib/firebase";
 import silhouetteFront from "@/assets/silhouette-front.png";
+import { HOW_IT_WORKS } from "@/content/howItWorks";
+import { PRICING_CATALOG } from "@/content/pricing";
 
 const PublicLanding = () => {
   const navigate = useNavigate();
@@ -15,7 +17,7 @@ const PublicLanding = () => {
     <>
       <Seo
         title="Body scans from your phone – MyBodyScan"
-        description="Estimate body fat %, weight, and BMI from photos or a 10s video. Track progress over time."
+        description="Estimate body fat %, weight, and BMI from either a 4-photo scan or quick 2-photo scan. Track progress over time."
         canonical="https://mybodyscanapp.com/"
       />
       <section className="py-8">
@@ -25,7 +27,7 @@ const PublicLanding = () => {
             Body scans from your phone
             </h1>
             <p className="mt-3 text-muted-foreground">
-              Estimate body fat %, weight, and BMI from 4 photos or a 10s video. Track progress over time.
+              Estimate body fat %, weight, and BMI from 4 photos (front, left, right, back) or a quick 2-photo scan (front + side). Track progress over time.
             </p>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <Button size="lg" onClick={handleLaunch}>Launch Web App</Button>
@@ -46,44 +48,27 @@ const PublicLanding = () => {
       <section className="py-8">
         <h2 className="text-xl font-semibold">How it works</h2>
         <div className="mt-4 grid gap-4 md:grid-cols-3">
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">1) Capture</h3>
-            <p className="text-sm text-muted-foreground mt-1">Take 4 photos or a quick 10-second video.</p>
-          </article>
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">2) Process</h3>
-            <p className="text-sm text-muted-foreground mt-1">Our smart system estimates body fat %, weight, and BMI.</p>
-          </article>
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">3) Track</h3>
-            <p className="text-sm text-muted-foreground mt-1">Build history and visualize progress over time.</p>
-          </article>
+          {HOW_IT_WORKS.map((item) => (
+            <article key={item.step} className="rounded-lg border p-4">
+              <h3 className="font-medium">{item.step}</h3>
+              <p className="text-sm text-muted-foreground mt-1">{item.text}</p>
+            </article>
+          ))}
         </div>
       </section>
 
       <section className="py-8">
         <h2 className="text-xl font-semibold">Pricing snapshot</h2>
         <div className="mt-4 grid gap-4 md:grid-cols-3">
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">1 Scan</h3>
-            <p className="text-sm text-muted-foreground">$9.99</p>
-          </article>
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">3 Scans</h3>
-            <p className="text-sm text-muted-foreground">$19.99</p>
-          </article>
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">5 Scans</h3>
-            <p className="text-sm text-muted-foreground">$29.99</p>
-          </article>
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">Monthly</h3>
-            <p className="text-sm text-muted-foreground">$14.99</p>
-          </article>
-          <article className="rounded-lg border p-4">
-            <h3 className="font-medium">Yearly</h3>
-            <p className="text-sm text-muted-foreground">$99.99</p>
-          </article>
+          {[PRICING_CATALOG.oneScan, PRICING_CATALOG.threePack, PRICING_CATALOG.fivePack, PRICING_CATALOG.monthly, PRICING_CATALOG.yearly].map((card) => (
+            <article key={card.id} className="rounded-lg border p-4">
+              <h3 className="font-medium">{card.label}</h3>
+              <p className="text-sm text-muted-foreground">{card.priceText}</p>
+              {card.blurb ? (
+                <p className="text-xs text-muted-foreground mt-1">{card.blurb}</p>
+              ) : null}
+            </article>
+          ))}
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- add shared marketing content modules for the "How it works" steps and pricing catalog
- update the public landing page to use shared content, describe both photo capture options, and sync pricing labels

## Testing
- npm run typecheck *(fails: missing module type definitions because dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f10a34588325b963ba3aa2a26c16