### PR TITLE
Expand coach programs and session guidance

### DIFF
--- a/src/content/programs/dumbbell-cut.json
+++ b/src/content/programs/dumbbell-cut.json
@@ -1,0 +1,112 @@
+{
+  "id": "dumbbell-cut",
+  "title": "Dumbbell Cut (3-4 Day)",
+  "goal": "cut",
+  "level": "intermediate",
+  "equipment": ["dumbbells"],
+  "durationPerSessionMin": 45,
+  "tags": ["Fat loss", "Dumbbell only", "Metabolic"],
+  "summary": "Higher-rep dumbbell circuits with optional fourth conditioning day to support a cut.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Full Body Strength",
+          "blocks": [
+            {
+              "title": "Compound Sets",
+              "exercises": [
+                {
+                  "name": "Dumbbell Goblet Squat",
+                  "sets": 4,
+                  "reps": "10",
+                  "restSec": 75,
+                  "substitutions": [
+                    {
+                      "name": "Bodyweight Tempo Squat",
+                      "reason": "Use when dumbbells are limited"
+                    }
+                  ]
+                },
+                {
+                  "name": "Dumbbell Bench Press",
+                  "sets": 4,
+                  "reps": "10",
+                  "restSec": 75,
+                  "substitutions": [
+                    {
+                      "name": "Floor Press",
+                      "reason": "Great when you don't have a bench"
+                    }
+                  ]
+                },
+                { "name": "Single-Arm Row", "sets": 3, "reps": "12/side", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Conditioning Mix",
+          "blocks": [
+            {
+              "title": "AMRAP Circuit (20 min)",
+              "exercises": [
+                { "name": "Dumbbell Thruster", "sets": 3, "reps": "12", "restSec": 0 },
+                { "name": "Renegade Row", "sets": 3, "reps": "10", "restSec": 0 },
+                { "name": "Mountain Climber", "sets": 3, "reps": "40", "restSec": 0 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Upper/Lower Split",
+          "blocks": [
+            {
+              "title": "Lower Body",
+              "exercises": [
+                {
+                  "name": "Dumbbell Romanian Deadlift",
+                  "sets": 4,
+                  "reps": "12",
+                  "restSec": 90
+                },
+                {
+                  "name": "Reverse Lunge",
+                  "sets": 3,
+                  "reps": "12/leg",
+                  "restSec": 90,
+                  "substitutions": [
+                    {
+                      "name": "Step-Back Lunge",
+                      "reason": "Bodyweight swap to keep moving"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Upper Body",
+              "exercises": [
+                { "name": "Dumbbell Push Press", "sets": 3, "reps": "12", "restSec": 75 },
+                { "name": "Hammer Curl", "sets": 3, "reps": "15", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 4 – Optional Sweat",
+          "blocks": [
+            {
+              "title": "Intervals",
+              "exercises": [
+                { "name": "Alternating Snatch", "sets": 4, "reps": "12/side", "restSec": 45 },
+                { "name": "Dumbbell Swing", "sets": 4, "reps": "20", "restSec": 45 },
+                { "name": "Plank", "sets": 3, "reps": "60s", "restSec": 30 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/kettlebell-3day.json
+++ b/src/content/programs/kettlebell-3day.json
@@ -1,0 +1,126 @@
+{
+  "id": "kettlebell-3day",
+  "title": "Kettlebell Power 3-Day",
+  "goal": "general",
+  "level": "intermediate",
+  "equipment": ["kettlebells"],
+  "durationPerSessionMin": 45,
+  "tags": ["Kettlebell", "Power endurance", "3 day"],
+  "summary": "Three efficient kettlebell sessions combining strength, power, and conditioning.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Strength & Swing",
+          "blocks": [
+            {
+              "title": "Strength",
+              "exercises": [
+                {
+                  "name": "Double Kettlebell Front Squat",
+                  "sets": 4,
+                  "reps": "6",
+                  "restSec": 90,
+                  "substitutions": [
+                    {
+                      "name": "Goblet Squat",
+                      "reason": "Use when you only have one bell"
+                    }
+                  ]
+                },
+                {
+                  "name": "Kettlebell Row",
+                  "sets": 4,
+                  "reps": "8/side",
+                  "restSec": 75
+                }
+              ]
+            },
+            {
+              "title": "Swing Finisher",
+              "exercises": [
+                {
+                  "name": "Two-Hand Swing",
+                  "sets": 5,
+                  "reps": "20",
+                  "restSec": 45,
+                  "substitutions": [
+                    {
+                      "name": "Single-Arm Swing",
+                      "reason": "Adds anti-rotation challenge"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Press & Carry",
+          "blocks": [
+            {
+              "title": "Press Ladder",
+              "exercises": [
+                {
+                  "name": "Single-Arm Clean and Press",
+                  "sets": 4,
+                  "reps": "5/side",
+                  "restSec": 75,
+                  "substitutions": [
+                    {
+                      "name": "Push Press",
+                      "reason": "Add leg drive for heavier bells"
+                    }
+                  ]
+                },
+                { "name": "Half Kneeling Windmill", "sets": 3, "reps": "6/side", "restSec": 60 }
+              ]
+            },
+            {
+              "title": "Carry",
+              "exercises": [
+                { "name": "Farmer Carry", "sets": 4, "reps": "40m", "restSec": 60 },
+                {
+                  "name": "Front Rack Carry",
+                  "sets": 3,
+                  "reps": "30m",
+                  "restSec": 60,
+                  "substitutions": [
+                    {
+                      "name": "Suitcase Carry",
+                      "reason": "Focuses on obliques with lighter bells"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Conditioning Complex",
+          "blocks": [
+            {
+              "title": "Complex x4",
+              "exercises": [
+                { "name": "Kettlebell Snatch", "sets": 4, "reps": "10/side", "restSec": 30 },
+                { "name": "Kettlebell Lunge Press", "sets": 4, "reps": "8/side", "restSec": 30 },
+                {
+                  "name": "Russian Twist",
+                  "sets": 4,
+                  "reps": "20",
+                  "restSec": 30,
+                  "substitutions": [
+                    {
+                      "name": "Dead Bug",
+                      "reason": "Great when twisting bothers the back"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/lift-plus-zone2.json
+++ b/src/content/programs/lift-plus-zone2.json
@@ -1,0 +1,166 @@
+{
+  "id": "lift-plus-zone2",
+  "title": "Lift + Zone 2 (3 Day)",
+  "goal": "general",
+  "level": "intermediate",
+  "equipment": ["barbell", "dumbbells", "machines"],
+  "durationPerSessionMin": 60,
+  "tags": ["Strength + cardio", "Zone 2", "3 day"],
+  "summary": "Two strength-focused sessions plus one mixed conditioning day with dedicated zone 2 cardio.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Full Body + Zone 2",
+          "blocks": [
+            {
+              "title": "Strength",
+              "exercises": [
+                {
+                  "name": "Back Squat",
+                  "sets": 3,
+                  "reps": "6",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Leg Press",
+                      "reason": "Use if you need a machine-guided squat",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Bench Press",
+                  "sets": 3,
+                  "reps": "6",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Dumbbell Bench Press",
+                      "reason": "Works for limited barbell access",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Zone 2",
+              "exercises": [
+                {
+                  "name": "Treadmill Zone 2 Walk",
+                  "sets": 1,
+                  "reps": "20 min",
+                  "substitutions": [
+                    {
+                      "name": "Stationary Bike Zone 2",
+                      "reason": "Low impact cardio alternative",
+                      "equipment": ["machines"]
+                    },
+                    {
+                      "name": "Outdoor Brisk Walk",
+                      "reason": "No gym access needed",
+                      "equipment": ["none"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Upper + Conditioning",
+          "blocks": [
+            {
+              "title": "Strength",
+              "exercises": [
+                {
+                  "name": "Overhead Press",
+                  "sets": 3,
+                  "reps": "6-8",
+                  "restSec": 120,
+                  "substitutions": [
+                    {
+                      "name": "Seated Dumbbell Press",
+                      "reason": "Joint friendly overhead option",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                },
+                { "name": "Single-Arm Row", "sets": 3, "reps": "10/side", "restSec": 90 }
+              ]
+            },
+            {
+              "title": "Cardio Finisher",
+              "exercises": [
+                {
+                  "name": "Row Erg Zone 2",
+                  "sets": 1,
+                  "reps": "15 min",
+                  "substitutions": [
+                    {
+                      "name": "Battle Rope Intervals",
+                      "reason": "Higher heart rate if you want variety",
+                      "equipment": ["none"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Posterior + Long Zone 2",
+          "blocks": [
+            {
+              "title": "Strength",
+              "exercises": [
+                {
+                  "name": "Romanian Deadlift",
+                  "sets": 3,
+                  "reps": "8",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Good Morning",
+                      "reason": "Keep hinge stimulus if you prefer",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Walking Lunge",
+                  "sets": 3,
+                  "reps": "12/leg",
+                  "restSec": 90
+                }
+              ]
+            },
+            {
+              "title": "Zone 2",
+              "exercises": [
+                {
+                  "name": "Bike Zone 2 Ride",
+                  "sets": 1,
+                  "reps": "30 min",
+                  "substitutions": [
+                    {
+                      "name": "Elliptical Zone 2",
+                      "reason": "Lower impact for knees",
+                      "equipment": ["machines"]
+                    },
+                    {
+                      "name": "Outdoor Jog",
+                      "reason": "Simple endurance option",
+                      "equipment": ["none"]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/linear-strength-3day.json
+++ b/src/content/programs/linear-strength-3day.json
@@ -1,0 +1,145 @@
+{
+  "id": "linear-strength-3day",
+  "title": "Linear Strength 3-Day",
+  "goal": "strength",
+  "level": "beginner",
+  "equipment": ["barbell", "dumbbells", "machines"],
+  "durationPerSessionMin": 55,
+  "tags": ["Linear progression", "3 day", "Full body"],
+  "summary": "Three focused strength sessions each week with small linear jumps and optional accessory swaps.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Squat Push",
+          "blocks": [
+            {
+              "title": "Main Lifts",
+              "exercises": [
+                {
+                  "name": "Back Squat",
+                  "sets": 4,
+                  "reps": "6",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Goblet Squat",
+                      "reason": "Works if you only have dumbbells",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Bench Press",
+                  "sets": 4,
+                  "reps": "6",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Machine Chest Press",
+                      "reason": "Great if you need more control",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Split Squat", "sets": 3, "reps": "10/leg", "restSec": 90 },
+                { "name": "Incline Dumbbell Press", "sets": 3, "reps": "10", "restSec": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Pull and Posterior",
+          "blocks": [
+            {
+              "title": "Main Lifts",
+              "exercises": [
+                {
+                  "name": "Deadlift",
+                  "sets": 3,
+                  "reps": "5",
+                  "restSec": 180,
+                  "substitutions": [
+                    {
+                      "name": "Romanian Deadlift",
+                      "reason": "Keeps posterior-chain emphasis with less fatigue",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Bent-Over Row",
+                  "sets": 4,
+                  "reps": "6",
+                  "restSec": 120,
+                  "substitutions": [
+                    {
+                      "name": "Lat Pulldown",
+                      "reason": "Simpler pulling pattern",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Hip Thrust", "sets": 3, "reps": "8", "restSec": 120 },
+                { "name": "Face Pull", "sets": 3, "reps": "15", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Press and Volume",
+          "blocks": [
+            {
+              "title": "Main Lifts",
+              "exercises": [
+                {
+                  "name": "Front Squat",
+                  "sets": 3,
+                  "reps": "6",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Leg Press",
+                      "reason": "Use when you need a machine-supported squat pattern",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Overhead Press",
+                  "sets": 4,
+                  "reps": "6",
+                  "restSec": 120,
+                  "substitutions": [
+                    {
+                      "name": "Dumbbell Shoulder Press",
+                      "reason": "Joint friendly overhead work",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Seated Row", "sets": 3, "reps": "10", "restSec": 90 },
+                { "name": "Farmer Carry", "sets": 3, "reps": "40m", "restSec": 90 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/mobility-core-2day.json
+++ b/src/content/programs/mobility-core-2day.json
@@ -1,0 +1,104 @@
+{
+  "id": "mobility-core-2day",
+  "title": "Mobility + Core 2-Day",
+  "goal": "general",
+  "level": "beginner",
+  "equipment": ["none", "bands"],
+  "durationPerSessionMin": 30,
+  "tags": ["Mobility", "Core", "Active recovery"],
+  "summary": "Two refreshing sessions that mix mobility flows with focused core work—ideal alongside heavier training.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Flow & Stability",
+          "blocks": [
+            {
+              "title": "Mobility Flow",
+              "exercises": [
+                {
+                  "name": "World's Greatest Stretch",
+                  "sets": 3,
+                  "reps": "6/side",
+                  "restSec": 30,
+                  "substitutions": [
+                    {
+                      "name": "Couch Stretch",
+                      "reason": "Focus on hip flexors if knees bother you"
+                    }
+                  ]
+                },
+                { "name": "Cat Cow", "sets": 3, "reps": "10", "restSec": 30 }
+              ]
+            },
+            {
+              "title": "Core Stability",
+              "exercises": [
+                {
+                  "name": "Dead Bug",
+                  "sets": 3,
+                  "reps": "12",
+                  "restSec": 30,
+                  "substitutions": [
+                    {
+                      "name": "Bird Dog",
+                      "reason": "Great when lying on your back is uncomfortable"
+                    }
+                  ]
+                },
+                { "name": "Side Plank", "sets": 3, "reps": "30s/side", "restSec": 30 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Hips & Antirotation",
+          "blocks": [
+            {
+              "title": "Mobility",
+              "exercises": [
+                {
+                  "name": "90/90 Hip Switch",
+                  "sets": 3,
+                  "reps": "10/side",
+                  "restSec": 30,
+                  "substitutions": [
+                    {
+                      "name": "Seated Hip Internal Rotation",
+                      "reason": "Simplify when knees feel tight"
+                    }
+                  ]
+                },
+                {
+                  "name": "Thoracic Rotation on All Fours",
+                  "sets": 3,
+                  "reps": "12/side",
+                  "restSec": 30
+                }
+              ]
+            },
+            {
+              "title": "Core",
+              "exercises": [
+                {
+                  "name": "Pallof Press",
+                  "sets": 3,
+                  "reps": "12/side",
+                  "restSec": 45,
+                  "substitutions": [
+                    {
+                      "name": "Band Hold Out",
+                      "reason": "Static version if you prefer to brace",
+                      "equipment": ["bands"]
+                    }
+                  ]
+                },
+                { "name": "Hollow Body Hold", "sets": 3, "reps": "30s", "restSec": 45 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/no-equipment-3day.json
+++ b/src/content/programs/no-equipment-3day.json
@@ -1,0 +1,99 @@
+{
+  "id": "no-equipment-3day",
+  "title": "No Equipment 3-Day",
+  "goal": "general",
+  "level": "beginner",
+  "equipment": ["none"],
+  "durationPerSessionMin": 35,
+  "tags": ["Bodyweight", "Home friendly", "3 day"],
+  "summary": "Minimalist three day plan using only bodyweight, perfect for travel or at-home training.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Push + Core",
+          "blocks": [
+            {
+              "title": "Circuit x3",
+              "exercises": [
+                {
+                  "name": "Push-Up",
+                  "sets": 3,
+                  "reps": "AMRAP",
+                  "restSec": 30,
+                  "substitutions": [
+                    {
+                      "name": "Knee Push-Up",
+                      "reason": "Reduce the difficulty to keep form"
+                    }
+                  ]
+                },
+                { "name": "Dip on Bench", "sets": 3, "reps": "12", "restSec": 30 },
+                {
+                  "name": "Plank",
+                  "sets": 3,
+                  "reps": "45s",
+                  "restSec": 30,
+                  "substitutions": [
+                    {
+                      "name": "High Plank Shoulder Tap",
+                      "reason": "Add anti-rotation challenge"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Lower Body",
+          "blocks": [
+            {
+              "title": "Interval Sets",
+              "exercises": [
+                {
+                  "name": "Reverse Lunge",
+                  "sets": 4,
+                  "reps": "15/leg",
+                  "restSec": 30,
+                  "substitutions": [
+                    {
+                      "name": "Split Squat Hold",
+                      "reason": "Static version when space is tight"
+                    }
+                  ]
+                },
+                { "name": "Bodyweight Squat", "sets": 4, "reps": "20", "restSec": 30 },
+                { "name": "Glute Bridge", "sets": 3, "reps": "20", "restSec": 30 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Conditioning",
+          "blocks": [
+            {
+              "title": "EMOM 20",
+              "exercises": [
+                {
+                  "name": "Burpee",
+                  "sets": 5,
+                  "reps": "12",
+                  "restSec": 0,
+                  "substitutions": [
+                    {
+                      "name": "Step-Back Burpee",
+                      "reason": "Lower impact version"
+                    }
+                  ]
+                },
+                { "name": "Jumping Jack", "sets": 5, "reps": "40", "restSec": 0 },
+                { "name": "V-Sit Hold", "sets": 5, "reps": "30s", "restSec": 0 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/phul.json
+++ b/src/content/programs/phul.json
@@ -1,0 +1,196 @@
+{
+  "id": "phul",
+  "title": "PHUL (Power Hypertrophy Upper Lower)",
+  "goal": "hypertrophy",
+  "level": "intermediate",
+  "equipment": ["barbell", "dumbbells", "machines"],
+  "durationPerSessionMin": 70,
+  "tags": ["4 day", "Power + hypertrophy", "Upper lower"],
+  "summary": "Alternating power and hypertrophy focused days to build strength and size together.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Upper Power",
+          "blocks": [
+            {
+              "title": "Power Moves",
+              "exercises": [
+                {
+                  "name": "Bench Press",
+                  "sets": 4,
+                  "reps": "3-5",
+                  "restSec": 180,
+                  "substitutions": [
+                    {
+                      "name": "Close Grip Bench Press",
+                      "reason": "Keeps heavy pressing with tricep focus",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Bent-Over Row",
+                  "sets": 4,
+                  "reps": "3-5",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Pendlay Row",
+                      "reason": "Explosive alternative for the upper back",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Overhead Press",
+                  "sets": 3,
+                  "reps": "5",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Push Press",
+                      "reason": "Use legs to drive heavier loads",
+                      "equipment": ["barbell"]
+                    },
+                    {
+                      "name": "Seated Dumbbell Press",
+                      "reason": "Joint friendly option",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Weighted Chin-Up", "sets": 3, "reps": "6-8", "restSec": 120 },
+                { "name": "Dumbbell Incline Press", "sets": 3, "reps": "8-10", "restSec": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Lower Power",
+          "blocks": [
+            {
+              "title": "Power Moves",
+              "exercises": [
+                {
+                  "name": "Back Squat",
+                  "sets": 4,
+                  "reps": "3-5",
+                  "restSec": 210,
+                  "substitutions": [
+                    {
+                      "name": "Safety Bar Squat",
+                      "reason": "Friendly for long torsos",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Deadlift",
+                  "sets": 3,
+                  "reps": "3-5",
+                  "restSec": 210,
+                  "substitutions": [
+                    {
+                      "name": "Trap Bar Deadlift",
+                      "reason": "More upright pull with similar stimulus",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Walking Lunge", "sets": 3, "reps": "12/leg", "restSec": 90 },
+                { "name": "Hanging Leg Raise", "sets": 3, "reps": "12-15", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Upper Hypertrophy",
+          "blocks": [
+            {
+              "title": "Volume Work",
+              "exercises": [
+                {
+                  "name": "Incline Dumbbell Press",
+                  "sets": 4,
+                  "reps": "8-10",
+                  "restSec": 90,
+                  "substitutions": [
+                    {
+                      "name": "Machine Chest Press",
+                      "reason": "Controlled pressing without spotter",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Seated Cable Row",
+                  "sets": 4,
+                  "reps": "10-12",
+                  "restSec": 90,
+                  "substitutions": [
+                    {
+                      "name": "Single-Arm Dumbbell Row",
+                      "reason": "Keeps focus on lats with minimal equipment",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                },
+                { "name": "Lateral Raise", "sets": 3, "reps": "12-15", "restSec": 60 },
+                { "name": "Cable Triceps Pressdown", "sets": 3, "reps": "12", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 4 – Lower Hypertrophy",
+          "blocks": [
+            {
+              "title": "Volume Work",
+              "exercises": [
+                {
+                  "name": "Front Squat",
+                  "sets": 3,
+                  "reps": "8",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Leg Press",
+                      "reason": "When knees need a more guided track",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Romanian Deadlift",
+                  "sets": 3,
+                  "reps": "8-10",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Good Morning",
+                      "reason": "Keeps hinge stimulus with lighter load",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                { "name": "Leg Curl", "sets": 3, "reps": "12", "restSec": 60 },
+                { "name": "Calf Raise", "sets": 4, "reps": "15", "restSec": 45 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/strength-5x5.json
+++ b/src/content/programs/strength-5x5.json
@@ -1,0 +1,182 @@
+{
+  "id": "strength-5x5",
+  "title": "Strength 5x5",
+  "goal": "strength",
+  "level": "intermediate",
+  "equipment": ["barbell", "dumbbells"],
+  "durationPerSessionMin": 65,
+  "tags": ["5x5", "Strength focus", "Simple progression"],
+  "summary": "A classic three day 5x5 strength split built around the squat, press, and pull.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Heavy Squat",
+          "blocks": [
+            {
+              "title": "Main Work",
+              "exercises": [
+                {
+                  "name": "Back Squat",
+                  "sets": 5,
+                  "reps": "5",
+                  "restSec": 180,
+                  "substitutions": [
+                    {
+                      "name": "Front Squat",
+                      "reason": "Keeps the upright squat pattern when you need a change",
+                      "equipment": ["barbell"]
+                    },
+                    {
+                      "name": "Safety Bar Squat",
+                      "reason": "Friendlier on shoulders and elbows",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Bench Press",
+                  "sets": 5,
+                  "reps": "5",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Incline Bench Press",
+                      "reason": "Add more upper chest while keeping a heavy press",
+                      "equipment": ["barbell"]
+                    },
+                    {
+                      "name": "Dumbbell Bench Press",
+                      "reason": "Great when racks are busy and for shoulder balance",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Barbell Row",
+                  "sets": 5,
+                  "reps": "5",
+                  "restSec": 120,
+                  "substitutions": [
+                    {
+                      "name": "Chest Supported Row",
+                      "reason": "Reduces lower-back fatigue",
+                      "equipment": ["machines"]
+                    },
+                    {
+                      "name": "Single-Arm Dumbbell Row",
+                      "reason": "Still heavy pulling with less spinal load",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Hanging Leg Raise", "sets": 3, "reps": "12", "restSec": 60 },
+                { "name": "Face Pull", "sets": 3, "reps": "15", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Heavy Pull",
+          "blocks": [
+            {
+              "title": "Main Work",
+              "exercises": [
+                {
+                  "name": "Deadlift",
+                  "sets": 3,
+                  "reps": "5",
+                  "restSec": 210,
+                  "substitutions": [
+                    {
+                      "name": "Trap Bar Deadlift",
+                      "reason": "More quad friendly pull",
+                      "equipment": ["barbell"]
+                    },
+                    {
+                      "name": "Romanian Deadlift",
+                      "reason": "Keeps posterior chain focus with less fatigue",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Overhead Press",
+                  "sets": 5,
+                  "reps": "5",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Push Press",
+                      "reason": "Adds a little leg drive for heavier weights",
+                      "equipment": ["barbell"]
+                    },
+                    {
+                      "name": "Seated Dumbbell Press",
+                      "reason": "Shoulder friendly pressing",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Pull-Up", "sets": 3, "reps": "AMRAP", "restSec": 120 },
+                { "name": "Barbell Hip Thrust", "sets": 3, "reps": "8", "restSec": 120 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Volume Bench",
+          "blocks": [
+            {
+              "title": "Main Work",
+              "exercises": [
+                {
+                  "name": "Front Squat",
+                  "sets": 5,
+                  "reps": "3",
+                  "restSec": 150
+                },
+                {
+                  "name": "Bench Press",
+                  "sets": 5,
+                  "reps": "5",
+                  "restSec": 120,
+                  "substitutions": [
+                    {
+                      "name": "Paused Bench Press",
+                      "reason": "Builds control off the chest",
+                      "equipment": ["barbell"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Barbell Row",
+                  "sets": 5,
+                  "reps": "5",
+                  "restSec": 120
+                }
+              ]
+            },
+            {
+              "title": "Assistance",
+              "exercises": [
+                { "name": "Dumbbell Romanian Deadlift", "sets": 3, "reps": "10", "restSec": 90 },
+                { "name": "Cable Chop", "sets": 3, "reps": "12/side", "restSec": 60 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/content/programs/womens-glute-focus.json
+++ b/src/content/programs/womens-glute-focus.json
@@ -1,0 +1,157 @@
+{
+  "id": "womens-glute-focus",
+  "title": "Women's Glute & Lower Body Focus",
+  "goal": "hypertrophy",
+  "level": "intermediate",
+  "equipment": ["barbell", "dumbbells", "bands", "machines"],
+  "durationPerSessionMin": 60,
+  "tags": ["Glute focus", "3-4 day", "Lower body"],
+  "summary": "Targeted glute and leg training with one optional pump day for extra volume.",
+  "weeks": [
+    {
+      "days": [
+        {
+          "name": "Day 1 – Glute Strength",
+          "blocks": [
+            {
+              "title": "Primary Lifts",
+              "exercises": [
+                {
+                  "name": "Barbell Hip Thrust",
+                  "sets": 4,
+                  "reps": "6-8",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Smith Machine Hip Thrust",
+                      "reason": "Keeps load heavy with more stability",
+                      "equipment": ["machines"]
+                    },
+                    {
+                      "name": "Dumbbell Hip Thrust",
+                      "reason": "For home setups",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Romanian Deadlift",
+                  "sets": 4,
+                  "reps": "8",
+                  "restSec": 150,
+                  "substitutions": [
+                    {
+                      "name": "Single-Leg Romanian Deadlift",
+                      "reason": "Great when loads are lighter",
+                      "equipment": ["dumbbells"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Accessory Volume",
+              "exercises": [
+                { "name": "Cable Kickback", "sets": 3, "reps": "12", "restSec": 60 },
+                { "name": "Walking Lunge", "sets": 3, "reps": "12/leg", "restSec": 90 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 2 – Upper Body Balance",
+          "blocks": [
+            {
+              "title": "Upper Push/Pull",
+              "exercises": [
+                {
+                  "name": "Incline Dumbbell Press",
+                  "sets": 3,
+                  "reps": "8-10",
+                  "restSec": 90,
+                  "substitutions": [
+                    {
+                      "name": "Push-Up",
+                      "reason": "Bodyweight option when equipment is limited",
+                      "equipment": ["none"]
+                    }
+                  ]
+                },
+                {
+                  "name": "Lat Pulldown",
+                  "sets": 3,
+                  "reps": "10-12",
+                  "restSec": 90,
+                  "substitutions": [
+                    {
+                      "name": "Assisted Pull-Up",
+                      "reason": "Keeps vertical pulling stimulus",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "title": "Arm & Shoulder Finish",
+              "exercises": [
+                { "name": "Cable Lateral Raise", "sets": 3, "reps": "15", "restSec": 45 },
+                { "name": "Rope Triceps Pressdown", "sets": 3, "reps": "12", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 3 – Glute Volume",
+          "blocks": [
+            {
+              "title": "Glute Giant Set",
+              "exercises": [
+                {
+                  "name": "Bulgarian Split Squat",
+                  "sets": 3,
+                  "reps": "10/leg",
+                  "restSec": 90,
+                  "substitutions": [
+                    {
+                      "name": "Leg Press",
+                      "reason": "Still hits quads and glutes if balance is limiting",
+                      "equipment": ["machines"]
+                    }
+                  ]
+                },
+                { "name": "Cable Abduction", "sets": 3, "reps": "15", "restSec": 45 },
+                { "name": "Back Extension", "sets": 3, "reps": "12", "restSec": 60 }
+              ]
+            }
+          ]
+        },
+        {
+          "name": "Day 4 – Optional Pump",
+          "blocks": [
+            {
+              "title": "Band & Bodyweight",
+              "exercises": [
+                {
+                  "name": "Banded Glute Bridge",
+                  "sets": 4,
+                  "reps": "20",
+                  "restSec": 45,
+                  "substitutions": [
+                    {
+                      "name": "Hip Circle Walk",
+                      "reason": "Quick travel-friendly option",
+                      "equipment": ["bands"]
+                    }
+                  ]
+                },
+                { "name": "Step-Up", "sets": 3, "reps": "15/leg", "restSec": 60 },
+                { "name": "Side Plank", "sets": 3, "reps": "45s/side", "restSec": 45 }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/src/lib/coach/progression.ts
+++ b/src/lib/coach/progression.ts
@@ -4,11 +4,14 @@ interface FlattenedSet {
   exIdx: number;
   set: number;
   name: string;
+  planName: string;
   targetReps: string;
   restSec?: number;
 }
 
-export function flattenDay(day: Day): FlattenedSet[] {
+type DisplayOverrides = Record<number, string | undefined>;
+
+export function flattenDay(day: Day, overrides?: DisplayOverrides): FlattenedSet[] {
   const rows: FlattenedSet[] = [];
   let globalExerciseIndex = 0;
   day.blocks.forEach((block) => {
@@ -17,7 +20,8 @@ export function flattenDay(day: Day): FlattenedSet[] {
         rows.push({
           exIdx: globalExerciseIndex,
           set: i,
-          name: exercise.name,
+          name: overrides?.[globalExerciseIndex] ?? exercise.name,
+          planName: exercise.name,
           targetReps: exercise.reps,
           restSec: exercise.restSec,
         });
@@ -34,4 +38,80 @@ export function nextProgressionHint(exercise: Exercise): string {
   const restText = typeof restSec === "number" ? ` Keep rest about ${Math.round(restSec / 30) * 30} sec.` : "";
   const tempoText = tempo ? ` Control tempo (${tempo}).` : "";
   return `Add 2.5–5 lb next week if all sets hit ${reps}.${rirText}${restText}${tempoText}`.trim();
+}
+
+function parseRepRange(reps: string): { lower: number | null; upper: number | null } | null {
+  const cleaned = reps.trim().toLowerCase();
+  if (!cleaned || cleaned.includes("amrap") || cleaned.includes("min")) {
+    return null;
+  }
+
+  const rangeMatch = cleaned.match(/(\d+)\s*-\s*(\d+)/);
+  if (rangeMatch) {
+    return {
+      lower: Number.parseInt(rangeMatch[1], 10),
+      upper: Number.parseInt(rangeMatch[2], 10),
+    };
+  }
+
+  const singleMatch = cleaned.match(/(\d+(?:\.\d+)?)/);
+  if (singleMatch) {
+    const value = Number.parseFloat(singleMatch[1]);
+    return { lower: value, upper: value };
+  }
+
+  return null;
+}
+
+function isCompoundLift(name: string): boolean {
+  const normalized = name.toLowerCase();
+  const keywords = [
+    "squat",
+    "deadlift",
+    "press",
+    "bench",
+    "row",
+    "pull-up",
+    "chin-up",
+    "lunge",
+    "clean",
+    "snatch",
+    "thruster",
+    "hip thrust",
+  ];
+  return keywords.some((keyword) => normalized.includes(keyword));
+}
+
+export function computeNextTargets(params: {
+  exerciseName: string;
+  lastSets: { reps: number; weight?: number }[];
+  planTarget: { sets: number; reps: string; rir?: number };
+}): { suggestion: string } {
+  const { exerciseName, lastSets, planTarget } = params;
+  if (!lastSets.length) {
+    return { suggestion: "maintain" };
+  }
+
+  const repRange = parseRepRange(planTarget.reps);
+  if (!repRange) {
+    return { suggestion: "maintain" };
+  }
+
+  const { lower, upper } = repRange;
+  const avgReps = lastSets.reduce((sum, set) => sum + set.reps, 0) / lastSets.length;
+  const allMetUpper = typeof upper === "number" && lastSets.every((set) => set.reps >= upper);
+
+  if (allMetUpper) {
+    if (isCompoundLift(exerciseName)) {
+      return { suggestion: "+5 lb if all sets completed" };
+    }
+    return { suggestion: "+1 rep if all sets completed" };
+  }
+
+  const baseline = lower ?? upper;
+  if (typeof baseline === "number" && avgReps <= baseline - 2) {
+    return { suggestion: "hold or drop 5%" };
+  }
+
+  return { suggestion: "maintain" };
 }

--- a/src/lib/coach/types.ts
+++ b/src/lib/coach/types.ts
@@ -44,6 +44,12 @@ export interface Block {
   exercises: Exercise[];
 }
 
+export interface ExerciseSubstitution {
+  name: string;
+  reason?: string;
+  equipment?: string[];
+}
+
 export interface Exercise {
   name: string;
   sets: number;
@@ -51,4 +57,5 @@ export interface Exercise {
   restSec?: number;
   rir?: number;
   tempo?: string;
+  substitutions?: ExerciseSubstitution[];
 }


### PR DESCRIPTION
## Summary
- add nine additional training programs spanning barbell strength, dumbbell-only cutting, kettlebells, mobility work, and more
- extend exercise typings and the Coach Day screen to support swapping movements with substitutions that persist in the workout log
- surface next session targets by analysing the latest log entries and applying simple progression heuristics

## Testing
- `npm run build` *(fails: vite not installed because npm install is blocked by 403 on @opentelemetry/semantic-conventions)*

------
https://chatgpt.com/codex/tasks/task_e_68d80febcaa88325aeba9d77df59d2a8