### PR TITLE
Set invoker to public for HTTP functions

### DIFF
--- a/functions/src/foodSearch.ts
+++ b/functions/src/foodSearch.ts
@@ -130,7 +130,7 @@ async function handler(req: Request, res: Response) {
   res.json({ items: results.map(toResponseItem) });
 }
 
-export const foodSearch = onRequest({ region: "us-central1" }, withCors(async (req, res) => {
+export const foodSearch = onRequest({ region: "us-central1", invoker: "public" }, withCors(async (req, res) => {
   try {
     await handler(req as Request, res as Response);
   } catch (error: any) {

--- a/functions/src/health.ts
+++ b/functions/src/health.ts
@@ -3,6 +3,7 @@ import { softVerifyAppCheck } from "./middleware/appCheck.js";
 import { withCors } from "./middleware/cors.js";
 
 export const health = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     await softVerifyAppCheck(req as any, res as any);
     res.json({ ok: true, ts: Date.now() });

--- a/functions/src/nutrition.ts
+++ b/functions/src/nutrition.ts
@@ -309,6 +309,7 @@ async function handleGetHistory(req: Request, res: any) {
 
 function withHandler(handler: (req: Request, res: any) => Promise<void>) {
   return onRequest(
+    { invoker: "public" },
     withCors(async (req, res) => {
       try {
         await softVerifyAppCheck(req as any, res as any);

--- a/functions/src/nutrition/barcode.ts
+++ b/functions/src/nutrition/barcode.ts
@@ -101,7 +101,7 @@ async function handler(req: Request, res: any) {
   res.json({ item: result.item, code, source: result.source, cached: false });
 }
 
-export const nutritionBarcode = onRequest({ region: "us-central1", secrets: ["USDA_FDC_API_KEY"] }, withCors(async (req, res) => {
+export const nutritionBarcode = onRequest({ region: "us-central1", secrets: ["USDA_FDC_API_KEY"], invoker: "public" }, withCors(async (req, res) => {
   try {
     await handler(req as Request, res);
   } catch (error: any) {

--- a/functions/src/nutrition/search.ts
+++ b/functions/src/nutrition/search.ts
@@ -210,7 +210,7 @@ async function handler(req: Request, res: any) {
   res.json({ items: merged, q: queryText, cached: false });
 }
 
-export const nutritionSearch = onRequest({ region: "us-central1", secrets: ["USDA_FDC_API_KEY"] }, withCors(async (req, res) => {
+export const nutritionSearch = onRequest({ region: "us-central1", secrets: ["USDA_FDC_API_KEY"], invoker: "public" }, withCors(async (req, res) => {
   try {
     await handler(req as Request, res);
   } catch (error: any) {

--- a/functions/src/payments.ts
+++ b/functions/src/payments.ts
@@ -97,7 +97,7 @@ async function handleCustomerPortal(req: Request, res: any) {
 
 function withHandler(handler: (req: Request, res: any) => Promise<void>) {
   return onRequest(
-    { region: "us-central1", secrets: ["STRIPE_SECRET_KEY"] },
+    { region: "us-central1", secrets: ["STRIPE_SECRET_KEY"], invoker: "public" },
     withCors(async (req, res) => {
       try {
         await softVerifyAppCheck(req as any, res as any);

--- a/functions/src/scan.ts
+++ b/functions/src/scan.ts
@@ -235,6 +235,7 @@ export const runBodyScan = onCall(
 );
 
 export const startScanSession = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     try {
       await softVerifyAppCheck(req as any, res as any);
@@ -246,6 +247,7 @@ export const startScanSession = onRequest(
 );
 
 export const submitScan = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     try {
       await softVerifyAppCheck(req as any, res as any);
@@ -266,6 +268,7 @@ export const submitScan = onRequest(
 );
 
 export const processQueuedScanHttp = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     try {
       await softVerifyAppCheck(req as any, res as any);
@@ -292,11 +295,12 @@ export const processQueuedScanHttp = onRequest(
   })
 );
 
-export const processScan = onRequest(async (req, res) => {
+export const processScan = onRequest({ invoker: "public" }, async (req, res) => {
   await processQueuedScanHttp(req, res);
 });
 
 export const getScanStatus = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     try {
       await softVerifyAppCheck(req as any, res as any);

--- a/functions/src/scan/beginPaidScan.ts
+++ b/functions/src/scan/beginPaidScan.ts
@@ -129,6 +129,7 @@ async function handler(req: Request, res: any) {
 }
 
 export const beginPaidScan = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     try {
       await handler(req as Request, res);

--- a/functions/src/scan/recordGateFailure.ts
+++ b/functions/src/scan/recordGateFailure.ts
@@ -43,6 +43,7 @@ async function handler(req: Request, res: any) {
 }
 
 export const recordGateFailure = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     try {
       await handler(req as Request, res);

--- a/functions/src/scan/refundIfNoResult.ts
+++ b/functions/src/scan/refundIfNoResult.ts
@@ -63,6 +63,7 @@ async function handler(req: Request, res: any) {
 }
 
 export const refundIfNoResult = onRequest(
+  { invoker: "public" },
   withCors(async (req, res) => {
     try {
       await handler(req as Request, res);

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -17,6 +17,7 @@ function buildStripe(): Stripe | null {
 export const stripeWebhook = onRequest({
   region: "us-central1",
   secrets: ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
+  invoker: "public",
 }, async (req, res) => {
   if (req.method !== "POST") {
     res.status(405).send("Method Not Allowed");

--- a/functions/src/workouts.ts
+++ b/functions/src/workouts.ts
@@ -218,6 +218,7 @@ async function handleGetWorkouts(req: Request, res: any) {
 
 function withHandler(handler: (req: Request, res: any) => Promise<void>) {
   return onRequest(
+    { invoker: "public" },
     withCors(async (req, res) => {
       try {
         await softVerifyAppCheck(req as any, res as any);


### PR DESCRIPTION
## Summary
- explicitly add `invoker: "public"` to every HTTPS onRequest handler across scan, nutrition, payments, webhook, workouts, and utility modules
- preserve existing configuration such as regions, secrets, and wrappers while leaving logic unchanged

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68d738f74fa08325b1d289417b43a507