### PR TITLE
Add deload support and refresh program catalog experience

### DIFF
--- a/src/content/programs/beginner-full-body.json
+++ b/src/content/programs/beginner-full-body.json
@@ -7,14 +7,16 @@
   "durationPerSessionMin": 55,
   "tags": ["Full body", "3-day split", "Strength foundations"],
   "summary": "Three focused full-body sessions each week to build strength and muscle with classic compound lifts.",
+  "rationale": "Alternating full-body days distributes volume across big movement patterns so beginners get frequent practice without overwhelming soreness. Progressive overload is baked in through moderate jumps in sets and rep ranges while RIR targets ensure technique stays crisp as load increases.",
+  "deloadWeeks": [4],
   "faqs": [
     {
-      "question": "How many days a week will I train?",
-      "answer": "You will train three days each week with at least one rest day between sessions."
+      "q": "How many days a week will I train?",
+      "a": "You will train three days each week with at least one rest day between sessions to lock in recovery."
     },
     {
-      "question": "Is this friendly for beginners?",
-      "answer": "Yes. The program introduces key movement patterns with moderate volume so you can master form and progress safely."
+      "q": "Is this friendly for beginners?",
+      "a": "Yes. The plan layers in compound lifts with accessory support so you can groove form, add weight gradually, and still have energy for life outside the gym."
     }
   ],
   "weeks": [

--- a/src/content/programs/dumbbell-cut.json
+++ b/src/content/programs/dumbbell-cut.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 45,
   "tags": ["Fat loss", "Dumbbell only", "Metabolic"],
   "summary": "Higher-rep dumbbell circuits with optional fourth conditioning day to support a cut.",
+  "rationale": "Alternating strength moves with metabolic finishers keeps total work high enough to drive calorie expenditure while maintaining lean tissue. Sessions stay dumbbell-only so you can push close to failure with minimal setup, and RIR targets help manage fatigue during a caloric deficit.",
+  "faqs": [
+    {
+      "q": "How should I progress weights while cutting?",
+      "a": "Aim to maintain or slightly increase loads week to week; if energy dips, keep weight steady but try to match previous rep counts."
+    },
+    {
+      "q": "Can I add extra cardio?",
+      "a": "Yes—slot easy zone-2 cardio on rest days or after the optional day as long as it does not interfere with recovery."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/kettlebell-3day.json
+++ b/src/content/programs/kettlebell-3day.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 45,
   "tags": ["Kettlebell", "Power endurance", "3 day"],
   "summary": "Three efficient kettlebell sessions combining strength, power, and conditioning.",
+  "rationale": "Each day layers grinds with ballistic work so you develop strength, power, and aerobic capacity together. Density blocks control work-to-rest ratios, keeping heart rate in a productive range while repeated exposure to swings and cleans sharpens technique.",
+  "faqs": [
+    {
+      "q": "How heavy should my kettlebells be?",
+      "a": "Choose a bell that challenges the final reps while maintaining crisp technique—usually 16–24 kg for swings and 8–16 kg for presses, adjusting to your strength."
+    },
+    {
+      "q": "Can I run this alongside other training?",
+      "a": "Yes, pair it with low-intensity cardio or bodyweight mobility work on off days; avoid stacking heavy barbell sessions on back-to-back days."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/lift-plus-zone2.json
+++ b/src/content/programs/lift-plus-zone2.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 60,
   "tags": ["Strength + cardio", "Zone 2", "3 day"],
   "summary": "Two strength-focused sessions plus one mixed conditioning day with dedicated zone 2 cardio.",
+  "rationale": "Strength sessions focus on compound lifts to preserve muscle while the dedicated zone 2 block builds an aerobic base that supports recovery and fat oxidation. The week balances higher-intensity intervals with easy steady-state cardio to improve work capacity without compromising lifting performance.",
+  "faqs": [
+    {
+      "q": "What heart rate should I target for zone 2?",
+      "a": "Aim for roughly 60–70% of max heart rate—breathing should be controlled enough to speak in full sentences."
+    },
+    {
+      "q": "Can I rearrange the days?",
+      "a": "Yes, keep at least one rest day between the lifting sessions and place the cardio day where it best fits your schedule."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/linear-strength-3day.json
+++ b/src/content/programs/linear-strength-3day.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 55,
   "tags": ["Linear progression", "3 day", "Full body"],
   "summary": "Three focused strength sessions each week with small linear jumps and optional accessory swaps.",
+  "rationale": "Main lifts stay in low-to-moderate rep ranges so you can add small amounts of weight weekly while maintaining technical quality. Accessories use higher reps and controlled RIR to build muscle that supports the big lifts without overwhelming CNS fatigue.",
+  "faqs": [
+    {
+      "q": "How quickly should I add weight?",
+      "a": "Add 2.5–5 lb when you hit all prescribed reps with the listed RIR; if you miss, keep the load the same next week."
+    },
+    {
+      "q": "Can I swap accessories?",
+      "a": "Yes—use the suggested substitutions or choose movements that hit the same muscle group for similar reps and tempo."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/mobility-core-2day.json
+++ b/src/content/programs/mobility-core-2day.json
@@ -7,6 +7,7 @@
   "durationPerSessionMin": 30,
   "tags": ["Mobility", "Core", "Active recovery"],
   "summary": "Two refreshing sessions that mix mobility flows with focused core work—ideal alongside heavier training.",
+  "rationale": "Sequences cycle from mobility drills into trunk stability work so you open up key joints before reinforcing new ranges. Low-load isometrics and anti-rotation moves build resilience without adding much systemic fatigue, making the plan perfect for active recovery."
   "weeks": [
     {
       "days": [

--- a/src/content/programs/no-equipment-3day.json
+++ b/src/content/programs/no-equipment-3day.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 35,
   "tags": ["Bodyweight", "Home friendly", "3 day"],
   "summary": "Minimalist three day plan using only bodyweight, perfect for travel or at-home training.",
+  "rationale": "Supersets pair pushing, pulling, and single-leg drills so you keep heart rate elevated and stimulate muscle without equipment. Tempo work and unilateral loading challenge stability, driving strength gains with progressive variations instead of added weight.",
+  "faqs": [
+    {
+      "q": "How do I make sessions harder over time?",
+      "a": "Add reps to the higher end of each range, slow the lowering phase, or reduce rest between circuits before introducing weighted backpacks."
+    },
+    {
+      "q": "Can I split the workouts across the day?",
+      "a": "Yes—perform one or two circuits in the morning and finish the rest later if that helps you stay consistent."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/phul.json
+++ b/src/content/programs/phul.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 70,
   "tags": ["4 day", "Power + hypertrophy", "Upper lower"],
   "summary": "Alternating power and hypertrophy focused days to build strength and size together.",
+  "rationale": "Heavy compound work at the start of the week reinforces neural drive so you can express strength, while higher-rep hypertrophy days accumulate volume for muscle growth. The split repeats twice weekly for each muscle group, giving optimal frequency with built-in intensity variation.",
+  "faqs": [
+    {
+      "q": "How should I pace the power sets?",
+      "a": "Rest 2–3 minutes between heavy compound sets so you can produce maximal force without technique breakdown."
+    },
+    {
+      "q": "Do I need to train six days?",
+      "a": "No, four dedicated lifting sessions cover the plan; add optional light cardio or mobility on off days if desired."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/push-pull-legs.json
+++ b/src/content/programs/push-pull-legs.json
@@ -7,14 +7,16 @@
   "durationPerSessionMin": 65,
   "tags": ["Push/pull/legs", "High volume", "Bodybuilding"],
   "summary": "A classic push, pull, legs split that stacks volume across six weekly sessions for experienced lifters.",
+  "rationale": "Each muscle group gets a heavy day and a pump-focused day, allowing you to accumulate 10–20 quality sets per week without burning out. Rotating rep targets and RIR guidelines keep progressive overload structured while still leaving room to chase a pump on accessory work.",
+  "deloadWeeks": [2],
   "faqs": [
     {
-      "question": "Can I reduce to five days?",
-      "answer": "You can drop one accessory-focused day when life gets busy and resume the full split the following week."
+      "q": "Can I reduce to five days?",
+      "a": "You can drop one accessory-focused day when life gets busy and resume the full split the following week."
     },
     {
-      "question": "What if I am short on equipment?",
-      "answer": "Swap cable or machine accessories for dumbbell variations when needed and keep the compound lifts consistent."
+      "q": "What if I am short on equipment?",
+      "a": "Swap cable or machine accessories for dumbbell variations when needed and keep the compound lifts consistent."
     }
   ],
   "weeks": [

--- a/src/content/programs/strength-5x5.json
+++ b/src/content/programs/strength-5x5.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 65,
   "tags": ["5x5", "Strength focus", "Simple progression"],
   "summary": "A classic three day 5x5 strength split built around the squat, press, and pull.",
+  "rationale": "Heavy 5x5 work delivers enough volume in the 70–85% 1RM range to drive strength without overshooting recovery. Small accessory supersets shore up weak links while the repeated exposure to core lifts ensures you can track progress clearly.",
+  "faqs": [
+    {
+      "q": "What if I stall on a lift?",
+      "a": "Repeat the same weight the following week; if you miss twice, drop 5–7% and build back up."
+    },
+    {
+      "q": "Can I add conditioning?",
+      "a": "Keep conditioning to short low-intensity sessions after lifting or on rest days so leg strength is not compromised."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/content/programs/upper-lower.json
+++ b/src/content/programs/upper-lower.json
@@ -7,14 +7,16 @@
   "durationPerSessionMin": 60,
   "tags": ["Upper/lower", "Strength focus", "4-day split"],
   "summary": "Alternating upper and lower body strength sessions with accessory finishers to drive progressive overload.",
+  "rationale": "Heavy compound lifts anchor each day so you can track progressive overload, while higher-rep accessory work fills in weak links and drives hypertrophy. Splitting upper and lower sessions balances fatigue across the week, and the built-in deload week pulls volume back so you come into the next block fresh.",
+  "deloadWeeks": [2],
   "faqs": [
     {
-      "question": "Who is this program best for?",
-      "answer": "Intermediate lifters who want a balanced mix of heavy compounds and hypertrophy accessories across four days."
+      "q": "Who is this program best for?",
+      "a": "Intermediate lifters who want a balanced mix of heavy compounds and hypertrophy accessories across four days."
     },
     {
-      "question": "Can I add cardio?",
-      "answer": "Yes, add light cardio on rest days or after lifts as long as it does not interfere with recovery."
+      "q": "Can I add cardio?",
+      "a": "Yes, add light cardio on rest days or after lifts as long as it does not interfere with recovery."
     }
   ],
   "weeks": [

--- a/src/content/programs/womens-glute-focus.json
+++ b/src/content/programs/womens-glute-focus.json
@@ -7,6 +7,17 @@
   "durationPerSessionMin": 60,
   "tags": ["Glute focus", "3-4 day", "Lower body"],
   "summary": "Targeted glute and leg training with one optional pump day for extra volume.",
+  "rationale": "Heavy hip hinge and squat variations provide the mechanical tension needed for glute growth, while pump sessions layer on metabolite work for extra stimulus. The optional day lets you auto-regulate volume based on recovery so you can stay consistent during busy weeks.",
+  "faqs": [
+    {
+      "q": "Do I need to perform the optional day?",
+      "a": "Use it when you feel fresh—skip it during stressful weeks so core sessions stay high quality."
+    },
+    {
+      "q": "What if a machine isn't available?",
+      "a": "Swap to dumbbell or banded alternatives that mimic the same direction of resistance and rep range."
+    }
+  ],
   "weeks": [
     {
       "days": [

--- a/src/lib/coach/types.ts
+++ b/src/lib/coach/types.ts
@@ -11,8 +11,8 @@ export type ProgramEquipment =
   | "bands";
 
 export interface ProgramFaq {
-  question: string;
-  answer: string;
+  q: string;
+  a: string;
 }
 
 export interface Program {
@@ -28,6 +28,11 @@ export interface Program {
   tags?: string[];
   heroImg?: string;
   faqs?: ProgramFaq[];
+  rationale?: string;
+  /**
+   * 1-based week numbers that should automatically run as deloads.
+   */
+  deloadWeeks?: number[];
 }
 
 export interface Week {

--- a/src/pages/Programs/index.tsx
+++ b/src/pages/Programs/index.tsx
@@ -51,6 +51,9 @@ type RankedProgram = {
 
 const hasHeroImage = (meta: ProgramMeta) => Boolean(meta.heroImg);
 
+const equipmentLabel = (value: ProgramEquipment) =>
+  EQUIPMENT_OPTIONS.find((option) => option.value === value)?.label ?? value;
+
 const deriveSummary = (program: Program, meta: ProgramMeta) => {
   if (program.summary) return program.summary;
   return `A ${meta.daysPerWeek}-day, ${meta.weeks}-week plan focused on ${goalLabels[meta.goal].toLowerCase()}.`;
@@ -257,6 +260,13 @@ export default function ProgramsCatalog() {
         <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
           {rankedPrograms.map(({ entry, score }) => {
             const { meta, program } = entry;
+            const weeksLabel = meta.weeks === 1 ? "wk" : "wks";
+            const sessionLengthLabel = meta.durationPerSessionMin
+              ? `${meta.durationPerSessionMin} min`
+              : "~45 min";
+            const scheduleCaption = `${meta.daysPerWeek} d/wk • ${meta.weeks} ${weeksLabel} • ${sessionLengthLabel}`;
+            const hasDeload = Boolean(program.deloadWeeks && program.deloadWeeks.length);
+            const equipmentSummary = Array.from(new Set(meta.equipment)).map((item) => equipmentLabel(item)).join(" • ");
             return (
               <Card
                 key={meta.id}
@@ -269,49 +279,59 @@ export default function ProgramsCatalog() {
                     navigate(`/programs/${meta.id}`);
                   }
                 }}
-                className="group flex h-full flex-col overflow-hidden transition hover:border-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+                className="group flex h-full flex-col overflow-hidden border bg-card/70 transition hover:-translate-y-1 hover:shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
               >
-                <div className="relative overflow-hidden">
+                <div className="relative">
                   <AspectRatio ratio={16 / 9}>
-                    {hasHeroImage(meta) ? (
-                      <img
-                        src={meta.heroImg}
-                        alt={program.title}
-                        className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.02]"
-                      />
-                    ) : (
-                      <div className="h-full w-full bg-gradient-to-br from-primary/20 via-primary/5 to-background" />
-                    )}
+                    <div className="relative h-full w-full">
+                      {hasHeroImage(meta) ? (
+                        <img
+                          src={meta.heroImg}
+                          alt={program.title}
+                          className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.03]"
+                        />
+                      ) : (
+                        <div className="h-full w-full bg-gradient-to-br from-primary/25 via-primary/10 to-background" />
+                      )}
+                      <div className="absolute inset-0 bg-gradient-to-t from-background via-background/30 to-transparent" />
+                      <div className="absolute bottom-3 left-3 flex flex-wrap gap-2 text-[11px] font-semibold text-foreground">
+                        <span className="rounded-full bg-background/80 px-3 py-1 shadow-sm backdrop-blur-sm">
+                          {goalLabels[meta.goal]}
+                        </span>
+                        <span className="rounded-full bg-background/70 px-3 py-1 shadow-sm backdrop-blur-sm">
+                          {levelLabels[meta.level]}
+                        </span>
+                      </div>
+                    </div>
                   </AspectRatio>
                 </div>
-                <CardHeader className="flex-1 space-y-2">
-                  <CardTitle className="text-xl">{program.title}</CardTitle>
-                  <p className="text-sm text-muted-foreground line-clamp-3">
-                    {deriveSummary(program, meta)}
-                  </p>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <div className="flex flex-wrap gap-2 text-xs">
-                    <Badge variant="secondary">{goalLabels[meta.goal]}</Badge>
-                    <Badge variant="outline">{levelLabels[meta.level]}</Badge>
-                    <Badge variant="outline">{meta.daysPerWeek} days / wk</Badge>
-                    <Badge variant="outline">{meta.weeks} weeks</Badge>
+                <div className="flex flex-1 flex-col gap-4 p-5">
+                  <div className="space-y-2">
+                    <h3 className="text-lg font-semibold text-foreground">{program.title}</h3>
+                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                      {scheduleCaption}
+                    </p>
+                    <p className="text-sm text-muted-foreground line-clamp-3">
+                      {deriveSummary(program, meta)}
+                    </p>
                   </div>
                   {program.tags && program.tags.length > 0 && (
-                    <div className="flex flex-wrap gap-2 text-xs">
+                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
                       {program.tags.map((tag) => (
-                        <span key={tag} className="rounded-full bg-muted px-2 py-1 text-[11px] text-muted-foreground">
+                        <span key={tag} className="rounded-full bg-muted px-2 py-1 text-[11px]">
                           {tag}
                         </span>
                       ))}
                     </div>
                   )}
-                  {hasActiveFilters && (
-                    <p className="text-xs font-medium text-primary">
-                      Match score: {score}%
-                    </p>
-                  )}
-                </CardContent>
+                  <div className="mt-auto flex flex-wrap items-center gap-2 text-[11px] text-muted-foreground">
+                    <span>{equipmentSummary}</span>
+                    {hasDeload && <span className="rounded-full bg-muted px-2 py-1 text-[10px] uppercase">Deload built-in</span>}
+                    {hasActiveFilters && (
+                      <span className="ml-auto font-medium text-primary">Match score: {score}%</span>
+                    )}
+                  </div>
+                </div>
               </Card>
             );
           })}


### PR DESCRIPTION
## Summary
- add deload helpers that detect deload weeks, scale day prescriptions, and surface a deload badge in the workout view
- enrich every program definition with rationale blurbs, FAQs, and deload metadata to support the new UI copy
- polish the programs catalog and detail pages with at-a-glance metadata, hero overlays, and FAQ accordions for a more professional catalog feel

## Testing
- `npm run build` *(fails: vite binary unavailable because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d813a73b148325a4128bce95de9007