### PR TITLE
Use production nutrition search API

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -84,6 +84,10 @@
         }
       },
       {
+        "source": "/api/nutrition/search",
+        "function": "nutritionSearch"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -21,6 +21,17 @@ async function authedFetch(path: string, init?: RequestInit) {
   });
 }
 
+export function fetchNutritionSearch(query: string, init?: RequestInit) {
+  const url = `/api/nutrition/search?q=${encodeURIComponent(query)}`;
+  return fetch(url, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      ...(init?.headers || {}),
+    },
+  });
+}
+
 export async function startScan(params: {
   filename: string;
   size: number;


### PR DESCRIPTION
## Summary
- add a Firebase Hosting rewrite that routes /api/nutrition/search to the nutritionSearch function
- provide a shared API helper for nutrition search and switch the shim to call the deployed endpoint
- remove local nutrition mock data so meal search always uses real results

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js' from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68ddae59b88483259f85d8e3fa462b97