### PR TITLE
Remove scan pack pricing from marketing and plans

### DIFF
--- a/src/content/pricing.ts
+++ b/src/content/pricing.ts
@@ -41,9 +41,27 @@ if (!catalog) {
     oneScan:   { id: "one-scan",   label: "1 Scan",  priceText: "$9.99" },
     threePack: { id: "three-pack", label: "3 Scans", priceText: "$19.99" },
     fivePack:  { id: "five-pack",  label: "5 Scans", priceText: "$29.99" },
-    monthly:   { id: "monthly",    label: "Monthly", priceText: "$14.99", blurb: "First month, then $24.99/mo" },
+    monthly:   {
+      id: "monthly",
+      label: "Monthly",
+      priceText: "$14.99",
+      blurb: "First month, then $24.99/mo · 3 scans/month",
+    },
     yearly:    { id: "yearly",     label: "Yearly",  priceText: "$199.99", blurb: "3 scans/month" },
   };
 }
 
-export const PRICING_CATALOG: PricingCatalog = catalog;
+const baseCatalog = catalog as PricingCatalog;
+
+export const PRICING_CATALOG = {
+  oneScan: baseCatalog.oneScan,
+  monthly: baseCatalog.monthly,
+  yearly: baseCatalog.yearly,
+} as const;
+
+const UNUSED_SCAN_PACKS = {
+  threePack: baseCatalog.threePack,
+  fivePack: baseCatalog.fivePack,
+};
+
+void UNUSED_SCAN_PACKS;

--- a/src/pages/Plans.tsx
+++ b/src/pages/Plans.tsx
@@ -34,27 +34,18 @@ export default function Plans() {
     }
   };
 
-  const plans = [
+  const ENABLE_SCAN_PACKS = false;
+
+  const corePlans = [
     {
-      name: "Single Scan",
+      name: "One Scan",
       price: "$9.99",
       period: "one-time",
       credits: "1 scan credit",
       priceId: "price_single_scan",
       mode: "payment" as const,
       features: ["1 body composition scan", "Detailed analysis", "Progress tracking"],
-      description: "Perfect for trying out MyBodyScan"
-    },
-    {
-      name: "Extra Scan", 
-      price: "$9.99",
-      period: "one-time",
-      credits: "1 scan credit",
-      priceId: "price_extra_scan",
-      mode: "payment" as const,
-      features: ["Additional scan credit", "For existing subscribers", "Same detailed analysis"],
-      description: "For subscribers who need extra scans",
-      subscriberOnly: true
+      description: "Perfect for trying out MyBodyScan",
     },
     {
       name: "Monthly",
@@ -64,19 +55,53 @@ export default function Plans() {
       credits: "3 scans/month + Coach + Nutrition",
       priceId: "price_monthly_intro",
       mode: "subscription" as const,
-      features: ["3 scans per month", "AI Coach & workout plans", "Nutrition tracking & advice", "Progress analytics", "Priority support"]
+      features: [
+        "3 scans per month",
+        "AI Coach & workout plans",
+        "Nutrition tracking & advice",
+        "Progress analytics",
+        "Priority support",
+      ],
     },
     {
-      name: "Annual",
+      name: "Yearly",
       price: "$199.99",
       period: "per year",
-      credits: "Everything included",
+      credits: "3 scans/month + Everything included",
       priceId: "price_annual",
       mode: "subscription" as const,
       popular: true,
-      features: ["All Monthly features", "Save $99.89 vs monthly", "Advanced analytics", "Export data", "Early access to new features"],
-      badge: "Best Value"
-    }
+      features: [
+        "3 scans per month",
+        "All Monthly features",
+        "Save $99.89 vs monthly",
+        "Advanced analytics",
+        "Export data",
+        "Early access to new features",
+      ],
+      badge: "Best Value",
+    },
+  ];
+
+  const scanPackPlans = [
+    {
+      name: "Extra Scan",
+      price: "$9.99",
+      period: "one-time",
+      credits: "1 scan credit",
+      priceId: "price_extra_scan",
+      mode: "payment" as const,
+      features: ["Additional scan credit", "For existing subscribers", "Same detailed analysis"],
+      description: "For subscribers who need extra scans",
+      subscriberOnly: true,
+    },
+  ];
+
+  const plans = [
+    corePlans[0],
+    ...(ENABLE_SCAN_PACKS ? scanPackPlans : []),
+    corePlans[1],
+    corePlans[2],
   ];
 
   return (

--- a/src/pages/PublicLanding.tsx
+++ b/src/pages/PublicLanding.tsx
@@ -59,11 +59,11 @@ const PublicLanding = () => {
 
       <section className="py-8">
         <h2 className="text-xl font-semibold">Pricing snapshot</h2>
-        <div className="mt-4 grid gap-4 md:grid-cols-3">
-          {[PRICING_CATALOG.oneScan, PRICING_CATALOG.threePack, PRICING_CATALOG.fivePack, PRICING_CATALOG.monthly, PRICING_CATALOG.yearly].map((card) => (
-            <article key={card.id} className="rounded-lg border p-4">
+        <div className="mt-4 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+          {[PRICING_CATALOG.oneScan, PRICING_CATALOG.monthly, PRICING_CATALOG.yearly].map((card) => (
+            <article key={card.id} className="rounded-xl border bg-card p-4">
               <h3 className="font-medium">{card.label}</h3>
-              <p className="text-sm text-muted-foreground">{card.priceText}</p>
+              <p className="text-sm text-foreground mt-1">{card.priceText}</p>
               {card.blurb ? (
                 <p className="text-xs text-muted-foreground mt-1">{card.blurb}</p>
               ) : null}


### PR DESCRIPTION
## Summary
- update the shared pricing catalog to only expose one scan, monthly, and yearly plans while keeping scan packs internal
- refresh the public marketing pricing grid to render only the three core plans with a balanced three-column layout
- gate in-app scan pack cards behind a feature flag so that only the one scan, monthly, and yearly plans are shown by default

## Testing
- npm run build *(fails: local environment is missing the `vite` binary)*

------
https://chatgpt.com/codex/tasks/task_e_68d5f8a2c9c483259a99a5bb3c1db6ef