### PR TITLE
Add estimator formulas and display scan preview metrics

### DIFF
--- a/src/lib/estimator/formulas.ts
+++ b/src/lib/estimator/formulas.ts
@@ -1,0 +1,111 @@
+const LOG10 = Math.log(10);
+
+function log10(value: number): number {
+  return Math.log(value) / LOG10;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return min;
+  return Math.min(Math.max(value, min), max);
+}
+
+function round(value: number): number {
+  return Number(value.toFixed(1));
+}
+
+export function navyMale({
+  waistIn,
+  neckIn,
+  heightIn,
+}: {
+  waistIn?: number;
+  neckIn?: number;
+  heightIn?: number;
+}): number {
+  if (!waistIn || !neckIn || !heightIn || waistIn <= neckIn) {
+    return NaN;
+  }
+  const bf = 86.010 * log10(waistIn - neckIn) - 70.041 * log10(heightIn) + 36.76;
+  return clamp(round(bf), 3, 65);
+}
+
+export function navyFemale({
+  waistIn,
+  neckIn,
+  hipIn,
+  heightIn,
+}: {
+  waistIn?: number;
+  neckIn?: number;
+  hipIn?: number;
+  heightIn?: number;
+}): number {
+  if (!waistIn || !neckIn || !hipIn || !heightIn || waistIn + hipIn <= neckIn) {
+    return NaN;
+  }
+  const bf = 163.205 * log10(waistIn + hipIn - neckIn) - 97.684 * log10(heightIn) - 78.387;
+  return clamp(round(bf), 5, 65);
+}
+
+export function deurenberg({
+  weightLb,
+  heightIn,
+  age,
+  sex,
+}: {
+  weightLb?: number;
+  heightIn?: number;
+  age?: number;
+  sex: "male" | "female";
+}): number {
+  if (!weightLb || !heightIn || !age || !Number.isFinite(age)) {
+    return NaN;
+  }
+  const bmi = (weightLb / (heightIn * heightIn)) * 703;
+  if (!Number.isFinite(bmi) || bmi <= 0) {
+    return NaN;
+  }
+  const sexFlag = sex === "male" ? 1 : 0;
+  const bf = 1.2 * bmi + 0.23 * age - 10.8 * sexFlag - 5.4;
+  return clamp(round(bf), 3, 65);
+}
+
+export function bai({
+  hipIn,
+  heightIn,
+}: {
+  hipIn?: number;
+  heightIn?: number;
+}): number {
+  if (!hipIn || !heightIn) {
+    return NaN;
+  }
+  const hipCm = hipIn * 2.54;
+  const heightM = heightIn * 0.0254;
+  if (heightM <= 0) {
+    return NaN;
+  }
+  const bf = hipCm / Math.pow(heightM, 1.5) - 18;
+  return clamp(round(bf), 3, 65);
+}
+
+export function wthr({
+  waistIn,
+  heightIn,
+  sex,
+}: {
+  waistIn?: number;
+  heightIn?: number;
+  sex: "male" | "female";
+}): number {
+  if (!waistIn || !heightIn) {
+    return NaN;
+  }
+  const ratio = waistIn / heightIn;
+  if (!Number.isFinite(ratio) || ratio <= 0) {
+    return NaN;
+  }
+  const adjustment = sex === "female" ? 6 : 2.2;
+  const bf = ratio * 100 * 1.1 + adjustment;
+  return clamp(round(bf), 5, 60);
+}

--- a/src/lib/estimator/index.ts
+++ b/src/lib/estimator/index.ts
@@ -1,0 +1,158 @@
+import type { PhotoFeatures } from "@/lib/vision/features";
+import { bai, deurenberg, navyFemale, navyMale, wthr } from "./formulas";
+
+export interface EstimateInput {
+  sex: "male" | "female";
+  age?: number;
+  heightIn: number;
+  weightLb?: number;
+  photoFeatures?: PhotoFeatures | null;
+  manualCircumferences?: {
+    neckIn?: number;
+    waistIn?: number;
+    hipIn?: number;
+  } | null;
+}
+
+export interface EstimateResult {
+  bodyFatPct: number;
+  bmi: number;
+  usedWeight: number | null;
+}
+
+function clamp01(value: number | undefined | null): number {
+  if (!Number.isFinite(value ?? NaN)) return 0;
+  if ((value as number) < 0) return 0;
+  if ((value as number) > 1) return 1;
+  return value as number;
+}
+
+function sanitize(value?: number | null): number | undefined {
+  if (!Number.isFinite(value ?? NaN)) return undefined;
+  if (!value || value <= 0) return undefined;
+  return value;
+}
+
+function toInches(value: number | undefined, scale: number | undefined): number | undefined {
+  if (!Number.isFinite(value ?? NaN) || !Number.isFinite(scale ?? NaN)) {
+    return undefined;
+  }
+  if (!value || value <= 0 || !scale || scale <= 0) {
+    return undefined;
+  }
+  return value * scale;
+}
+
+type MeasurementSource = "manual" | "photo" | null;
+
+type Measurement = { value?: number; source: MeasurementSource };
+
+function resolveMeasurement(manual?: number, photo?: number): Measurement {
+  const manualValue = sanitize(manual);
+  if (manualValue != null) {
+    return { value: manualValue, source: "manual" };
+  }
+  const photoValue = sanitize(photo);
+  if (photoValue != null) {
+    return { value: photoValue, source: "photo" };
+  }
+  return { value: undefined, source: null };
+}
+
+function measurementConfidence(source: MeasurementSource, pose: number): number {
+  if (source === "manual") {
+    return 1;
+  }
+  if (source === "photo") {
+    return 0.4 + 0.6 * pose;
+  }
+  return 0;
+}
+
+function average(values: number[]): number {
+  if (!values.length) return 0;
+  const total = values.reduce((sum, value) => sum + value, 0);
+  return total / values.length;
+}
+
+function weightedMedian(entries: Array<{ value: number; weight: number }>): number {
+  const valid = entries
+    .filter((entry) => Number.isFinite(entry.value) && entry.weight > 0)
+    .sort((a, b) => a.value - b.value);
+  if (!valid.length) {
+    return NaN;
+  }
+  const totalWeight = valid.reduce((sum, entry) => sum + entry.weight, 0);
+  if (totalWeight <= 0) {
+    return NaN;
+  }
+  let cumulative = 0;
+  const target = totalWeight / 2;
+  for (const entry of valid) {
+    cumulative += entry.weight;
+    if (cumulative >= target) {
+      return entry.value;
+    }
+  }
+  return valid[valid.length - 1]?.value ?? NaN;
+}
+
+export function estimateBodyComp(input: EstimateInput): EstimateResult {
+  const { sex, age, heightIn, weightLb, photoFeatures, manualCircumferences } = input;
+  const poseScore = clamp01(photoFeatures?.poseScore ?? 0);
+
+  const averages = photoFeatures?.averages;
+  const heightPixels = sanitize(averages?.heightPixels);
+  const scale = heightPixels ? heightIn / heightPixels : undefined;
+
+  const photoNeckIn = toInches(averages?.neckWidth, scale);
+  const photoWaistIn = toInches(averages?.waistWidth, scale);
+  const photoHipIn = toInches(averages?.hipWidth, scale);
+
+  const neck = resolveMeasurement(manualCircumferences?.neckIn ?? undefined, photoNeckIn);
+  const waist = resolveMeasurement(manualCircumferences?.waistIn ?? undefined, photoWaistIn);
+  const hip = resolveMeasurement(manualCircumferences?.hipIn ?? undefined, photoHipIn);
+
+  const circumferenceSources = [neck.source, waist.source, hip.source];
+  const manualCount = circumferenceSources.filter((source) => source === "manual").length;
+  const photoCount = circumferenceSources.filter((source) => source === "photo").length;
+  const circumferencePresence = manualCount + photoCount;
+
+  const navyEstimate =
+    sex === "female"
+      ? navyFemale({ waistIn: waist.value, neckIn: neck.value, hipIn: hip.value, heightIn })
+      : navyMale({ waistIn: waist.value, neckIn: neck.value, heightIn });
+  const navyConfidenceComponents = sex === "female"
+    ? [waist, neck, hip]
+    : [waist, neck];
+  const navyWeight = average(
+    navyConfidenceComponents.map((measurement) => measurementConfidence(measurement.source, poseScore)),
+  );
+
+  const baiEstimate = bai({ hipIn: hip.value, heightIn });
+  const baiWeight = measurementConfidence(hip.source, poseScore);
+
+  const wthrEstimate = wthr({ waistIn: waist.value, heightIn, sex });
+  const wthrWeight = measurementConfidence(waist.source, poseScore);
+
+  const bmi = weightLb ? Number(((weightLb / (heightIn * heightIn)) * 703).toFixed(1)) : NaN;
+  const deurenbergEstimate = deurenberg({ weightLb, heightIn, age, sex });
+  const weightConfidence = weightLb ? 0.6 : 0;
+  const circumferenceBonus = circumferencePresence >= 2 ? 0.3 : circumferencePresence === 1 ? 0.15 : 0;
+  const deurenbergWeight = weightConfidence + circumferenceBonus;
+
+  const combined = weightedMedian([
+    { value: navyEstimate, weight: navyWeight },
+    { value: deurenbergEstimate, weight: deurenbergWeight },
+    { value: baiEstimate, weight: baiWeight },
+    { value: wthrEstimate, weight: wthrWeight },
+  ]);
+
+  const bodyFatPct = Number.isFinite(combined) ? Number((combined as number).toFixed(1)) : NaN;
+
+  return {
+    bodyFatPct,
+    bmi: Number.isFinite(bmi) ? bmi : NaN,
+    usedWeight: weightLb ? Number(weightLb.toFixed(1)) : null,
+  };
+}

--- a/src/pages/Scan/Result.tsx
+++ b/src/pages/Scan/Result.tsx
@@ -1,31 +1,217 @@
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Seo } from "@/components/Seo";
-import { CAPTURE_VIEW_SETS, useScanCaptureStore } from "./scanCaptureStore";
+import { useUserProfile } from "@/hooks/useUserProfile";
+import { estimateBodyComp } from "@/lib/estimator";
+import type { ViewName, PhotoFeatures } from "@/lib/vision/features";
+import { combineLandmarks } from "@/lib/vision/features";
+import type { Landmarks } from "@/lib/vision/landmarks";
+import { analyzePhoto } from "@/lib/vision/landmarks";
+import { cmToIn, kgToLb } from "@/lib/units";
+import { getLastWeight } from "@/lib/userState";
+import { CAPTURE_VIEW_SETS, type CaptureView, useScanCaptureStore } from "./scanCaptureStore";
+
+const VIEW_NAME_MAP: Record<CaptureView, ViewName> = {
+  Front: "front",
+  Side: "side",
+  Back: "back",
+  Left: "left",
+  Right: "right",
+};
+
+function formatDecimal(value: number | null | undefined): string | null {
+  if (!Number.isFinite(value ?? NaN)) {
+    return null;
+  }
+  const numeric = value as number;
+  return numeric.toFixed(1);
+}
 
 export default function ScanFlowResult() {
   const { mode, files } = useScanCaptureStore();
+  const { profile } = useUserProfile();
+  const [refineOpen, setRefineOpen] = useState(false);
+  const [refineForm, setRefineForm] = useState({ neck: "", waist: "", hip: "" });
+  const [photoFeatures, setPhotoFeatures] = useState<PhotoFeatures | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [analysisError, setAnalysisError] = useState<string | null>(null);
+  const [lastWeight] = useState<number | null>(() => getLastWeight());
+
   const shots = useMemo(() => CAPTURE_VIEW_SETS[mode], [mode]);
-  const capturedShots = shots.filter((view) => Boolean(files[view]));
+  const capturedShots = useMemo(
+    () => shots.filter((view) => Boolean(files[view])),
+    [shots, files],
+  );
   const allCaptured = capturedShots.length === shots.length;
+
+  useEffect(() => {
+    let cancelled = false;
+    const tasks = shots
+      .map((view) => {
+        const file = files[view];
+        if (!file) return null;
+        return { key: VIEW_NAME_MAP[view], file };
+      })
+      .filter((entry): entry is { key: ViewName; file: File } => Boolean(entry));
+
+    if (!tasks.length) {
+      setPhotoFeatures(null);
+      setAnalysisError(null);
+      setAnalyzing(false);
+      return;
+    }
+
+    setAnalyzing(true);
+    setAnalysisError(null);
+
+    (async () => {
+      try {
+        const results = await Promise.all(
+          tasks.map(async ({ key, file }) => ({ key, data: await analyzePhoto(file, key) })),
+        );
+        if (cancelled) return;
+
+        const views: Partial<Record<ViewName, Landmarks>> = {};
+        for (const result of results) {
+          views[result.key] = result.data;
+        }
+        const combined = combineLandmarks(views.front, views.side, views.left, views.right, views.back);
+        setPhotoFeatures(combined);
+        setAnalyzing(false);
+      } catch (error) {
+        console.error("analyzePhoto", error);
+        if (cancelled) return;
+        setAnalysisError("Could not analyze photos.");
+        setPhotoFeatures(null);
+        setAnalyzing(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [files, shots]);
+
+  const sex = profile?.sex === "male" || profile?.sex === "female" ? profile.sex : undefined;
+  const age = profile?.age && Number.isFinite(profile.age) ? profile.age : undefined;
+  const heightIn = profile?.height_cm ? cmToIn(profile.height_cm) : undefined;
+  const profileWeightLb = profile?.weight_kg ? kgToLb(profile.weight_kg) : undefined;
+  const weightLb = lastWeight ?? profileWeightLb ?? undefined;
+
+  const estimate = useMemo(() => {
+    if (!photoFeatures) return null;
+    if (!heightIn || !sex) return null;
+    return estimateBodyComp({
+      sex,
+      age,
+      heightIn,
+      weightLb: weightLb ?? undefined,
+      photoFeatures,
+    });
+  }, [age, heightIn, photoFeatures, sex, weightLb]);
+
+  const bodyFatValue = formatDecimal(estimate?.bodyFatPct ?? null);
+  const bmiValue = formatDecimal(estimate?.bmi ?? null);
+  const weightValue = formatDecimal((estimate?.usedWeight ?? weightLb) ?? null);
+
+  const estimateStatus = useMemo(() => {
+    if (analysisError) return analysisError;
+    if (analyzing) return "Analyzing photos…";
+    if (!allCaptured) return "Capture every required angle to analyze the scan.";
+    if (!heightIn || !sex) return "Add your height and sex in Settings to unlock the preview.";
+    if (!bodyFatValue) return "Add your weight to see the full estimate.";
+    return "Scan preview based on your latest photos.";
+  }, [analysisError, analyzing, allCaptured, heightIn, sex, bodyFatValue]);
 
   return (
     <div className="space-y-6">
       <Seo title="Scan Result Preview – MyBodyScan" description="Review the draft estimate before finalizing." />
       <div className="space-y-2">
         <h1 className="text-3xl font-semibold">Preview Result</h1>
-        <p className="text-muted-foreground">
-          {allCaptured
-            ? "Your images are ready. This placeholder shows where your next estimate will appear."
-            : "We need every required angle before we can analyze your scan."}
-        </p>
+        <p className="text-muted-foreground">{estimateStatus}</p>
       </div>
       <Card>
         <CardHeader>
           <CardTitle>Estimated body metrics</CardTitle>
         </CardHeader>
-        <CardContent className="space-y-4">
+        <CardContent className="space-y-6">
+          <div className="space-y-3 rounded-lg border p-4">
+            <div>
+              <p className="text-sm text-muted-foreground">Estimated Body Fat</p>
+              <p className="text-3xl font-semibold">{bodyFatValue ? `${bodyFatValue}%` : "—"}</p>
+            </div>
+            <p className="text-sm">
+              Estimated BMI: {bmiValue ?? "—"} · Weight: {weightValue ? `${weightValue} lb` : "—"}
+            </p>
+            <p className="text-xs text-muted-foreground">Estimates only. Not a medical diagnosis.</p>
+            <Dialog open={refineOpen} onOpenChange={setRefineOpen}>
+              <DialogTrigger asChild>
+                <button type="button" className="text-sm font-medium text-primary underline-offset-4 hover:underline">
+                  Refine measurements
+                </button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Refine estimate</DialogTitle>
+                  <DialogDescription>Enter manual measurements to update the result preview.</DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="refine-neck">Neck (in)</Label>
+                    <Input
+                      id="refine-neck"
+                      type="number"
+                      min="0"
+                      step="0.1"
+                      value={refineForm.neck}
+                      onChange={(event) => setRefineForm((prev) => ({ ...prev, neck: event.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="refine-waist">Waist (in)</Label>
+                    <Input
+                      id="refine-waist"
+                      type="number"
+                      min="0"
+                      step="0.1"
+                      value={refineForm.waist}
+                      onChange={(event) => setRefineForm((prev) => ({ ...prev, waist: event.target.value }))}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="refine-hip">Hip (in)</Label>
+                    <Input
+                      id="refine-hip"
+                      type="number"
+                      min="0"
+                      step="0.1"
+                      value={refineForm.hip}
+                      onChange={(event) => setRefineForm((prev) => ({ ...prev, hip: event.target.value }))}
+                    />
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setRefineOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button disabled>Save adjustments</Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
+
           <div className="space-y-2">
             <h2 className="text-lg font-medium">Captured photos</h2>
             <ul className="space-y-2">
@@ -46,12 +232,6 @@ export default function ScanFlowResult() {
               })}
             </ul>
           </div>
-          <div className="rounded-md border border-dashed p-6 text-center text-muted-foreground">
-            Estimate placeholder
-          </div>
-          <Button className="w-full" disabled={!allCaptured}>
-            Continue
-          </Button>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
- add estimator formulas covering Navy, Deurenberg, BAI, and waist-to-height methods
- implement a body composition estimator that scales landmark widths and blends method estimates
- update the scan result preview to analyze captured photos, call the estimator, and surface the estimate with a refine dialog stub

## Testing
- `npm run build` *(fails: vite dependency unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d71feddef48325a95097501dd3696e