### PR TITLE
Improve checkout error handling and founder onboarding perks

### DIFF
--- a/functions/src/authTriggers.ts
+++ b/functions/src/authTriggers.ts
@@ -1,0 +1,40 @@
+import { onAuthUserCreate } from "firebase-functions/v2/auth";
+import { config } from "firebase-functions";
+
+import { getFirestore } from "./firebase.js";
+import { addCredits } from "./credits.js";
+
+const db = getFirestore();
+
+function parseFounderEmails(): Set<string> {
+  try {
+    const raw = config().founders?.emails as string | undefined;
+    if (!raw) return new Set();
+    const entries = raw
+      .split(/[,\s]+/)
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean);
+    return new Set(entries);
+  } catch {
+    return new Set();
+  }
+}
+
+export const handleUserCreate = onAuthUserCreate({ region: "us-central1" }, async (event) => {
+  const email = event.data.email?.toLowerCase();
+  if (!email) return;
+  const founders = parseFounderEmails();
+  if (!founders.has(email)) return;
+
+  const uid = event.data.uid;
+  console.log("founder_signup", { uid, email });
+  await Promise.all([
+    addCredits(uid, 30, "Founder", 12),
+    db.doc(`users/${uid}`).set(
+      {
+        meta: { founder: true },
+      },
+      { merge: true }
+    ),
+  ]);
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -35,5 +35,8 @@ export { createCheckoutSession, createCheckout, createCustomerPortal } from "./p
 export { stripeWebhook } from "./stripeWebhook.js";
 export { useCredit } from "./useCredit.js";
 
+// Auth triggers
+export { handleUserCreate } from "./authTriggers.js";
+
 // Food search
 export { foodSearch } from "./foodSearch.js";

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -4,19 +4,19 @@ import Stripe from 'stripe';
 
 import { addCredits, setSubscriptionStatus } from "./credits.js";
 
-const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+const STRIPE_SECRET = process.env.STRIPE_SECRET || process.env.STRIPE_SECRET_KEY;
 const STRIPE_WEBHOOK_SECRET = process.env.STRIPE_WEBHOOK_SECRET;
 
 type RequestWithRawBody = Request & Record<'rawBody', Buffer>;
 
 function buildStripe(): Stripe | null {
-  if (!STRIPE_SECRET_KEY) return null;
-  return new Stripe(STRIPE_SECRET_KEY, { apiVersion: "2024-06-20" });
+  if (!STRIPE_SECRET) return null;
+  return new Stripe(STRIPE_SECRET, { apiVersion: "2024-06-20" });
 }
 
 export const stripeWebhook = onRequest({
   region: "us-central1",
-  secrets: ["STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
+  secrets: ["STRIPE_SECRET", "STRIPE_SECRET_KEY", "STRIPE_WEBHOOK_SECRET"],
   invoker: "public",
 }, async (req, res) => {
   if (req.method !== "POST") {
@@ -47,6 +47,7 @@ export const stripeWebhook = onRequest({
   }
 
   try {
+    console.log("stripe_webhook_event", { type: event.type, id: event.id });
     switch (event.type) {
       case "checkout.session.completed": {
         const session = event.data.object as Stripe.Checkout.Session;

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { CreditsBadge } from "@/components/CreditsBadge";
 import { DemoBadge } from "@/components/DemoBadge";
@@ -6,11 +7,27 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigge
 import { useAuthUser, signOutAll } from "@/lib/auth";
 import { useNavigate, useLocation } from "react-router-dom";
 import { Settings, LogOut, User } from "lucide-react";
+import { doc, onSnapshot } from "firebase/firestore";
+import { db } from "@/lib/firebase";
 
 export function AppHeader() {
   const { user } = useAuthUser();
   const navigate = useNavigate();
   const location = useLocation();
+  const [isFounder, setIsFounder] = useState(false);
+
+  useEffect(() => {
+    if (!user?.uid) {
+      setIsFounder(false);
+      return;
+    }
+    const ref = doc(db, "users", user.uid);
+    const unsub = onSnapshot(ref, (snap) => {
+      const data = snap.data() as { meta?: { founder?: boolean } } | undefined;
+      setIsFounder(Boolean(data?.meta?.founder));
+    });
+    return () => unsub();
+  }, [user?.uid]);
 
   const tabs = [
     { label: "Today", path: "/today" },
@@ -37,28 +54,35 @@ export function AppHeader() {
               <DemoBadge />
             </div>
           
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon">
-                <Avatar className="h-6 w-6">
-                  <AvatarImage src={user?.photoURL || ""} />
-                  <AvatarFallback>
-                    <User className="h-4 w-4" />
-                  </AvatarFallback>
-                </Avatar>
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem onClick={() => navigate("/settings")}>
-                <Settings className="mr-2 h-4 w-4" />
-                Settings
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={handleSignOut}>
-                <LogOut className="mr-2 h-4 w-4" />
-                Sign out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <div className="flex items-center gap-2">
+            {isFounder && (
+              <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase text-primary">
+                Founder
+              </span>
+            )}
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon">
+                  <Avatar className="h-6 w-6">
+                    <AvatarImage src={user?.photoURL || ""} />
+                    <AvatarFallback>
+                      <User className="h-4 w-4" />
+                    </AvatarFallback>
+                  </Avatar>
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => navigate("/settings")}>
+                  <Settings className="mr-2 h-4 w-4" />
+                  Settings
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={handleSignOut}>
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sign out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
 
         {/* Navigation tabs - hidden on mobile, shown on desktop */}

--- a/src/pages/Plans.tsx
+++ b/src/pages/Plans.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { AppHeader } from "@/components/AppHeader";
 import { BottomNav } from "@/components/BottomNav";
 import { Seo } from "@/components/Seo";
-import { startCheckout } from "@/lib/payments";
+import { startCheckout, type CheckoutPlanKey } from "@/lib/payments";
 import { toast } from "@/hooks/use-toast";
 import { Check } from "lucide-react";
 import { useI18n } from "@/lib/i18n";
@@ -13,10 +13,10 @@ import { isDemoGuest } from "@/lib/demoFlag";
 
 export default function Plans() {
   const { t } = useI18n();
-  const handleCheckout = async (priceId: string, mode: "payment" | "subscription") => {
+  const handleCheckout = async (plan: CheckoutPlanKey, mode: "payment" | "subscription") => {
     try {
-      track("checkout_start", { plan: priceId });
-      await startCheckout(priceId, mode);
+      track("checkout_start", { plan });
+      await startCheckout(plan);
     } catch (err: any) {
       if (err?.message?.includes("Backend URL not configured")) {
         toast({
@@ -42,7 +42,7 @@ export default function Plans() {
       price: "$9.99",
       period: "one-time",
       credits: "1 scan credit",
-      priceId: "price_single_scan",
+      plan: "single" as const,
       mode: "payment" as const,
       features: ["1 body composition scan", "Detailed analysis", "Progress tracking"],
       description: "Perfect for trying out MyBodyScan",
@@ -57,7 +57,7 @@ export default function Plans() {
       originalPrice: "$24.99",
       period: "first month, then $24.99/mo",
       credits: "3 scans/month + Coach + Nutrition",
-      priceId: "price_monthly_intro",
+      plan: "monthly" as const,
       mode: "subscription" as const,
       features: [
         "3 scans per month",
@@ -76,7 +76,7 @@ export default function Plans() {
       price: "$199.99",
       period: "per year",
       credits: "3 scans/month + Everything included",
-      priceId: "price_annual",
+      plan: "yearly" as const,
       mode: "subscription" as const,
       popular: true,
       features: [
@@ -100,7 +100,7 @@ export default function Plans() {
       price: "$9.99",
       period: "one-time",
       credits: "1 scan credit",
-      priceId: "price_extra_scan",
+      plan: "extra" as const,
       mode: "payment" as const,
       features: ["Additional scan credit", "For existing subscribers", "Same detailed analysis"],
       description: "For subscribers who need extra scans",
@@ -174,7 +174,7 @@ export default function Plans() {
                 <Button
                   className="w-full"
                   variant={plan.popular ? "default" : "outline"}
-                  onClick={() => handleCheckout(plan.priceId, plan.mode)}
+                  onClick={() => handleCheckout(plan.plan, plan.mode)}
                 >
                   {plan.mode === "subscription" ? t('plans.subscribe') : t('plans.buyNow')}
                 </Button>


### PR DESCRIPTION
## Summary
- map checkout requests to plan keys, validate Stripe secrets, and surface config/internal errors with canonical return URLs
- log webhook events, add an auth trigger that auto-grants founder credits, and expose the new trigger for deployment
- update the web client to send plan keys, show friendly failure toasts, and display a Founder badge when applicable

## Testing
- `npm run build` *(fails: vite not found because npm install is blocked by 403 errors for @opentelemetry/semantic-conventions)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fc653d448325bda54b0b89468319