### PR TITLE
Fix coach Firestore paths and guard missing plan doc

### DIFF
--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { auth, db } from "@/lib/firebase";
 import { doc, onSnapshot } from "firebase/firestore";
+import { coachPlanDoc } from "@/lib/db/coachPaths";
 
 export interface CoachProfile {
   sex?: "male" | "female";
@@ -44,7 +45,7 @@ export function useUserProfile() {
     const unsub1 = onSnapshot(profileRef, (snap) => {
       setProfile((snap.data() as CoachProfile) || null);
     });
-    const planRef = doc(db, "users", uid, "coach", "plan", "current");
+    const planRef = coachPlanDoc(uid);
     const unsub2 = onSnapshot(planRef, (snap) => {
       setPlan((snap.data() as CoachPlan) || null);
     });

--- a/src/lib/db/coachPaths.ts
+++ b/src/lib/db/coachPaths.ts
@@ -1,0 +1,7 @@
+import { collection, doc } from "firebase/firestore";
+
+import { db } from "@/lib/firebase";
+
+export const coachPlanDoc = (uid: string) => doc(db, "users", uid, "coach", "plan");
+
+export const workoutLogsCol = (uid: string) => collection(db, "users", uid, "workoutLogs");

--- a/src/pages/Coach/Day.tsx
+++ b/src/pages/Coach/Day.tsx
@@ -28,8 +28,8 @@ import {
 } from "@/lib/coach/progression";
 import type { Day as ProgramDay, Exercise, ExerciseSubstitution } from "@/lib/coach/types";
 import { loadAllPrograms, type CatalogEntry } from "@/lib/coach/catalog";
+import { workoutLogsCol } from "@/lib/db/coachPaths";
 import {
-  collection,
   addDoc,
   doc,
   getDocs,
@@ -238,7 +238,7 @@ export default function CoachDay() {
       }
 
       try {
-        const logsRef = collection(db, "users", user.uid, "workoutLogs");
+        const logsRef = workoutLogsCol(user.uid);
         const recentQuery = query(logsRef, orderBy("completedAt", "desc"), limit(20));
         const snapshot = await getDocs(recentQuery);
         const entries = snapshot.docs.map((docSnap) => docSnap.data());
@@ -381,7 +381,7 @@ export default function CoachDay() {
 
     setIsSaving(true);
     try {
-      const logsRef = collection(db, "users", user.uid, "workoutLogs");
+      const logsRef = workoutLogsCol(user.uid);
       await addDoc(logsRef, {
         programId: rawProgram.id,
         weekIdx: safeWeekIdx,


### PR DESCRIPTION
## Summary
- add shared Firestore helpers for coach plan and workout logs
- update coach data subscriptions to use the canonical coach plan document path
- guard the Coach overview when no plan document exists and reuse helpers in workout logging

## Testing
- npm run lint *(fails: missing @eslint/js in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d827a403fc83259ad1a358a0d286d0