### PR TITLE
Add credit gating and history persistence to scan preview

### DIFF
--- a/src/lib/scans.ts
+++ b/src/lib/scans.ts
@@ -28,9 +28,11 @@ export function extractScanMetrics(scan: any): NormalizedScanMetrics {
   const bodyFatPercent = firstNumber(
     metrics.bf_percent,
     metrics.bodyFatPct,
+    metrics.bfPct,
     metrics.body_fat,
     results.bf_percent,
     results.bodyFatPct,
+    fallback.bfPct,
     fallback.bodyFatPercentage,
     fallback.body_fat,
     fallback.bodyfat,
@@ -39,8 +41,10 @@ export function extractScanMetrics(scan: any): NormalizedScanMetrics {
 
   const bmi = firstNumber(
     metrics.bmi,
+    metrics.body_mass_index,
     results.bmi,
     fallback.bmi,
+    fallback.bmiValue,
     measurements.bmi
   );
 
@@ -58,6 +62,7 @@ export function extractScanMetrics(scan: any): NormalizedScanMetrics {
   const weightLbDirect = firstNumber(
     metrics.weight_lb,
     metrics.weightLb,
+    metrics.weight,
     results.weight_lb,
     results.weightLb,
     fallback.weight_lbs,

--- a/src/pages/Scan/History.tsx
+++ b/src/pages/Scan/History.tsx
@@ -1,24 +1,147 @@
+import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Seo } from "@/components/Seo";
+import { auth, db } from "@/lib/firebase";
+import { collection, limit, onSnapshot, orderBy, query } from "firebase/firestore";
+import { extractScanMetrics } from "@/lib/scans";
+
+interface StoredScan {
+  id: string;
+  createdAt?: unknown;
+  bfPct?: number | null;
+  bmi?: number | null;
+  weightLb?: number | null;
+  thumbnail?: string | null;
+  method?: string | null;
+  [key: string]: unknown;
+}
+
+function resolveDate(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof value === "object") {
+    const maybe = value as { toDate?: () => Date; seconds?: number };
+    if (typeof maybe.toDate === "function") {
+      try {
+        return maybe.toDate();
+      } catch {
+        // ignore
+      }
+    }
+    if (typeof maybe.seconds === "number") {
+      return new Date(maybe.seconds * 1000);
+    }
+  }
+  if (typeof value === "number") {
+    return new Date(value);
+  }
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.valueOf())) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function formatDate(value: unknown): string {
+  const date = resolveDate(value);
+  if (!date) return "Pending";
+  try {
+    return date.toLocaleString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+  } catch {
+    return date.toISOString();
+  }
+}
+
+function formatMethod(method?: string | null): string {
+  if (!method) return "Photo";
+  if (method === "photo") return "Photo";
+  if (method === "photo+measure") return "Photo + Tape";
+  if (method === "bmi_fallback") return "BMI Fallback";
+  return method;
+}
 
 export default function ScanFlowHistory() {
+  const [scans, setScans] = useState<StoredScan[]>([]);
+
+  useEffect(() => {
+    const user = auth.currentUser;
+    if (!user) {
+      setScans([]);
+      return;
+    }
+
+    const scansRef = collection(db, "users", user.uid, "scans");
+    const q = query(scansRef, orderBy("createdAt", "desc"), limit(50));
+    const unsubscribe = onSnapshot(q, (snapshot) => {
+      const next: StoredScan[] = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+      setScans(next);
+    });
+
+    return () => unsubscribe();
+  }, []);
+
+  const hasScans = scans.length > 0;
+
   return (
     <div className="space-y-6">
       <Seo title="Scan Flow History – MyBodyScan" description="Review past runs of the new scan flow." />
       <div className="space-y-2">
         <h1 className="text-3xl font-semibold">Scan Flow History</h1>
-        <p className="text-muted-foreground">A simple placeholder list until data wiring is ready.</p>
+        <p className="text-muted-foreground">
+          Completed photo scans are saved automatically after analysis finishes.
+        </p>
       </div>
       <Card>
         <CardHeader>
-          <CardTitle>Recent sessions</CardTitle>
+          <CardTitle>Recent scans</CardTitle>
         </CardHeader>
         <CardContent>
-          <ul className="space-y-3">
-            <li className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">Session placeholder #1</li>
-            <li className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">Session placeholder #2</li>
-            <li className="rounded-md border border-dashed p-4 text-sm text-muted-foreground">Session placeholder #3</li>
-          </ul>
+          {hasScans ? (
+            <ul className="space-y-3">
+              {scans.map((scan) => {
+                const metrics = extractScanMetrics(scan);
+                const thumbnail = typeof scan.thumbnail === "string" ? scan.thumbnail : null;
+                const methodLabel = formatMethod((scan.method as string | undefined) ?? (metrics.method ?? null));
+                return (
+                  <li key={scan.id} className="flex items-center gap-4 rounded-lg border p-4">
+                    <div className="flex h-16 w-16 items-center justify-center overflow-hidden rounded-md bg-muted">
+                      {thumbnail ? (
+                        <img src={thumbnail} alt="Scan thumbnail" className="h-full w-full object-cover" />
+                      ) : (
+                        <span className="px-2 text-center text-xs text-muted-foreground">No preview</span>
+                      )}
+                    </div>
+                    <div className="flex flex-1 flex-col gap-1">
+                      <p className="font-medium leading-tight">{formatDate(scan.createdAt)}</p>
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">{methodLabel}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {metrics.weightLb != null ? `${metrics.weightLb.toFixed(1)} lb` : "Weight —"}
+                        {metrics.bmi != null ? ` · BMI ${metrics.bmi.toFixed(1)}` : ""}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="text-xs uppercase tracking-wide text-muted-foreground">Body Fat</p>
+                      <p className="text-lg font-semibold">
+                        {metrics.bodyFatPercent != null ? `${metrics.bodyFatPercent.toFixed(1)}%` : "—"}
+                      </p>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          ) : (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              Run a photo scan to see it listed here.
+            </p>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/pages/Scan/Result.tsx
+++ b/src/pages/Scan/Result.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Dialog,
   DialogContent,
@@ -21,6 +22,9 @@ import { analyzePhoto } from "@/lib/vision/landmarks";
 import { cmToIn, kgToLb } from "@/lib/units";
 import { getLastWeight } from "@/lib/userState";
 import { findRangeForValue, getSexAgeBands, type LabeledRange } from "@/content/referenceRanges";
+import { consumeOneCredit } from "@/lib/payments";
+import { auth, db } from "@/lib/firebase";
+import { collection, doc, serverTimestamp, setDoc } from "firebase/firestore";
 import { CAPTURE_VIEW_SETS, type CaptureView, useScanCaptureStore } from "./scanCaptureStore";
 import { RefineMeasurementsForm } from "./Refine";
 import { setPhotoCircumferences, useScanRefineStore } from "./scanRefineStore";
@@ -34,12 +38,50 @@ const VIEW_NAME_MAP: Record<CaptureView, ViewName> = {
   Right: "right",
 };
 
+type CreditStatus = "idle" | "pending" | "consumed" | "error";
+type CreditError = "no-credits" | "general" | null;
+
+type PhotoMetadata = {
+  name: string;
+  size: number;
+  type: string;
+  lastModified?: number;
+};
+
 function formatDecimal(value: number | null | undefined): string | null {
   if (!Number.isFinite(value ?? NaN)) {
     return null;
   }
   const numeric = value as number;
   return numeric.toFixed(1);
+}
+
+async function createThumbnailDataUrl(file: File, maxSize = 128): Promise<string | null> {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onerror = () => resolve(null);
+    reader.onload = () => {
+      const image = new Image();
+      image.onerror = () => resolve(null);
+      image.onload = () => {
+        const scale = Math.min(maxSize / image.width, maxSize / image.height, 1);
+        const width = Math.max(1, Math.round(image.width * scale));
+        const height = Math.max(1, Math.round(image.height * scale));
+        const canvas = document.createElement("canvas");
+        canvas.width = width;
+        canvas.height = height;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) {
+          resolve(null);
+          return;
+        }
+        ctx.drawImage(image, 0, 0, width, height);
+        resolve(canvas.toDataURL("image/jpeg", 0.6));
+      };
+      image.src = reader.result as string;
+    };
+    reader.readAsDataURL(file);
+  });
 }
 
 function toInches(value?: number | null, scale?: number | null): number | undefined {
@@ -64,11 +106,18 @@ export default function ScanFlowResult() {
   const { mode, files } = useScanCaptureStore();
   const { profile } = useUserProfile();
   const [refineOpen, setRefineOpen] = useState(false);
-  const { manualInputs } = useScanRefineStore();
+  const { manualInputs, photoCircumferences } = useScanRefineStore();
   const [photoFeatures, setPhotoFeatures] = useState<PhotoFeatures | null>(null);
   const [analyzing, setAnalyzing] = useState(false);
   const [analysisError, setAnalysisError] = useState<string | null>(null);
   const [lastWeight] = useState<number | null>(() => getLastWeight());
+  const [creditStatus, setCreditStatus] = useState<CreditStatus>("idle");
+  const [creditError, setCreditError] = useState<CreditError>(null);
+  const [saving, setSaving] = useState(false);
+  const [savedScanId, setSavedScanId] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [thumbnailDataUrl, setThumbnailDataUrl] = useState<string | null>(null);
+  const [lastSavedSignature, setLastSavedSignature] = useState<string | null>(null);
 
   const shots = useMemo(() => CAPTURE_VIEW_SETS[mode], [mode]);
   const capturedShots = useMemo(
@@ -77,20 +126,56 @@ export default function ScanFlowResult() {
   );
   const allCaptured = capturedShots.length === shots.length;
 
+  const tasks = useMemo(
+    () =>
+      shots
+        .map((view) => {
+          const file = files[view];
+          if (!file) return null;
+          return { key: VIEW_NAME_MAP[view], file };
+        })
+        .filter((entry): entry is { key: ViewName; file: File } => Boolean(entry)),
+    [shots, files],
+  );
+
+  useEffect(() => {
+    if (!allCaptured) return;
+    if (!tasks.length) return;
+    if (creditStatus !== "idle") return;
+    let cancelled = false;
+    setCreditStatus("pending");
+    setCreditError(null);
+    consumeOneCredit()
+      .then(() => {
+        if (cancelled) return;
+        setCreditStatus("consumed");
+      })
+      .catch((error: any) => {
+        if (cancelled) return;
+        setCreditStatus("error");
+        setCreditError(error?.message === "No credits available" ? "no-credits" : "general");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [allCaptured, tasks, creditStatus]);
+
   useEffect(() => {
     let cancelled = false;
-    const tasks = shots
-      .map((view) => {
-        const file = files[view];
-        if (!file) return null;
-        return { key: VIEW_NAME_MAP[view], file };
-      })
-      .filter((entry): entry is { key: ViewName; file: File } => Boolean(entry));
 
     if (!tasks.length) {
       setPhotoFeatures(null);
       setAnalysisError(null);
       setAnalyzing(false);
+      return;
+    }
+
+    if (creditStatus !== "consumed") {
+      setAnalyzing(false);
+      if (creditStatus === "error") {
+        setPhotoFeatures(null);
+      }
       return;
     }
 
@@ -123,7 +208,7 @@ export default function ScanFlowResult() {
     return () => {
       cancelled = true;
     };
-  }, [files, shots]);
+  }, [tasks, creditStatus]);
 
   const sex = profile?.sex === "male" || profile?.sex === "female" ? profile.sex : undefined;
   const age = profile?.age && Number.isFinite(profile.age) ? profile.age : undefined;
@@ -161,6 +246,46 @@ export default function ScanFlowResult() {
     return { neckIn, waistIn, hipIn };
   }, [manualInputs]);
 
+  const primaryFile = useMemo(() => {
+    const firstCaptured = capturedShots[0];
+    if (!firstCaptured) return null;
+    return files[firstCaptured] ?? null;
+  }, [capturedShots, files]);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!primaryFile) {
+      setThumbnailDataUrl(null);
+      return;
+    }
+    createThumbnailDataUrl(primaryFile).then((dataUrl) => {
+      if (cancelled) return;
+      setThumbnailDataUrl(dataUrl);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [primaryFile]);
+
+  const photoMetadata = useMemo(() => {
+    const meta: Partial<Record<ViewName, PhotoMetadata>> = {};
+    for (const view of capturedShots) {
+      const file = files[view];
+      if (!file) continue;
+      const key = VIEW_NAME_MAP[view];
+      const entry: PhotoMetadata = {
+        name: file.name,
+        size: file.size,
+        type: file.type || "image/jpeg",
+      };
+      if (typeof file.lastModified === "number") {
+        entry.lastModified = file.lastModified;
+      }
+      meta[key] = entry;
+    }
+    return meta;
+  }, [capturedShots, files]);
+
   const estimate = useMemo(() => {
     if (!photoFeatures) return null;
     if (!heightIn || !sex) return null;
@@ -195,14 +320,156 @@ export default function ScanFlowResult() {
   const bmiValue = formatDecimal(estimate?.bmi ?? null);
   const weightValue = formatDecimal((estimate?.usedWeight ?? weightLb) ?? null);
 
+  const photoEstimatePayload = useMemo(
+    () => ({
+      neck: photoCircumferences?.neckIn ?? null,
+      waist: photoCircumferences?.waistIn ?? null,
+      hip: photoCircumferences?.hipIn ?? null,
+    }),
+    [photoCircumferences],
+  );
+
+  const userCircumPayload = useMemo(
+    () => ({
+      neck: manualCircumferences?.neckIn ?? null,
+      waist: manualCircumferences?.waistIn ?? null,
+      hip: manualCircumferences?.hipIn ?? null,
+    }),
+    [manualCircumferences],
+  );
+
+  const bmiNumber = useMemo(() => {
+    const value = estimate?.bmi;
+    if (!Number.isFinite(value ?? NaN)) return null;
+    return Number((value as number).toFixed(1));
+  }, [estimate]);
+
+  const usedWeightLb = useMemo(() => {
+    const raw = estimate?.usedWeight ?? weightLb ?? null;
+    if (!Number.isFinite(raw ?? NaN)) return null;
+    return Number((raw as number).toFixed(1));
+  }, [estimate, weightLb]);
+
+  const heightInValue = useMemo(() => {
+    if (!Number.isFinite(heightIn ?? NaN)) return null;
+    return Number(heightIn);
+  }, [heightIn]);
+
+  const payload = useMemo(() => {
+    if (bodyFatPctNumber == null) return null;
+    const normalizedBf = Number((bodyFatPctNumber as number).toFixed(1));
+    return {
+      method: "photo" as const,
+      bfPct: normalizedBf,
+      bmi: bmiNumber,
+      weightLb: usedWeightLb,
+      sex: sex ?? null,
+      age: age ?? null,
+      heightIn: heightInValue,
+      photoEstimates: photoEstimatePayload,
+      userCircumIn: userCircumPayload,
+      photos: {
+        mode,
+        captureViews: capturedShots,
+        files: photoMetadata,
+      },
+      thumbnail: thumbnailDataUrl ?? null,
+    };
+  }, [
+    bodyFatPctNumber,
+    bmiNumber,
+    usedWeightLb,
+    sex,
+    age,
+    heightInValue,
+    photoEstimatePayload,
+    userCircumPayload,
+    mode,
+    capturedShots,
+    photoMetadata,
+    thumbnailDataUrl,
+  ]);
+
+  const payloadSignature = useMemo(() => (payload ? JSON.stringify(payload) : null), [payload]);
+
+  useEffect(() => {
+    if (creditStatus !== "consumed") return;
+    if (!payload || !payloadSignature) return;
+    if (payloadSignature === lastSavedSignature && savedScanId) return;
+    const user = auth.currentUser;
+    if (!user) return;
+
+    const scansCollection = collection(db, "users", user.uid, "scans");
+    const docRef = savedScanId ? doc(scansCollection, savedScanId) : doc(scansCollection);
+    const docId = docRef.id;
+    let cancelled = false;
+
+    setSaving(true);
+    setSaveError(null);
+
+    const data: Record<string, unknown> = {
+      ...payload,
+      status: "completed",
+      updatedAt: serverTimestamp(),
+    };
+    if (!savedScanId) {
+      data.createdAt = serverTimestamp();
+    }
+
+    setDoc(docRef, data, { merge: true })
+      .then(() => {
+        if (cancelled) return;
+        setSaving(false);
+        setLastSavedSignature(payloadSignature);
+        if (!savedScanId) {
+          setSavedScanId(docId);
+        }
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        console.error("save_scan_preview", error);
+        setSaving(false);
+        setSaveError("Unable to save scan. Try again.");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [creditStatus, payload, payloadSignature, savedScanId, lastSavedSignature]);
+
   const estimateStatus = useMemo(() => {
+    if (creditStatus === "pending") return "Confirming scan credit…";
+    if (creditStatus === "error") {
+      if (creditError === "no-credits") {
+        return "No credits available. Add credits to continue.";
+      }
+      return "Could not confirm scan credit.";
+    }
     if (analysisError) return analysisError;
     if (analyzing) return "Analyzing photos…";
+    if (saving) return "Saving scan result…";
+    if (saveError) return saveError;
+    if (savedScanId) return "Scan saved to your history.";
     if (!allCaptured) return "Capture every required angle to analyze the scan.";
     if (!heightIn || !sex) return "Add your height and sex in Settings to unlock the preview.";
     if (!bodyFatValue) return "Add your weight to see the full estimate.";
     return "Scan preview based on your latest photos.";
-  }, [analysisError, analyzing, allCaptured, heightIn, sex, bodyFatValue]);
+  }, [
+    analysisError,
+    analyzing,
+    allCaptured,
+    heightIn,
+    sex,
+    bodyFatValue,
+    creditStatus,
+    creditError,
+    saving,
+    saveError,
+    savedScanId,
+  ]);
+
+  const creditBlocked = creditStatus === "error";
+  const noCredits = creditError === "no-credits";
 
   return (
     <div className="space-y-6">
@@ -211,11 +478,44 @@ export default function ScanFlowResult() {
         <h1 className="text-3xl font-semibold">Preview Result</h1>
         <p className="text-muted-foreground">{estimateStatus}</p>
       </div>
-      <Card>
-        <CardHeader>
-          <CardTitle>Estimated body metrics</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-6">
+      {creditBlocked ? (
+        <Card className="border-dashed">
+          <CardContent className="space-y-4 py-6 text-center">
+            <div className="space-y-2">
+              <h2 className="text-xl font-semibold">
+                {noCredits ? "Add credits to finish" : "Unable to reserve a credit"}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {noCredits
+                  ? "You need at least one scan credit before we can analyze your latest photos."
+                  : "We couldn't confirm a scan credit. Try again in a moment."}
+              </p>
+            </div>
+            <div className="flex flex-col items-center justify-center gap-3 sm:flex-row">
+              {noCredits ? (
+                <Button asChild size="lg">
+                  <Link to="/plans">View plans</Link>
+                </Button>
+              ) : null}
+              <Button
+                variant="outline"
+                size="lg"
+                onClick={() => {
+                  setCreditStatus("idle");
+                  setCreditError(null);
+                }}
+              >
+                Retry credit check
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>Estimated body metrics</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
           <div className="space-y-3 rounded-lg border p-4">
             <div>
               <p className="text-sm text-muted-foreground">Estimated Body Fat</p>
@@ -274,8 +574,22 @@ export default function ScanFlowResult() {
               })}
             </ul>
           </div>
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
+      {!creditBlocked && savedScanId ? (
+        <Card className="border border-dashed">
+          <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-medium">Scan saved</p>
+              <p className="text-sm text-muted-foreground">Find this scan anytime in your history.</p>
+            </div>
+            <Button asChild variant="outline" size="sm">
+              <Link to="/scan/history">View history</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- charge a scan credit before running the capture result preview and block the flow with a retry/upsell card when no credits remain
- persist completed preview results to Firestore with body metrics, circumference sources, photo metadata, and a generated thumbnail
- replace the scan flow history placeholder with a live list of saved scans showing dates, body-fat %, and available thumbnails

## Testing
- npm run lint *(fails: missing optional dependency `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_68d726d013a08325b173b9f9837ae824