### PR TITLE
Add scan flow scaffolding pages and routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,11 @@ import CheckoutSuccess from "./pages/CheckoutSuccess";
 import CheckoutCanceled from "./pages/CheckoutCanceled";
 import ScanNew from "./pages/ScanNew";
 import ScanResult from "./pages/ScanResult";
+import ScanStart from "./pages/Scan/Start";
+import ScanCapture from "./pages/Scan/Capture";
+import ScanFlowResult from "./pages/Scan/Result";
+import ScanRefine from "./pages/Scan/Refine";
+import ScanFlowHistory from "./pages/Scan/History";
 import Report from "./pages/Report";
 import DebugCredits from "./pages/DebugCredits";
 import CoachOnboarding from "./pages/CoachOnboarding";
@@ -387,6 +392,76 @@ const App = () => {
             <Route path="/coach/tracker" element={<ProtectedRoute><AuthedLayout><CoachTracker /></AuthedLayout></ProtectedRoute>} />
             <Route path="/settings/health" element={<ProtectedRoute><AuthedLayout><SettingsHealth /></AuthedLayout></ProtectedRoute>} />
             {/* New scan routes */}
+            <Route
+              path="/scan/start"
+              element={
+                <FeatureGate name="scan" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ScanStart />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
+              path="/scan/capture"
+              element={
+                <FeatureGate name="scan" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ScanCapture />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
+              path="/scan/result"
+              element={
+                <FeatureGate name="scan" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ScanFlowResult />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
+              path="/scan/refine"
+              element={
+                <FeatureGate name="scan" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ScanRefine />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
+              path="/scan/history"
+              element={
+                <FeatureGate name="scan" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ScanFlowHistory />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
             <Route path="/scan/new" element={<ProtectedRoute><AuthedLayout><ScanNew /></AuthedLayout></ProtectedRoute>} />
             <Route path="/scan/:scanId" element={<ProtectedRoute><AuthedLayout><ScanResult /></AuthedLayout></ProtectedRoute>} />
             <Route path="/scan/tips" element={<ProtectedRoute><AuthedLayout><ScanTips /></AuthedLayout></ProtectedRoute>} />

--- a/src/pages/Scan/Capture.tsx
+++ b/src/pages/Scan/Capture.tsx
@@ -1,0 +1,63 @@
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { Seo } from "@/components/Seo";
+
+const PHOTO_SETS: Record<"2" | "4", string[]> = {
+  "2": ["Front", "Side"],
+  "4": ["Front", "Back", "Left", "Right"],
+};
+
+export default function ScanCapture() {
+  const [mode, setMode] = useState<"2" | "4">("2");
+
+  const shots = useMemo(() => PHOTO_SETS[mode], [mode]);
+
+  return (
+    <div className="space-y-6">
+      <Seo title="Capture Photos – MyBodyScan" description="Select how many angles to capture for your scan." />
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Capture Photos</h1>
+        <p className="text-muted-foreground">Choose the angles you will capture. Camera integration arrives later.</p>
+      </div>
+      <div className="space-y-3">
+        <p className="text-sm font-medium text-muted-foreground">Capture mode</p>
+        <ToggleGroup
+          type="single"
+          value={mode}
+          onValueChange={(value) => {
+            if (value === "2" || value === "4") {
+              setMode(value);
+            }
+          }}
+          className="grid w-full grid-cols-2 gap-2"
+        >
+          <ToggleGroupItem value="2" aria-label="Capture two photos" className="py-3">
+            2 photos
+          </ToggleGroupItem>
+          <ToggleGroupItem value="4" aria-label="Capture four photos" className="py-3">
+            4 photos
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Planned shots</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-3">
+            {shots.map((label) => (
+              <li key={label} className="flex items-center justify-between">
+                <span>{label}</span>
+                <Button variant="outline" size="sm" disabled>
+                  Pending
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/Scan/History.tsx
+++ b/src/pages/Scan/History.tsx
@@ -1,0 +1,26 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Seo } from "@/components/Seo";
+
+export default function ScanFlowHistory() {
+  return (
+    <div className="space-y-6">
+      <Seo title="Scan Flow History – MyBodyScan" description="Review past runs of the new scan flow." />
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Scan Flow History</h1>
+        <p className="text-muted-foreground">A simple placeholder list until data wiring is ready.</p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent sessions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ul className="space-y-3">
+            <li className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">Session placeholder #1</li>
+            <li className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">Session placeholder #2</li>
+            <li className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">Session placeholder #3</li>
+          </ul>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/Scan/Refine.tsx
+++ b/src/pages/Scan/Refine.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Seo } from "@/components/Seo";
+
+export default function ScanRefine() {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div className="space-y-6">
+      <Seo title="Refine Estimate – MyBodyScan" description="Fine-tune your scan results with manual inputs." />
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Refine Scan</h1>
+        <p className="text-muted-foreground">Adjust the estimate with quick manual measurements.</p>
+      </div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger asChild>
+          <Button variant="outline">Edit measurements</Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Refine estimate</DialogTitle>
+            <DialogDescription>Enter manual measurements to update the result preview.</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="refine-neck">Neck (in)</Label>
+              <Input id="refine-neck" type="number" min="0" step="0.1" placeholder="13.5" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="refine-waist">Waist (in)</Label>
+              <Input id="refine-waist" type="number" min="0" step="0.1" placeholder="32.0" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="refine-hip">Hip (in)</Label>
+              <Input id="refine-hip" type="number" min="0" step="0.1" placeholder="38.5" />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button disabled>Save adjustments</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/pages/Scan/Result.tsx
+++ b/src/pages/Scan/Result.tsx
@@ -1,0 +1,28 @@
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Seo } from "@/components/Seo";
+
+export default function ScanFlowResult() {
+  return (
+    <div className="space-y-6">
+      <Seo title="Scan Result Preview – MyBodyScan" description="Review the draft estimate before finalizing." />
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Preview Result</h1>
+        <p className="text-muted-foreground">This placeholder shows where your next estimate will appear.</p>
+      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>Estimated body metrics</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-md border border-dashed p-6 text-center text-muted-foreground">
+            Estimate placeholder
+          </div>
+          <Button className="w-full" disabled>
+            Continue
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/pages/Scan/Start.tsx
+++ b/src/pages/Scan/Start.tsx
@@ -1,0 +1,20 @@
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Seo } from "@/components/Seo";
+
+export default function ScanStart() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="space-y-6">
+      <Seo title="Start Scan – MyBodyScan" description="Begin your next body scan." />
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Start a Scan</h1>
+        <p className="text-muted-foreground">Get set to capture your next progress photos.</p>
+      </div>
+      <Button size="lg" onClick={() => navigate("/scan/capture")}>
+        Begin scan
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add scaffold components for the new scan flow, including start, capture, result, refine, and history placeholders
- register the new scan flow routes behind the existing scan feature gate

## Testing
- npm run build *(fails: vite not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7170e62288325a05fe9ffca52d1f3