### PR TITLE
Implement scan photo selection workflow

### DIFF
--- a/src/pages/Scan/Result.tsx
+++ b/src/pages/Scan/Result.tsx
@@ -1,24 +1,55 @@
+import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Seo } from "@/components/Seo";
+import { CAPTURE_VIEW_SETS, useScanCaptureStore } from "./scanCaptureStore";
 
 export default function ScanFlowResult() {
+  const { mode, files } = useScanCaptureStore();
+  const shots = useMemo(() => CAPTURE_VIEW_SETS[mode], [mode]);
+  const capturedShots = shots.filter((view) => Boolean(files[view]));
+  const allCaptured = capturedShots.length === shots.length;
+
   return (
     <div className="space-y-6">
       <Seo title="Scan Result Preview – MyBodyScan" description="Review the draft estimate before finalizing." />
       <div className="space-y-2">
         <h1 className="text-3xl font-semibold">Preview Result</h1>
-        <p className="text-muted-foreground">This placeholder shows where your next estimate will appear.</p>
+        <p className="text-muted-foreground">
+          {allCaptured
+            ? "Your images are ready. This placeholder shows where your next estimate will appear."
+            : "We need every required angle before we can analyze your scan."}
+        </p>
       </div>
       <Card>
         <CardHeader>
           <CardTitle>Estimated body metrics</CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <h2 className="text-lg font-medium">Captured photos</h2>
+            <ul className="space-y-2">
+              {shots.map((view) => {
+                const file = files[view];
+                return (
+                  <li key={view} className="flex items-center justify-between rounded-md border p-3">
+                    <span className="font-medium">{view}</span>
+                    {file ? (
+                      <span className="text-sm text-muted-foreground">
+                        {file.name} · {(file.size / 1024).toFixed(0)} KB
+                      </span>
+                    ) : (
+                      <span className="text-sm text-destructive">Missing</span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
           <div className="rounded-md border border-dashed p-6 text-center text-muted-foreground">
             Estimate placeholder
           </div>
-          <Button className="w-full" disabled>
+          <Button className="w-full" disabled={!allCaptured}>
             Continue
           </Button>
         </CardContent>

--- a/src/pages/Scan/scanCaptureStore.ts
+++ b/src/pages/Scan/scanCaptureStore.ts
@@ -1,0 +1,87 @@
+import { useSyncExternalStore } from "react";
+
+export type CaptureMode = "2" | "4";
+export type CaptureView = "Front" | "Side" | "Back" | "Left" | "Right";
+
+export const CAPTURE_VIEW_SETS: Record<CaptureMode, CaptureView[]> = {
+  "2": ["Front", "Side"],
+  "4": ["Front", "Back", "Left", "Right"],
+};
+
+interface CaptureState {
+  mode: CaptureMode;
+  files: Partial<Record<CaptureView, File>>;
+}
+
+let state: CaptureState = {
+  mode: "2",
+  files: {},
+};
+
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function setState(nextState: CaptureState) {
+  if (state === nextState) return;
+  state = nextState;
+  emit();
+}
+
+export function getCaptureState() {
+  return state;
+}
+
+export function setCaptureMode(mode: CaptureMode) {
+  if (state.mode === mode) return;
+  setState({
+    ...state,
+    mode,
+  });
+}
+
+export function setCaptureFile(view: CaptureView, file?: File) {
+  const nextFiles = { ...state.files };
+  if (!file) {
+    delete nextFiles[view];
+  } else {
+    nextFiles[view] = file;
+  }
+  setState({
+    ...state,
+    files: nextFiles,
+  });
+}
+
+export function pruneCaptureFiles(validViews: CaptureView[]) {
+  const validSet = new Set(validViews);
+  const nextFiles: Partial<Record<CaptureView, File>> = {};
+  for (const [view, file] of Object.entries(state.files) as [CaptureView, File][]) {
+    if (validSet.has(view)) {
+      nextFiles[view] = file;
+    }
+  }
+  setState({
+    ...state,
+    files: nextFiles,
+  });
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot() {
+  return state;
+}
+
+export function useScanCaptureStore() {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}


### PR DESCRIPTION
## Summary
- add a lightweight scan capture store to persist selected photo files across the flow
- implement capture UI with upload/retake controls, previews, and analyze gating
- show the selected files on the result screen to confirm availability before continuing

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' imported from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d71c63104c8325a91809b39090df2e