### PR TITLE
Add weight confirmation flow before scan capture

### DIFF
--- a/src/lib/userState.ts
+++ b/src/lib/userState.ts
@@ -1,0 +1,53 @@
+const PROFILE_STATE_KEY = "mbs_profile_state";
+
+interface StoredProfileState {
+  lastWeightLb?: number;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function readProfileState(): StoredProfileState {
+  if (!isBrowser()) {
+    return {};
+  }
+  try {
+    const raw = window.localStorage.getItem(PROFILE_STATE_KEY);
+    if (!raw) {
+      return {};
+    }
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as StoredProfileState) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeProfileState(state: StoredProfileState) {
+  if (!isBrowser()) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(PROFILE_STATE_KEY, JSON.stringify(state));
+  } catch {
+    // ignore persistence errors
+  }
+}
+
+export function getLastWeight(): number | null {
+  const { lastWeightLb } = readProfileState();
+  return typeof lastWeightLb === "number" && Number.isFinite(lastWeightLb) ? lastWeightLb : null;
+}
+
+export function setLastWeight(lb: number) {
+  if (!Number.isFinite(lb) || lb <= 0) {
+    return;
+  }
+  const normalized = Math.round(lb * 10) / 10;
+  const nextState: StoredProfileState = {
+    ...readProfileState(),
+    lastWeightLb: normalized,
+  };
+  writeProfileState(nextState);
+}

--- a/src/pages/Scan/Start.tsx
+++ b/src/pages/Scan/Start.tsx
@@ -1,9 +1,44 @@
+import { FormEvent, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Seo } from "@/components/Seo";
+import { getLastWeight, setLastWeight } from "@/lib/userState";
+
+function formatWeight(weight: number): string {
+  return Number.isInteger(weight) ? weight.toFixed(0) : weight.toFixed(1);
+}
 
 export default function ScanStart() {
   const navigate = useNavigate();
+  const storedWeightRef = useRef<number | null>(getLastWeight());
+  const initialWeight = storedWeightRef.current;
+  const [storedWeight, setStoredWeight] = useState<number | null>(initialWeight);
+  const [mode, setMode] = useState<"confirm" | "input">(initialWeight == null ? "input" : "confirm");
+  const [weightInput, setWeightInput] = useState<string>(initialWeight != null ? initialWeight.toString() : "");
+  const [error, setError] = useState<string | null>(null);
+
+  const goToCapture = () => navigate("/scan/capture");
+
+  const handleSave = (event?: FormEvent<HTMLFormElement>) => {
+    event?.preventDefault();
+    setError(null);
+
+    const parsed = Number(weightInput.trim());
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      setError("Enter a valid weight in pounds.");
+      return;
+    }
+
+    setLastWeight(parsed);
+    const normalized = Math.round(parsed * 10) / 10;
+    setStoredWeight(normalized);
+    setMode("confirm");
+    goToCapture();
+  };
+
+  const showInput = mode === "input";
 
   return (
     <div className="space-y-6">
@@ -12,9 +47,49 @@ export default function ScanStart() {
         <h1 className="text-3xl font-semibold">Start a Scan</h1>
         <p className="text-muted-foreground">Get set to capture your next progress photos.</p>
       </div>
-      <Button size="lg" onClick={() => navigate("/scan/capture")}>
-        Begin scan
-      </Button>
+
+      {showInput ? (
+        <form onSubmit={handleSave} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="current-weight">Current weight (lb)</Label>
+            <Input
+              id="current-weight"
+              type="number"
+              inputMode="decimal"
+              step="0.1"
+              min="1"
+              required
+              value={weightInput}
+              onChange={(event) => setWeightInput(event.target.value)}
+            />
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          </div>
+          <Button type="submit" size="lg">
+            Save and continue
+          </Button>
+        </form>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-lg font-medium">Is your weight still {formatWeight(storedWeight!)} lb?</p>
+          <div className="flex flex-wrap gap-3">
+            <Button size="lg" onClick={goToCapture}>
+              Yes
+            </Button>
+            <Button
+              type="button"
+              size="lg"
+              variant="outline"
+              onClick={() => {
+                setMode("input");
+                setWeightInput(storedWeight != null ? storedWeight.toString() : "");
+                setError(null);
+              }}
+            >
+              Update
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a lightweight user profile state helper that persists the last known weight in local storage
- update the scan start page to require entering or confirming weight before navigating to capture

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d719627bc48325ad65ed3e57e3d924