### PR TITLE
Add training programs catalog, detail view, and quiz

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -59,6 +59,9 @@ import Workouts from "./pages/Workouts";
 import Meals from "./pages/Meals";
 import Coach from "./pages/Coach";
 import CoachDay from "./pages/Coach/Day";
+import ProgramsCatalog from "./pages/Programs";
+import ProgramDetail from "./pages/Programs/Detail";
+import ProgramsQuiz from "./pages/Programs/Quiz";
 import Nutrition from "./pages/Nutrition";
 import { ConsentGate } from "./components/ConsentGate";
 import MealsSearch from "./pages/MealsSearch";
@@ -174,6 +177,48 @@ const App = () => {
                     <AuthedLayout>
                       <RouteBoundary>
                         <CoachDay />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
+              path="/programs"
+              element={
+                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ProgramsCatalog />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
+              path="/programs/quiz"
+              element={
+                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ProgramsQuiz />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
+              path="/programs/:id"
+              element={
+                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}>
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <ProgramDetail />
                       </RouteBoundary>
                     </AuthedLayout>
                   </ProtectedRoute>

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,4 +1,15 @@
-import { Home as HomeIcon, Camera, CalendarCheck, Dumbbell, Utensils, Bot, History, CreditCard, Settings } from "lucide-react";
+import {
+  Home as HomeIcon,
+  Camera,
+  CalendarCheck,
+  Dumbbell,
+  Utensils,
+  Bot,
+  History,
+  CreditCard,
+  Settings,
+  Layers,
+} from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { Link, useLocation } from "react-router-dom";
 import { cn } from "@/lib/utils";
@@ -10,6 +21,7 @@ const navItems: Array<{ path: string; icon: LucideIcon; label: string; feature?:
   { path: "/today", icon: CalendarCheck, label: "Today", feature: "health" },
   { path: "/meals", icon: Utensils, label: "Meals", feature: "nutrition" },
   { path: "/workouts", icon: Dumbbell, label: "Workouts", feature: "workouts" },
+  { path: "/programs", icon: Layers, label: "Programs", feature: "coach" },
   { path: "/coach", icon: Bot, label: "Coach", feature: "coach" },
   { path: "/history", icon: History, label: "History", feature: "scan" },
   { path: "/plans", icon: CreditCard, label: "Plans", feature: "account" },

--- a/src/content/programs/beginner-full-body.json
+++ b/src/content/programs/beginner-full-body.json
@@ -2,6 +2,21 @@
   "id": "beginner-full-body",
   "title": "Beginner Full Body",
   "goal": "hypertrophy",
+  "level": "beginner",
+  "equipment": ["barbell", "dumbbells", "machines"],
+  "durationPerSessionMin": 55,
+  "tags": ["Full body", "3-day split", "Strength foundations"],
+  "summary": "Three focused full-body sessions each week to build strength and muscle with classic compound lifts.",
+  "faqs": [
+    {
+      "question": "How many days a week will I train?",
+      "answer": "You will train three days each week with at least one rest day between sessions."
+    },
+    {
+      "question": "Is this friendly for beginners?",
+      "answer": "Yes. The program introduces key movement patterns with moderate volume so you can master form and progress safely."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/push-pull-legs.json
+++ b/src/content/programs/push-pull-legs.json
@@ -2,6 +2,21 @@
   "id": "push-pull-legs",
   "title": "Push / Pull / Legs",
   "goal": "hypertrophy",
+  "level": "intermediate",
+  "equipment": ["barbell", "dumbbells", "machines"],
+  "durationPerSessionMin": 65,
+  "tags": ["Push/pull/legs", "High volume", "Bodybuilding"],
+  "summary": "A classic push, pull, legs split that stacks volume across six weekly sessions for experienced lifters.",
+  "faqs": [
+    {
+      "question": "Can I reduce to five days?",
+      "answer": "You can drop one accessory-focused day when life gets busy and resume the full split the following week."
+    },
+    {
+      "question": "What if I am short on equipment?",
+      "answer": "Swap cable or machine accessories for dumbbell variations when needed and keep the compound lifts consistent."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/upper-lower.json
+++ b/src/content/programs/upper-lower.json
@@ -2,6 +2,21 @@
   "id": "upper-lower",
   "title": "Upper / Lower Split",
   "goal": "strength",
+  "level": "intermediate",
+  "equipment": ["barbell", "dumbbells", "machines"],
+  "durationPerSessionMin": 60,
+  "tags": ["Upper/lower", "Strength focus", "4-day split"],
+  "summary": "Alternating upper and lower body strength sessions with accessory finishers to drive progressive overload.",
+  "faqs": [
+    {
+      "question": "Who is this program best for?",
+      "answer": "Intermediate lifters who want a balanced mix of heavy compounds and hypertrophy accessories across four days."
+    },
+    {
+      "question": "Can I add cardio?",
+      "answer": "Yes, add light cardio on rest days or after lifts as long as it does not interfere with recovery."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -14,8 +14,12 @@ export interface CoachProfile {
   style?: "ease_in" | "all_in";
   medical_flags?: Record<string, boolean>;
   currentProgramId?: string;
+  activeProgramId?: string;
   lastCompletedWeekIdx?: number;
   lastCompletedDayIdx?: number;
+  currentWeekIdx?: number;
+  currentDayIdx?: number;
+  startedAt?: string;
 }
 
 export interface CoachPlan {

--- a/src/layouts/AuthedLayout.tsx
+++ b/src/layouts/AuthedLayout.tsx
@@ -19,6 +19,7 @@ const navItems: Array<{ to: string; label: string; feature?: FeatureName }> = [
   { to: "/today", label: "Today", feature: "health" },
   { to: "/meals", label: "Meals", feature: "nutrition" },
   { to: "/workouts", label: "Workouts", feature: "workouts" },
+  { to: "/programs", label: "Programs", feature: "coach" },
   { to: "/coach", label: "Coach", feature: "coach" },
   { to: "/history", label: "History", feature: "scan" },
   { to: "/plans", label: "Plans", feature: "account" },

--- a/src/lib/coach/catalog.ts
+++ b/src/lib/coach/catalog.ts
@@ -1,0 +1,187 @@
+import type {
+  Program,
+  ProgramEquipment,
+  ProgramGoal,
+  ProgramLevel,
+} from "@/lib/coach/types";
+
+export type ProgramMeta = {
+  id: string;
+  title: string;
+  goal: ProgramGoal;
+  level: ProgramLevel;
+  daysPerWeek: number;
+  weeks: number;
+  equipment: ProgramEquipment[];
+  durationPerSessionMin: number;
+  tags: string[];
+  heroImg?: string;
+};
+
+export type CatalogEntry = {
+  meta: ProgramMeta;
+  program: Program;
+};
+
+type ProgramModule = Program;
+
+const DEFAULT_LEVEL: ProgramLevel = "beginner";
+const DEFAULT_DURATION = 45;
+const DEFAULT_EQUIPMENT: ProgramEquipment[] = ["none"];
+
+const modules = import.meta.glob<ProgramModule>("@/content/programs/*.json", {
+  eager: true,
+  import: "default",
+});
+
+let cachedPrograms: CatalogEntry[] | null = null;
+
+function averageDaysPerWeek(program: Program): number {
+  const weeks = program.weeks.length;
+  if (!weeks) return 0;
+  const totalDays = program.weeks.reduce((acc, week) => acc + (week.days?.length ?? 0), 0);
+  if (!totalDays) return 0;
+  return Math.max(1, Math.round(totalDays / weeks));
+}
+
+function resolveLevel(program: Program): ProgramLevel {
+  return program.level ?? DEFAULT_LEVEL;
+}
+
+function resolveEquipment(program: Program): ProgramEquipment[] {
+  if (program.equipment?.length) {
+    return [...new Set(program.equipment)];
+  }
+  return DEFAULT_EQUIPMENT;
+}
+
+function resolveDuration(program: Program): number {
+  return program.durationPerSessionMin ?? DEFAULT_DURATION;
+}
+
+function resolveTags(program: Program): string[] {
+  return program.tags ?? [];
+}
+
+function buildMeta(program: Program): ProgramMeta {
+  return {
+    id: program.id,
+    title: program.title,
+    goal: program.goal,
+    level: resolveLevel(program),
+    daysPerWeek: averageDaysPerWeek(program),
+    weeks: program.weeks.length,
+    equipment: resolveEquipment(program),
+    durationPerSessionMin: resolveDuration(program),
+    tags: resolveTags(program),
+    heroImg: program.heroImg,
+  };
+}
+
+export async function loadAllPrograms(): Promise<CatalogEntry[]> {
+  if (cachedPrograms) {
+    return cachedPrograms;
+  }
+
+  const records: CatalogEntry[] = Object.values(modules).map((program) => {
+    const meta = buildMeta(program);
+    return { meta, program };
+  });
+
+  cachedPrograms = records;
+  return records;
+}
+
+const LEVEL_ORDER: Record<ProgramLevel, number> = {
+  beginner: 0,
+  intermediate: 1,
+  advanced: 2,
+};
+
+const SCORE_WEIGHTS = {
+  goal: 35,
+  level: 20,
+  days: 15,
+  equipment: 20,
+  time: 10,
+} as const;
+
+export function matchScore(
+  meta: ProgramMeta,
+  prefs: {
+    goal?: ProgramGoal;
+    level?: ProgramLevel;
+    days?: number;
+    equipment?: ProgramEquipment[];
+    time?: number;
+  }
+): number {
+  let score = 0;
+  let maxScore = 0;
+
+  if (prefs.goal) {
+    maxScore += SCORE_WEIGHTS.goal;
+    if (meta.goal === prefs.goal) {
+      score += SCORE_WEIGHTS.goal;
+    } else if (prefs.goal === "general" && meta.goal !== "general") {
+      score += SCORE_WEIGHTS.goal * 0.5;
+    }
+  }
+
+  if (prefs.level) {
+    maxScore += SCORE_WEIGHTS.level;
+    const target = LEVEL_ORDER[prefs.level];
+    const programLevel = LEVEL_ORDER[meta.level] ?? LEVEL_ORDER[DEFAULT_LEVEL];
+    const distance = Math.abs(target - programLevel);
+    if (distance === 0) {
+      score += SCORE_WEIGHTS.level;
+    } else if (distance === 1) {
+      score += SCORE_WEIGHTS.level * 0.6;
+    } else if (distance === 2) {
+      score += SCORE_WEIGHTS.level * 0.25;
+    }
+  }
+
+  if (typeof prefs.days === "number" && !Number.isNaN(prefs.days)) {
+    maxScore += SCORE_WEIGHTS.days;
+    const diff = Math.abs(meta.daysPerWeek - prefs.days);
+    if (diff === 0) {
+      score += SCORE_WEIGHTS.days;
+    } else if (diff === 1) {
+      score += SCORE_WEIGHTS.days * 0.7;
+    } else if (diff === 2) {
+      score += SCORE_WEIGHTS.days * 0.35;
+    }
+  }
+
+  if (prefs.equipment && prefs.equipment.length) {
+    maxScore += SCORE_WEIGHTS.equipment;
+    const required = meta.equipment.filter((item) => item !== "none");
+    if (!required.length) {
+      score += SCORE_WEIGHTS.equipment;
+    } else {
+      const owned = new Set(prefs.equipment);
+      const missing = required.filter((item) => !owned.has(item));
+      if (missing.length === 0) {
+        score += SCORE_WEIGHTS.equipment;
+      } else if (missing.length < required.length) {
+        score += SCORE_WEIGHTS.equipment * 0.5;
+      }
+    }
+  }
+
+  if (typeof prefs.time === "number" && prefs.time > 0) {
+    maxScore += SCORE_WEIGHTS.time;
+    if (meta.durationPerSessionMin <= prefs.time) {
+      score += SCORE_WEIGHTS.time;
+    } else if (meta.durationPerSessionMin <= prefs.time + 10) {
+      score += SCORE_WEIGHTS.time * 0.5;
+    }
+  }
+
+  if (maxScore === 0) {
+    return 50;
+  }
+
+  return Math.round((score / maxScore) * 100);
+}

--- a/src/lib/coach/types.ts
+++ b/src/lib/coach/types.ts
@@ -1,8 +1,33 @@
+export type ProgramGoal = "hypertrophy" | "strength" | "cut" | "general";
+
+export type ProgramLevel = "beginner" | "intermediate" | "advanced";
+
+export type ProgramEquipment =
+  | "none"
+  | "dumbbells"
+  | "kettlebells"
+  | "barbell"
+  | "machines"
+  | "bands";
+
+export interface ProgramFaq {
+  question: string;
+  answer: string;
+}
+
 export interface Program {
   id: string;
   title: string;
-  goal: "hypertrophy" | "strength" | "cut";
+  goal: ProgramGoal;
   weeks: Week[];
+  summary?: string;
+  description?: string;
+  level?: ProgramLevel;
+  equipment?: ProgramEquipment[];
+  durationPerSessionMin?: number;
+  tags?: string[];
+  heroImg?: string;
+  faqs?: ProgramFaq[];
 }
 
 export interface Week {

--- a/src/pages/Coach/index.tsx
+++ b/src/pages/Coach/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { CalendarDays, CheckCircle2, ChevronLeft, ChevronRight } from "lucide-react";
+import { CalendarDays, CheckCircle2, ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
 import { AppHeader } from "@/components/AppHeader";
 import { BottomNav } from "@/components/BottomNav";
 import { Seo } from "@/components/Seo";
@@ -14,21 +14,8 @@ import { toast } from "@/hooks/use-toast";
 import { auth, db } from "@/lib/firebase";
 import { cn } from "@/lib/utils";
 import type { Program } from "@/lib/coach/types";
-import beginnerFullBody from "@/content/programs/beginner-full-body.json";
-import upperLower from "@/content/programs/upper-lower.json";
-import pushPullLegs from "@/content/programs/push-pull-legs.json";
+import { loadAllPrograms, type CatalogEntry } from "@/lib/coach/catalog";
 import { doc, setDoc } from "firebase/firestore";
-
-const PROGRAMS: Program[] = [
-  beginnerFullBody as Program,
-  upperLower as Program,
-  pushPullLegs as Program,
-];
-
-const PROGRAM_MAP = PROGRAMS.reduce<Record<string, Program>>((acc, program) => {
-  acc[program.id] = program;
-  return acc;
-}, {});
 
 const DEFAULT_PROGRAM_ID = "beginner-full-body";
 
@@ -36,6 +23,7 @@ const goalCopy: Record<Program["goal"], string> = {
   hypertrophy: "Hypertrophy",
   strength: "Strength",
   cut: "Cut / Recomp",
+  general: "General Fitness",
 };
 
 function nextTargetFor(program: Program, lastWeek: number, lastDay: number) {
@@ -57,50 +45,90 @@ export default function CoachOverview() {
   const { profile } = useUserProfile();
   const navigate = useNavigate();
   const [hydrated, setHydrated] = useState(false);
-  const [selectedProgramId, setSelectedProgramId] = useState<string>(DEFAULT_PROGRAM_ID);
+  const [programEntries, setProgramEntries] = useState<CatalogEntry[]>([]);
+  const [isLoadingPrograms, setIsLoadingPrograms] = useState(true);
+  const [selectedProgramId, setSelectedProgramId] = useState<string | null>(null);
   const [weekIdx, setWeekIdx] = useState(0);
   const [isSaving, setIsSaving] = useState(false);
 
-  const program = useMemo(() => {
-    return PROGRAM_MAP[selectedProgramId] ?? PROGRAM_MAP[DEFAULT_PROGRAM_ID];
-  }, [selectedProgramId]);
+  useEffect(() => {
+    let isMounted = true;
+    setIsLoadingPrograms(true);
+    loadAllPrograms()
+      .then((entries) => {
+        if (!isMounted) return;
+        setProgramEntries(entries);
+      })
+      .finally(() => {
+        if (isMounted) {
+          setIsLoadingPrograms(false);
+        }
+      });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
-  const lastWeekForProgram = useMemo(() => {
-    if (!profile) return -1;
-    if (profile.currentProgramId !== program.id) return -1;
-    return typeof profile.lastCompletedWeekIdx === "number" ? profile.lastCompletedWeekIdx : -1;
-  }, [profile, program.id]);
-
-  const lastDayForProgram = useMemo(() => {
-    if (!profile) return -1;
-    if (profile.currentProgramId !== program.id) return -1;
-    return typeof profile.lastCompletedDayIdx === "number" ? profile.lastCompletedDayIdx : -1;
-  }, [profile, program.id]);
-
-  const nextTarget = useMemo(
-    () => nextTargetFor(program, lastWeekForProgram, lastDayForProgram),
-    [program, lastWeekForProgram, lastDayForProgram]
-  );
+  const programMap = useMemo(() => {
+    return programEntries.reduce<Record<string, CatalogEntry>>((acc, entry) => {
+      acc[entry.program.id] = entry;
+      return acc;
+    }, {});
+  }, [programEntries]);
 
   useEffect(() => {
-    if (!profile || hydrated) return;
-    const profileProgram = profile.currentProgramId && PROGRAM_MAP[profile.currentProgramId]
-      ? profile.currentProgramId
-      : DEFAULT_PROGRAM_ID;
-    setSelectedProgramId(profileProgram);
-    const initialWeek =
-      profile.currentProgramId === profileProgram && typeof profile.lastCompletedWeekIdx === "number"
-        ? Math.min(profile.lastCompletedWeekIdx, (PROGRAM_MAP[profileProgram]?.weeks.length || 1) - 1)
+    if (!programEntries.length) return;
+    setSelectedProgramId((prev) => prev ?? programEntries[0]?.program.id ?? DEFAULT_PROGRAM_ID);
+  }, [programEntries]);
+
+  const activeProgramId = profile?.activeProgramId ?? profile?.currentProgramId ?? null;
+
+  useEffect(() => {
+    if (!profile || !programEntries.length || hydrated) return;
+    const fallbackId = programEntries[0]?.program.id ?? DEFAULT_PROGRAM_ID;
+    const nextId = activeProgramId && programMap[activeProgramId] ? activeProgramId : fallbackId;
+    setSelectedProgramId(nextId);
+    const weeksInProgram = programMap[nextId]?.program.weeks.length ?? 1;
+    const initialWeek = typeof profile.currentWeekIdx === "number"
+      ? profile.currentWeekIdx
+      : typeof profile.lastCompletedWeekIdx === "number"
+        ? profile.lastCompletedWeekIdx
         : 0;
-    setWeekIdx(Math.max(0, initialWeek));
+    setWeekIdx(Math.max(0, Math.min(initialWeek, Math.max(weeksInProgram - 1, 0))));
     setHydrated(true);
-  }, [profile, hydrated]);
+  }, [profile, programEntries, hydrated, programMap, activeProgramId]);
+
+  const selectedEntry = selectedProgramId ? programMap[selectedProgramId] : undefined;
+  const program = selectedEntry?.program;
+  const meta = selectedEntry?.meta;
 
   useEffect(() => {
+    if (!program) return;
     if (!program.weeks[weekIdx]) {
-      setWeekIdx(program.weeks.length ? program.weeks.length - 1 : 0);
+      setWeekIdx(program.weeks.length ? Math.max(0, program.weeks.length - 1) : 0);
     }
   }, [program, weekIdx]);
+
+  const lastWeekForProgram = useMemo(() => {
+    if (!profile || !program) return -1;
+    if (activeProgramId !== program.id) return -1;
+    if (typeof profile.lastCompletedWeekIdx === "number") return profile.lastCompletedWeekIdx;
+    if (typeof profile.currentWeekIdx === "number") return profile.currentWeekIdx;
+    return -1;
+  }, [profile, program?.id, activeProgramId]);
+
+  const lastDayForProgram = useMemo(() => {
+    if (!profile || !program) return -1;
+    if (activeProgramId !== program.id) return -1;
+    if (typeof profile.lastCompletedDayIdx === "number") return profile.lastCompletedDayIdx;
+    if (typeof profile.currentDayIdx === "number") return profile.currentDayIdx;
+    return -1;
+  }, [profile, program?.id, activeProgramId]);
+
+  const nextTarget = useMemo(() => {
+    if (!program) return { weekIdx: 0, dayIdx: 0 };
+    return nextTargetFor(program, lastWeekForProgram, lastDayForProgram);
+  }, [program, lastWeekForProgram, lastDayForProgram]);
 
   const persistProfile = async (partial: Record<string, unknown>) => {
     const user = auth.currentUser;
@@ -118,7 +146,12 @@ export default function CoachOverview() {
   const handleProgramChange = (value: string) => {
     setSelectedProgramId(value);
     setWeekIdx(0);
-    persistProfile({ currentProgramId: value });
+    persistProfile({
+      currentProgramId: value,
+      activeProgramId: value,
+      currentWeekIdx: 0,
+      currentDayIdx: 0,
+    });
   };
 
   const handlePrevWeek = () => {
@@ -126,14 +159,22 @@ export default function CoachOverview() {
   };
 
   const handleNextWeek = () => {
+    if (!program) return;
     setWeekIdx((idx) => Math.min(program.weeks.length - 1, idx + 1));
   };
 
   const handleOpenDay = (dayIdx: number) => {
+    if (!program) return;
     navigate(`/coach/day?programId=${program.id}&week=${weekIdx}&day=${dayIdx}`);
   };
 
-  const currentWeek = program.weeks[weekIdx] ?? program.weeks[0];
+  const currentWeek = program?.weeks[weekIdx] ?? program?.weeks[0];
+  const totalWeeks = program?.weeks.length ?? meta?.weeks ?? 0;
+  const daysThisWeek = currentWeek?.days.length ?? 0;
+  const maxWeekIndex = totalWeeks > 0 ? totalWeeks - 1 : 0;
+  const displayWeekCount = totalWeeks > 0 ? totalWeeks : 1;
+  const displayWeekIndex = totalWeeks > 0 ? Math.min(weekIdx + 1, totalWeeks) : 1;
+  const showEmptyState = !isLoadingPrograms && !program;
 
   return (
     <div className="min-h-screen bg-background pb-16 md:pb-0">
@@ -141,6 +182,31 @@ export default function CoachOverview() {
       <AppHeader />
       <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-6">
         <NotMedicalAdviceBanner />
+        {profile && !activeProgramId && (
+          <Card className="border border-dashed border-primary/40 bg-primary/5">
+            <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-start gap-3">
+                <div className="rounded-full bg-primary/10 p-2 text-primary">
+                  <Sparkles className="h-4 w-4" />
+                </div>
+                <div>
+                  <p className="text-sm font-semibold text-foreground">Choose your training plan</p>
+                  <p className="text-xs text-muted-foreground">
+                    Take the quick quiz or browse all programs to set your next block.
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+                <Button size="sm" onClick={() => navigate("/programs/quiz")}>
+                  Take 60-sec quiz
+                </Button>
+                <Button size="sm" variant="outline" onClick={() => navigate("/programs")}> 
+                  Browse programs
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        )}
         <header className="flex flex-col gap-4 rounded-lg border bg-card/40 p-5">
           <div className="flex items-start justify-between gap-4">
             <div>
@@ -153,23 +219,32 @@ export default function CoachOverview() {
                 Dialed-in bodybuilding days with detailed lifts and recovery guidance.
               </p>
             </div>
-            <Badge variant="secondary">{goalCopy[program.goal]}</Badge>
+            {program && <Badge variant="secondary">{goalCopy[program.goal]}</Badge>}
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <Select value={program.id} onValueChange={handleProgramChange} disabled={isSaving}>
+            <Select
+              value={program?.id}
+              onValueChange={handleProgramChange}
+              disabled={isSaving || isLoadingPrograms || !programEntries.length}
+            >
               <SelectTrigger className="w-full sm:w-64">
-                <SelectValue placeholder="Select program" />
+                <SelectValue placeholder={isLoadingPrograms ? "Loading programs..." : "Select program"} />
               </SelectTrigger>
               <SelectContent>
-                {PROGRAMS.map((item) => (
-                  <SelectItem key={item.id} value={item.id}>
-                    {item.title}
+                {programEntries.map((entry) => (
+                  <SelectItem key={entry.program.id} value={entry.program.id}>
+                    {entry.program.title}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
             <p className="text-xs text-muted-foreground">
-              {program.weeks.length} weeks • {currentWeek?.days.length ?? 0} days this week
+              {totalWeeks
+                ? `${totalWeeks} weeks`
+                : isLoadingPrograms
+                  ? "Loading schedule..."
+                  : "Program length TBD"}
+              {" "}• {daysThisWeek} days this week
             </p>
           </div>
         </header>
@@ -178,7 +253,7 @@ export default function CoachOverview() {
           <div>
             <p className="text-xs uppercase tracking-wide text-muted-foreground">Current Week</p>
             <p className="text-lg font-semibold">
-              Week {weekIdx + 1} of {program.weeks.length}
+              Week {displayWeekIndex} of {displayWeekCount}
             </p>
             {nextTarget.weekIdx === weekIdx && (
               <p className="text-xs text-muted-foreground">
@@ -194,74 +269,88 @@ export default function CoachOverview() {
               variant="outline"
               size="sm"
               onClick={handleNextWeek}
-              disabled={weekIdx >= program.weeks.length - 1}
+              disabled={!program || weekIdx >= maxWeekIndex}
             >
               Next <ChevronRight className="ml-1 h-4 w-4" />
             </Button>
           </div>
         </section>
 
-        <div className="space-y-4">
-          {currentWeek?.days.map((day, dayIdx) => {
-            const totalExercises = day.blocks.reduce(
-              (count, block) => count + block.exercises.length,
-              0
-            );
-            const totalSets = day.blocks.reduce(
-              (count, block) =>
-                count + block.exercises.reduce((sum, exercise) => sum + exercise.sets, 0),
-              0
-            );
-            const completed =
-              lastWeekForProgram > weekIdx ||
-              (lastWeekForProgram === weekIdx && lastDayForProgram >= dayIdx);
-            const isNextTarget = nextTarget.weekIdx === weekIdx && nextTarget.dayIdx === dayIdx;
-            return (
-              <Card
-                key={dayIdx}
-                role="button"
-                tabIndex={0}
-                onClick={() => handleOpenDay(dayIdx)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    handleOpenDay(dayIdx);
-                  }
-                }}
-                className={cn(
-                  "group cursor-pointer border transition hover:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50",
-                  completed && "border-muted-foreground/40",
-                  isNextTarget && "border-primary shadow-sm"
-                )}
-              >
-                <CardHeader className="flex flex-row items-center justify-between space-y-0">
-                  <CardTitle className="text-xl">{day.name}</CardTitle>
-                  {completed ? (
-                    <span className="flex items-center gap-1 text-sm text-muted-foreground">
-                      <CheckCircle2 className="h-4 w-4 text-primary" /> Completed
-                    </span>
-                  ) : (
-                    <span className="text-sm text-muted-foreground">Tap to start</span>
-                  )}
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  {day.blocks.map((block, blockIdx) => (
-                    <div key={blockIdx} className="rounded-md bg-muted/50 p-3">
-                      <p className="text-sm font-medium text-foreground">{block.title}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {block.exercises.map((exercise) => exercise.name).join(" • ")}
-                      </p>
-                    </div>
-                  ))}
-                  <div className="flex items-center justify-between text-xs text-muted-foreground">
-                    <span>{totalExercises} exercises</span>
-                    <span>{totalSets} total sets</span>
-                  </div>
+        {showEmptyState ? (
+          <Card className="rounded-lg border border-dashed bg-muted/40 p-6 text-center text-sm text-muted-foreground">
+            <p>Select a program to see your upcoming training days.</p>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {currentWeek && currentWeek.days.length ? (
+              currentWeek.days.map((day, dayIdx) => {
+                const totalExercises = day.blocks.reduce(
+                  (count, block) => count + block.exercises.length,
+                  0
+                );
+                const totalSets = day.blocks.reduce(
+                  (count, block) =>
+                    count + block.exercises.reduce((sum, exercise) => sum + exercise.sets, 0),
+                  0
+                );
+                const completed =
+                  lastWeekForProgram > weekIdx ||
+                  (lastWeekForProgram === weekIdx && lastDayForProgram >= dayIdx);
+                const isNextTarget = nextTarget.weekIdx === weekIdx && nextTarget.dayIdx === dayIdx;
+                return (
+                  <Card
+                    key={dayIdx}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => handleOpenDay(dayIdx)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        handleOpenDay(dayIdx);
+                      }
+                    }}
+                    className={cn(
+                      "group cursor-pointer border transition hover:border-primary focus:outline-none focus:ring-2 focus:ring-primary/50",
+                      completed && "border-muted-foreground/40",
+                      isNextTarget && "border-primary shadow-sm"
+                    )}
+                  >
+                    <CardHeader className="flex flex-row items-center justify-between space-y-0">
+                      <CardTitle className="text-xl">{day.name}</CardTitle>
+                      {completed ? (
+                        <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                          <CheckCircle2 className="h-4 w-4 text-primary" /> Completed
+                        </span>
+                      ) : (
+                        <span className="text-sm text-muted-foreground">Tap to start</span>
+                      )}
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                      {day.blocks.map((block, blockIdx) => (
+                        <div key={blockIdx} className="rounded-md bg-muted/50 p-3">
+                          <p className="text-sm font-medium text-foreground">{block.title}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {block.exercises.map((exercise) => exercise.name).join(" • ")}
+                          </p>
+                        </div>
+                      ))}
+                      <div className="flex items-center justify-between text-xs text-muted-foreground">
+                        <span>{totalExercises} exercises</span>
+                        <span>{totalSets} total sets</span>
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })
+            ) : (
+              <Card className="border bg-card/40">
+                <CardContent className="p-6 text-sm text-muted-foreground">
+                  No scheduled training days for this week.
                 </CardContent>
               </Card>
-            );
-          })}
-        </div>
+            )}
+          </div>
+        )}
       </main>
       <BottomNav />
     </div>

--- a/src/pages/Programs/Detail.tsx
+++ b/src/pages/Programs/Detail.tsx
@@ -1,0 +1,347 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, CheckCircle2, Info } from "lucide-react";
+import { AppHeader } from "@/components/AppHeader";
+import { BottomNav } from "@/components/BottomNav";
+import { Seo } from "@/components/Seo";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { Separator } from "@/components/ui/separator";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { loadAllPrograms, type CatalogEntry } from "@/lib/coach/catalog";
+import type { Program, ProgramEquipment, ProgramFaq } from "@/lib/coach/types";
+import { auth, db } from "@/lib/firebase";
+import { doc, setDoc } from "firebase/firestore";
+import { toast } from "@/hooks/use-toast";
+
+const equipmentLabels: Record<ProgramEquipment, string> = {
+  none: "Bodyweight",
+  dumbbells: "Dumbbells",
+  kettlebells: "Kettlebells",
+  barbell: "Barbell",
+  machines: "Machines",
+  bands: "Bands",
+};
+
+const goalLabels: Record<Program["goal"], string> = {
+  hypertrophy: "Hypertrophy",
+  strength: "Strength",
+  cut: "Cut / Recomp",
+  general: "General Fitness",
+};
+
+const levelLabels = {
+  beginner: "Beginner",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+};
+
+function formatDuration(minutes: number | undefined) {
+  if (!minutes) return "~45 min";
+  if (minutes % 15 === 0) return `${minutes} min sessions`;
+  return `~${minutes} min sessions`;
+}
+
+function firstTrainingDay(program: Program) {
+  for (const week of program.weeks) {
+    const day = week.days?.[0];
+    if (day) return day;
+  }
+  return program.weeks[0]?.days?.[0];
+}
+
+export default function ProgramDetail() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const [entry, setEntry] = useState<CatalogEntry | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    loadAllPrograms()
+      .then((items) => {
+        if (!mounted) return;
+        const match = items.find((item) => item.meta.id === id);
+        setEntry(match ?? null);
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [id]);
+
+  const program = entry?.program;
+  const meta = entry?.meta;
+
+  const sampleDay = useMemo(() => (program ? firstTrainingDay(program) : null), [program]);
+
+  const handleStartProgram = async () => {
+    if (!program || !meta) return;
+    const user = auth.currentUser;
+    if (!user) {
+      toast({ title: "Sign in required", description: "Log in to save your training program." });
+      return;
+    }
+    try {
+      setIsSaving(true);
+      await setDoc(
+        doc(db, "users", user.uid, "coach", "profile"),
+        {
+          currentProgramId: program.id,
+          activeProgramId: program.id,
+          startedAt: new Date().toISOString(),
+          currentWeekIdx: 0,
+          currentDayIdx: 0,
+          lastCompletedWeekIdx: -1,
+          lastCompletedDayIdx: -1,
+        },
+        { merge: true }
+      );
+      toast({ title: "Program started", description: `${program.title} is now your active plan.` });
+      navigate("/coach", { replace: true });
+    } catch (error) {
+      toast({
+        title: "Could not start program",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const handlePreview = () => {
+    if (!program) return;
+    navigate(`/coach/day?programId=${program.id}&week=0&day=0`);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-background pb-16 md:pb-0">
+        <Seo title="Programs – MyBodyScan" description="Browse structured training programs." />
+        <AppHeader />
+        <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+          <div className="h-64 animate-pulse rounded-lg bg-muted/50" />
+          <div className="space-y-4">
+            <div className="h-10 w-1/2 animate-pulse rounded bg-muted/40" />
+            <div className="h-32 animate-pulse rounded bg-muted/40" />
+          </div>
+        </main>
+        <BottomNav />
+      </div>
+    );
+  }
+
+  if (!entry || !program || !meta) {
+    return (
+      <div className="min-h-screen bg-background pb-16 md:pb-0">
+        <Seo title="Program not found – MyBodyScan" description="Program details." />
+        <AppHeader />
+        <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-6">
+          <Button variant="ghost" className="w-fit" onClick={() => navigate(-1)}>
+            <ArrowLeft className="mr-2 h-4 w-4" />
+            Back to programs
+          </Button>
+          <Card>
+            <CardContent className="p-8 text-center text-sm text-muted-foreground">
+              We couldn't find that program. Browse the catalog to pick another option.
+            </CardContent>
+          </Card>
+        </main>
+        <BottomNav />
+      </div>
+    );
+  }
+
+  const equipment = meta.equipment.length ? meta.equipment : ["none"];
+
+  return (
+    <div className="min-h-screen bg-background pb-16 md:pb-0">
+      <Seo title={`${program.title} – MyBodyScan`} description={program.summary ?? "Training program details"} />
+      <AppHeader />
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+        <Button variant="ghost" className="w-fit" onClick={() => navigate(-1)}>
+          <ArrowLeft className="mr-2 h-4 w-4" /> Back to programs
+        </Button>
+
+        <Card className="overflow-hidden border bg-card/60">
+          <AspectRatio ratio={16 / 7}>
+            {meta.heroImg ? (
+              <img src={meta.heroImg} alt={program.title} className="h-full w-full object-cover" />
+            ) : (
+              <div className="h-full w-full bg-gradient-to-br from-primary/20 via-primary/5 to-background" />
+            )}
+          </AspectRatio>
+          <CardHeader className="space-y-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <CardTitle className="text-3xl font-semibold">{program.title}</CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  {program.summary ?? `A ${meta.daysPerWeek}-day plan for ${levelLabels[meta.level]}.`}
+                </p>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Badge variant="secondary">{goalLabels[program.goal]}</Badge>
+                <Badge variant="outline">{levelLabels[meta.level]}</Badge>
+                <Badge variant="outline">{meta.daysPerWeek} days / wk</Badge>
+                <Badge variant="outline">{meta.weeks} weeks</Badge>
+                <Badge variant="outline">{formatDuration(meta.durationPerSessionMin)}</Badge>
+              </div>
+            </div>
+            {program.description && (
+              <p className="text-sm text-muted-foreground">{program.description}</p>
+            )}
+          </CardHeader>
+        </Card>
+
+        <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <Card className="border bg-card/60">
+            <CardHeader>
+              <CardTitle className="text-xl">Weekly schedule overview</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-20">Week</TableHead>
+                    <TableHead>Training Days</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {program.weeks.map((week, index) => (
+                    <TableRow key={index}>
+                      <TableCell className="font-medium">Week {index + 1}</TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {week.days.map((day) => day.name).join(" • ")}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          <Card className="border bg-card/60">
+            <CardHeader>
+              <CardTitle className="text-xl">Required equipment</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <p className="text-sm text-muted-foreground">
+                You’ll primarily need:
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {equipment.map((item) => (
+                  <Badge key={item} variant="outline" className="capitalize">
+                    {equipmentLabels[item] ?? item}
+                  </Badge>
+                ))}
+              </div>
+              <p className="text-xs text-muted-foreground">
+                Swap accessories as needed to match your gym setup.
+              </p>
+            </CardContent>
+          </Card>
+        </section>
+
+        <Card className="border bg-card/60">
+          <CardHeader>
+            <CardTitle className="text-xl">Sample training day</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {sampleDay ? (
+              <Accordion type="single" collapsible defaultValue="day-1">
+                <AccordionItem value="day-1">
+                  <AccordionTrigger className="text-left text-base font-medium">
+                    {sampleDay.name}
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4 pt-4">
+                    {sampleDay.blocks.map((block, blockIdx) => (
+                      <div key={blockIdx} className="rounded-md border bg-muted/40 p-4">
+                        <p className="text-sm font-semibold text-foreground">{block.title}</p>
+                        <Separator className="my-2" />
+                        <ul className="space-y-2 text-sm text-muted-foreground">
+                          {block.exercises.map((exercise, exerciseIdx) => (
+                            <li key={exerciseIdx} className="flex items-start justify-between gap-4">
+                              <span>{exercise.name}</span>
+                              <span className="text-xs uppercase tracking-wide">
+                                {exercise.sets} × {exercise.reps}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    ))}
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            ) : (
+              <p className="text-sm text-muted-foreground">No training days provided.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        {program.faqs && program.faqs.length > 0 && (
+          <Card className="border bg-card/60">
+            <CardHeader>
+              <CardTitle className="text-xl">FAQs</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <Accordion type="single" collapsible>
+                {program.faqs.map((faq: ProgramFaq, index) => (
+                  <AccordionItem key={index} value={`faq-${index}`}>
+                    <AccordionTrigger className="text-left text-sm font-medium">
+                      {faq.question}
+                    </AccordionTrigger>
+                    <AccordionContent className="text-sm text-muted-foreground">
+                      {faq.answer}
+                    </AccordionContent>
+                  </AccordionItem>
+                ))}
+              </Accordion>
+            </CardContent>
+          </Card>
+        )}
+
+        <Card className="border bg-card/60">
+          <CardContent className="flex flex-col gap-4 p-6 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-start gap-3">
+              <Info className="mt-1 h-5 w-5 text-primary" />
+              <p className="text-sm text-muted-foreground">
+                Starting this program keeps your past logs intact and resets your weekly schedule to week 1.
+              </p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <Button size="sm" variant="outline" onClick={handlePreview}>
+                Preview week 1
+              </Button>
+              <Button size="sm" onClick={handleStartProgram} disabled={isSaving}>
+                <CheckCircle2 className="mr-2 h-4 w-4" /> Start program
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/pages/Programs/Quiz.tsx
+++ b/src/pages/Programs/Quiz.tsx
@@ -1,0 +1,330 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Sparkles, ChevronRight, CheckCircle2 } from "lucide-react";
+import { AppHeader } from "@/components/AppHeader";
+import { BottomNav } from "@/components/BottomNav";
+import { Seo } from "@/components/Seo";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
+import { Checkbox } from "@/components/ui/checkbox";
+import { loadAllPrograms, matchScore, type CatalogEntry } from "@/lib/coach/catalog";
+import type { ProgramEquipment, ProgramGoal, ProgramLevel } from "@/lib/coach/types";
+import { auth, db } from "@/lib/firebase";
+import { doc, setDoc } from "firebase/firestore";
+import { toast } from "@/hooks/use-toast";
+
+const goalOptions: Array<{ value: ProgramGoal; label: string; description: string }> = [
+  { value: "hypertrophy", label: "Build muscle", description: "Hypertrophy-focused growth" },
+  { value: "strength", label: "Get stronger", description: "Prioritize heavier compounds" },
+  { value: "cut", label: "Lean out", description: "Maintain muscle while cutting" },
+  { value: "general", label: "Stay balanced", description: "General fitness and training" },
+];
+
+const levelOptions: Array<{ value: ProgramLevel; label: string; description: string }> = [
+  { value: "beginner", label: "New lifter", description: "Under 1 year of training" },
+  { value: "intermediate", label: "Intermediate", description: "1-3 years under the bar" },
+  { value: "advanced", label: "Advanced", description: "3+ years with structured training" },
+];
+
+const equipmentOptions: Array<{ value: ProgramEquipment; label: string }> = [
+  { value: "none", label: "Bodyweight" },
+  { value: "dumbbells", label: "Dumbbells" },
+  { value: "kettlebells", label: "Kettlebells" },
+  { value: "barbell", label: "Barbell" },
+  { value: "machines", label: "Machines" },
+  { value: "bands", label: "Bands" },
+];
+
+type QuizResult = {
+  entry: CatalogEntry;
+  score: number;
+  reasons: string[];
+};
+
+export default function ProgramsQuiz() {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const [entries, setEntries] = useState<CatalogEntry[]>([]);
+  const [goal, setGoal] = useState<ProgramGoal>("hypertrophy");
+  const [level, setLevel] = useState<ProgramLevel>("beginner");
+  const [daysPerWeek, setDaysPerWeek] = useState<number>(4);
+  const [ownedEquipment, setOwnedEquipment] = useState<ProgramEquipment[]>([]);
+  const [sessionTime, setSessionTime] = useState<number>(45);
+  const [results, setResults] = useState<QuizResult[] | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    loadAllPrograms()
+      .then((items) => {
+        if (!mounted) return;
+        setEntries(items);
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const toggleEquipment = (value: ProgramEquipment) => {
+    setOwnedEquipment((prev) =>
+      prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
+    );
+  };
+
+  const computeReasons = (entry: CatalogEntry, score: number): string[] => {
+    const reasons: string[] = [];
+    const { meta } = entry;
+    if (meta.goal === goal) reasons.push("Matches your goal");
+    if (Math.abs(meta.daysPerWeek - daysPerWeek) <= 1) {
+      reasons.push(`Fits your ${daysPerWeek}-day routine`);
+    }
+    if (meta.level === level) {
+      reasons.push(`${levelOptions.find((item) => item.value === level)?.label} friendly`);
+    }
+    const required = meta.equipment.filter((item) => item !== "none");
+    if (!required.length) {
+      reasons.push("No equipment required");
+    } else if (required.every((item) => ownedEquipment.includes(item))) {
+      reasons.push("Uses equipment you already own");
+    }
+    if (meta.durationPerSessionMin <= sessionTime) {
+      reasons.push("Stays within your time limit");
+    }
+    if (score >= 85 && !reasons.includes("High match score")) {
+      reasons.push("High match score");
+    }
+    return reasons.slice(0, 3);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!entries.length) return;
+    const ranked = entries
+      .map((entry) => {
+        const score = matchScore(entry.meta, {
+          goal,
+          level,
+          days: daysPerWeek,
+          equipment: ownedEquipment.length ? ownedEquipment : undefined,
+          time: sessionTime,
+        });
+        return {
+          entry,
+          score,
+        };
+      })
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 3)
+      .map((item) => ({
+        ...item,
+        reasons: computeReasons(item.entry, item.score),
+      }));
+    setResults(ranked);
+  };
+
+  const topRecommendation = results?.[0] ?? null;
+
+  const handleStartRecommended = async () => {
+    if (!topRecommendation) return;
+    const user = auth.currentUser;
+    if (!user) {
+      toast({ title: "Sign in required", description: "Log in to save your program." });
+      return;
+    }
+    try {
+      setIsSaving(true);
+      await setDoc(
+        doc(db, "users", user.uid, "coach", "profile"),
+        {
+          currentProgramId: topRecommendation.entry.program.id,
+          activeProgramId: topRecommendation.entry.program.id,
+          startedAt: new Date().toISOString(),
+          currentWeekIdx: 0,
+          currentDayIdx: 0,
+          lastCompletedWeekIdx: -1,
+          lastCompletedDayIdx: -1,
+        },
+        { merge: true }
+      );
+      toast({
+        title: "Program selected",
+        description: `${topRecommendation.entry.program.title} is ready in Coach.`,
+      });
+      navigate("/coach", { replace: true });
+    } catch (error) {
+      toast({
+        title: "Unable to start program",
+        description: "Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-background pb-16 md:pb-0">
+      <Seo title="Program quiz – MyBodyScan" description="Find the right training plan in under a minute." />
+      <AppHeader />
+      <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-6">
+        <Card className="border bg-card/60">
+          <CardHeader className="space-y-2">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-primary">
+              <Sparkles className="h-4 w-4" /> Quick quiz
+            </div>
+            <CardTitle className="text-3xl font-semibold">Find your next program</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              Answer five questions and we’ll recommend the top three blocks for your goals.
+            </p>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <section className="space-y-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Goal</h2>
+                <RadioGroup value={goal} onValueChange={(value) => setGoal(value as ProgramGoal)} className="grid gap-2 md:grid-cols-2">
+                  {goalOptions.map((option) => (
+                    <Label
+                      key={option.value}
+                      htmlFor={`goal-${option.value}`}
+                      className="flex cursor-pointer flex-col gap-1 rounded-md border bg-card px-4 py-3 text-sm transition hover:border-primary"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="font-medium text-foreground">{option.label}</span>
+                        <RadioGroupItem value={option.value} id={`goal-${option.value}`} />
+                      </div>
+                      <span className="text-xs text-muted-foreground">{option.description}</span>
+                    </Label>
+                  ))}
+                </RadioGroup>
+              </section>
+
+              <section className="space-y-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Experience level</h2>
+                <RadioGroup value={level} onValueChange={(value) => setLevel(value as ProgramLevel)} className="grid gap-2 md:grid-cols-3">
+                  {levelOptions.map((option) => (
+                    <Label
+                      key={option.value}
+                      htmlFor={`level-${option.value}`}
+                      className="flex cursor-pointer flex-col gap-1 rounded-md border bg-card px-4 py-3 text-sm transition hover:border-primary"
+                    >
+                      <div className="flex items-center justify-between gap-3">
+                        <span className="font-medium text-foreground">{option.label}</span>
+                        <RadioGroupItem value={option.value} id={`level-${option.value}`} />
+                      </div>
+                      <span className="text-xs text-muted-foreground">{option.description}</span>
+                    </Label>
+                  ))}
+                </RadioGroup>
+              </section>
+
+              <section className="space-y-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Days per week</h2>
+                <div className="space-y-3 rounded-md border bg-muted/40 px-4 py-5">
+                  <Slider min={2} max={6} step={1} value={[daysPerWeek]} onValueChange={(value) => setDaysPerWeek(value[0] ?? 4)} />
+                  <p className="text-xs text-muted-foreground">{daysPerWeek} training days (±1 wiggle room)</p>
+                </div>
+              </section>
+
+              <section className="space-y-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Equipment you have</h2>
+                <div className="grid gap-2 md:grid-cols-3">
+                  {equipmentOptions.map((option) => (
+                    <Label
+                      key={option.value}
+                      htmlFor={`equipment-${option.value}`}
+                      className="flex cursor-pointer items-center gap-2 rounded-md border bg-card px-3 py-2 text-sm transition hover:border-primary"
+                    >
+                      <Checkbox
+                        id={`equipment-${option.value}`}
+                        checked={ownedEquipment.includes(option.value)}
+                        onCheckedChange={() => toggleEquipment(option.value)}
+                      />
+                      <span>{option.label}</span>
+                    </Label>
+                  ))}
+                </div>
+                {ownedEquipment.length === 0 && (
+                  <p className="text-xs text-muted-foreground">Select anything you can access, or leave blank for bodyweight only.</p>
+                )}
+              </section>
+
+              <section className="space-y-3">
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">Time per session</h2>
+                <div className="space-y-3 rounded-md border bg-muted/40 px-4 py-5">
+                  <Slider min={20} max={75} step={5} value={[sessionTime]} onValueChange={(value) => setSessionTime(value[0] ?? 45)} />
+                  <p className="text-xs text-muted-foreground">Up to {sessionTime} minutes each workout</p>
+                </div>
+              </section>
+
+              <div className="flex items-center justify-between">
+                <Button type="button" variant="ghost" onClick={() => setResults(null)} disabled={!results}>
+                  Reset results
+                </Button>
+                <Button type="submit" disabled={isLoading}>
+                  See my matches <ChevronRight className="ml-2 h-4 w-4" />
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        {results && (
+          <Card className="border bg-card/60">
+            <CardHeader>
+              <CardTitle className="text-xl">Your top programs</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {results.map((item, index) => (
+                <div key={item.entry.meta.id} className="rounded-lg border bg-background/60 p-4 shadow-sm">
+                  <div className="flex flex-wrap items-center justify-between gap-3">
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-lg font-semibold text-foreground">{item.entry.program.title}</h3>
+                        {index === 0 && <Badge variant="secondary">Top pick</Badge>}
+                      </div>
+                      <p className="text-xs text-muted-foreground">Match score: {item.score}%</p>
+                    </div>
+                    <Button variant="ghost" size="sm" onClick={() => navigate(`/programs/${item.entry.meta.id}`)}>
+                      View details
+                    </Button>
+                  </div>
+                  {item.reasons.length > 0 && (
+                    <ul className="mt-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      {item.reasons.map((reason) => (
+                        <li key={reason} className="flex items-center gap-1 rounded-full bg-muted px-2 py-1">
+                          <CheckCircle2 className="h-3 w-3 text-primary" />
+                          <span>{reason}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              ))}
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-sm text-muted-foreground">
+                  Start your top pick now or keep browsing the full catalog.
+                </p>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button variant="outline" size="sm" onClick={() => navigate("/programs")}>View catalog</Button>
+                  <Button size="sm" onClick={handleStartRecommended} disabled={!topRecommendation || isSaving}>
+                    Start recommended
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/pages/Programs/index.tsx
+++ b/src/pages/Programs/index.tsx
@@ -1,0 +1,330 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Filter, SlidersHorizontal } from "lucide-react";
+import { AppHeader } from "@/components/AppHeader";
+import { BottomNav } from "@/components/BottomNav";
+import { Seo } from "@/components/Seo";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { AspectRatio } from "@/components/ui/aspect-ratio";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { loadAllPrograms, matchScore, type CatalogEntry, type ProgramMeta } from "@/lib/coach/catalog";
+import type { Program, ProgramEquipment, ProgramGoal, ProgramLevel } from "@/lib/coach/types";
+
+const goalLabels: Record<ProgramGoal, string> = {
+  hypertrophy: "Hypertrophy",
+  strength: "Strength",
+  cut: "Cut / Recomp",
+  general: "General Fitness",
+};
+
+const levelLabels: Record<ProgramLevel, string> = {
+  beginner: "Beginner",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+};
+
+const EQUIPMENT_OPTIONS: Array<{ value: ProgramEquipment; label: string }> = [
+  { value: "none", label: "Bodyweight" },
+  { value: "dumbbells", label: "Dumbbells" },
+  { value: "kettlebells", label: "Kettlebells" },
+  { value: "barbell", label: "Barbell" },
+  { value: "machines", label: "Machines" },
+  { value: "bands", label: "Bands" },
+];
+
+type GoalFilter = "all" | ProgramGoal;
+type LevelFilter = "all" | ProgramLevel;
+
+type RankedProgram = {
+  entry: CatalogEntry;
+  score: number;
+};
+
+const hasHeroImage = (meta: ProgramMeta) => Boolean(meta.heroImg);
+
+const deriveSummary = (program: Program, meta: ProgramMeta) => {
+  if (program.summary) return program.summary;
+  return `A ${meta.daysPerWeek}-day, ${meta.weeks}-week plan focused on ${goalLabels[meta.goal].toLowerCase()}.`;
+};
+
+export default function ProgramsCatalog() {
+  const navigate = useNavigate();
+  const [isLoading, setIsLoading] = useState(true);
+  const [entries, setEntries] = useState<CatalogEntry[]>([]);
+  const [goalFilter, setGoalFilter] = useState<GoalFilter>("all");
+  const [levelFilter, setLevelFilter] = useState<LevelFilter>("all");
+  const [daysFilter, setDaysFilter] = useState<number | null>(null);
+  const [equipmentFilter, setEquipmentFilter] = useState<ProgramEquipment[]>([]);
+
+  useEffect(() => {
+    let mounted = true;
+    loadAllPrograms()
+      .then((items) => {
+        if (!mounted) return;
+        setEntries(items);
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const hasActiveFilters =
+    goalFilter !== "all" || levelFilter !== "all" || daysFilter !== null || equipmentFilter.length > 0;
+
+  const rankedPrograms = useMemo<RankedProgram[]>(() => {
+    if (!entries.length) return [];
+    return entries
+      .map((entry) => ({
+        entry,
+        score: matchScore(entry.meta, {
+          goal: goalFilter !== "all" ? goalFilter : undefined,
+          level: levelFilter !== "all" ? levelFilter : undefined,
+          days: daysFilter ?? undefined,
+          equipment: equipmentFilter.length ? equipmentFilter : undefined,
+        }),
+      }))
+      .filter(({ entry }) => {
+        if (goalFilter !== "all" && entry.meta.goal !== goalFilter) return false;
+        if (levelFilter !== "all" && entry.meta.level !== levelFilter) return false;
+        if (daysFilter !== null && Math.abs(entry.meta.daysPerWeek - daysFilter) > 1) return false;
+        if (equipmentFilter.length) {
+          const required = entry.meta.equipment.filter((item) => item !== "none");
+          if (required.some((item) => !equipmentFilter.includes(item))) {
+            return false;
+          }
+        }
+        return true;
+      })
+      .sort((a, b) => b.score - a.score);
+  }, [entries, goalFilter, levelFilter, daysFilter, equipmentFilter]);
+
+  const toggleEquipment = (value: ProgramEquipment) => {
+    setEquipmentFilter((prev) =>
+      prev.includes(value) ? prev.filter((item) => item !== value) : [...prev, value]
+    );
+  };
+
+  const resetFilters = () => {
+    setGoalFilter("all");
+    setLevelFilter("all");
+    setDaysFilter(null);
+    setEquipmentFilter([]);
+  };
+
+  return (
+    <div className="min-h-screen bg-background pb-16 md:pb-0">
+      <Seo title="Programs – MyBodyScan" description="Browse structured training programs." />
+      <AppHeader />
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-semibold text-foreground">Training Programs</h1>
+          <p className="text-sm text-muted-foreground">
+            Compare programs, filter by your schedule, and find the block that fits your goals.
+          </p>
+        </div>
+
+        <Card className="border bg-card/60">
+          <CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0">
+            <div className="flex items-center gap-2">
+              <SlidersHorizontal className="h-4 w-4 text-muted-foreground" />
+              <CardTitle className="text-base">Filters</CardTitle>
+            </div>
+            {hasActiveFilters && (
+              <Button variant="ghost" size="sm" onClick={resetFilters}>
+                Clear all
+              </Button>
+            )}
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4">
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Goal</span>
+                <Select value={goalFilter} onValueChange={(value) => setGoalFilter(value as GoalFilter)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="All goals" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All goals</SelectItem>
+                    {Object.entries(goalLabels).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Level</span>
+                <Select value={levelFilter} onValueChange={(value) => setLevelFilter(value as LevelFilter)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="All levels" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">All levels</SelectItem>
+                    {Object.entries(levelLabels).map(([value, label]) => (
+                      <SelectItem key={value} value={value}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between text-xs">
+                  <span className="font-medium uppercase tracking-wide text-muted-foreground">Days / Week</span>
+                  <button
+                    type="button"
+                    className="text-muted-foreground underline-offset-2 hover:underline"
+                    onClick={() => setDaysFilter(null)}
+                  >
+                    {daysFilter === null ? "Any" : "Clear"}
+                  </button>
+                </div>
+                <div className="space-y-3 rounded-md border bg-muted/40 px-3 py-4">
+                  <Slider
+                    min={2}
+                    max={6}
+                    step={1}
+                    value={[daysFilter ?? 4]}
+                    onValueChange={(value) => setDaysFilter(value[0] ?? null)}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {daysFilter === null
+                      ? "Any schedule"
+                      : `${daysFilter} days (±1 day wiggle room)`}
+                  </p>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2">
+                <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Equipment</span>
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="outline" className="justify-between">
+                      <span>{equipmentFilter.length ? `${equipmentFilter.length} selected` : "Any equipment"}</span>
+                      <Filter className="h-4 w-4 opacity-60" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end" className="w-48">
+                    {EQUIPMENT_OPTIONS.map((option) => (
+                      <DropdownMenuCheckboxItem
+                        key={option.value}
+                        checked={equipmentFilter.includes(option.value)}
+                        onCheckedChange={() => toggleEquipment(option.value)}
+                      >
+                        {option.label}
+                      </DropdownMenuCheckboxItem>
+                    ))}
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                {equipmentFilter.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {equipmentFilter.map((item) => {
+                      const label = EQUIPMENT_OPTIONS.find((option) => option.value === item)?.label ?? item;
+                      return (
+                        <Badge key={item} variant="secondary" className="capitalize">
+                          {label}
+                        </Badge>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <div className="flex items-center justify-between text-sm text-muted-foreground">
+          <span>
+            {isLoading ? "Loading programs..." : `${rankedPrograms.length} program${rankedPrograms.length === 1 ? "" : "s"}`}
+          </span>
+          {hasActiveFilters && <span>Sorted by best match</span>}
+        </div>
+
+        <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+          {rankedPrograms.map(({ entry, score }) => {
+            const { meta, program } = entry;
+            return (
+              <Card
+                key={meta.id}
+                role="button"
+                tabIndex={0}
+                onClick={() => navigate(`/programs/${meta.id}`)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    navigate(`/programs/${meta.id}`);
+                  }
+                }}
+                className="group flex h-full flex-col overflow-hidden transition hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+              >
+                <div className="relative overflow-hidden">
+                  <AspectRatio ratio={16 / 9}>
+                    {hasHeroImage(meta) ? (
+                      <img
+                        src={meta.heroImg}
+                        alt={program.title}
+                        className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
+                      />
+                    ) : (
+                      <div className="h-full w-full bg-gradient-to-br from-primary/20 via-primary/5 to-background" />
+                    )}
+                  </AspectRatio>
+                </div>
+                <CardHeader className="flex-1 space-y-2">
+                  <CardTitle className="text-xl">{program.title}</CardTitle>
+                  <p className="text-sm text-muted-foreground line-clamp-3">
+                    {deriveSummary(program, meta)}
+                  </p>
+                </CardHeader>
+                <CardContent className="space-y-3">
+                  <div className="flex flex-wrap gap-2 text-xs">
+                    <Badge variant="secondary">{goalLabels[meta.goal]}</Badge>
+                    <Badge variant="outline">{levelLabels[meta.level]}</Badge>
+                    <Badge variant="outline">{meta.daysPerWeek} days / wk</Badge>
+                    <Badge variant="outline">{meta.weeks} weeks</Badge>
+                  </div>
+                  {program.tags && program.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-2 text-xs">
+                      {program.tags.map((tag) => (
+                        <span key={tag} className="rounded-full bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                  {hasActiveFilters && (
+                    <p className="text-xs font-medium text-primary">
+                      Match score: {score}%
+                    </p>
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+          {!isLoading && !rankedPrograms.length && (
+            <Card className="col-span-full border-dashed">
+              <CardContent className="p-8 text-center text-sm text-muted-foreground">
+                No programs match these filters yet. Try widening your equipment or schedule preferences.
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </main>
+      <BottomNav />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a catalog loader for program metadata and scoring
- build programs catalog, detail, and quiz pages with coach integration
- update coach flow and navigation to use new program selection

## Testing
- npm run build *(fails: vite missing because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8054ac33083258a1f837f17214300