### PR TITLE
Add consistent disclaimer to results-related pages

### DIFF
--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -16,6 +16,7 @@ const Privacy = () => {
         <p>
           You can request data deletion at any time by contacting <a href="mailto:support@mybodyscanapp.com">support@mybodyscanapp.com</a>.
         </p>
+        <p className="text-sm text-muted-foreground">Estimates only. Not a medical diagnosis.</p>
       </article>
     </>
   );

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -11,7 +11,8 @@ const Terms = () => {
       <article className="prose prose-neutral dark:prose-invert max-w-none">
         <h1>Terms of Service</h1>
         <p>
-          MyBodyScan provides general-wellness information and is not a medical device. Results are estimates and should not be used for diagnosis or treatment. Always consult a qualified professional for medical advice.
+          MyBodyScan provides general-wellness information and is not a medical device. Estimates only. Not a medical diagnosis.
+          Always consult a qualified professional for medical advice.
         </p>
         <p>
           Purchases are non-refundable once a scan has been processed, except where required by applicable law.

--- a/src/pages/legal/Privacy.tsx
+++ b/src/pages/legal/Privacy.tsx
@@ -20,7 +20,7 @@ const Privacy = () => {
         <p>
           Credits expire 12 months after purchase and transaction logs are kept only as required for payments.
         </p>
-        <p className="text-sm text-muted-foreground">This app is not medical advice.</p>
+        <p className="text-sm text-muted-foreground">Estimates only. Not a medical diagnosis.</p>
       </article>
     </>
   );

--- a/src/pages/legal/Terms.tsx
+++ b/src/pages/legal/Terms.tsx
@@ -16,6 +16,7 @@ const Terms = () => {
         </p>
         <p>Keep your account secure and use the service responsibly.</p>
         <p>We may terminate accounts for misuse or non-payment.</p>
+        <p className="text-sm text-muted-foreground">Estimates only. Not a medical diagnosis.</p>
         <p>These terms are governed by the laws of your jurisdiction.</p>
       </article>
     </>


### PR DESCRIPTION
## Summary
- add the required "Estimates only. Not a medical diagnosis." disclaimer to the legal Terms and Privacy pages
- mirror the disclaimer on legacy Terms and Privacy page variants to keep wording consistent

## Testing
- npm run build *(fails: `vite` missing prior to dependency install; npm install blocked by registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d72f09544483259ad0a8c68bc53ce4