### PR TITLE
feat: live nutrition search (USDA + OFF) + servings editor

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -60,10 +60,8 @@
       },
       {
         "source": "/api/nutrition/search",
-        "function": {
-          "functionId": "nutritionSearch",
-          "region": "us-central1"
-        }
+        "function": "nutritionSearch",
+        "functionRegion": "us-central1"
       },
       {
         "source": "/api/scan/start",

--- a/src/components/nutrition/ServingEditor.tsx
+++ b/src/components/nutrition/ServingEditor.tsx
@@ -4,7 +4,7 @@ import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import type { NormalizedItem } from "@/lib/nutritionShim";
+import type { FoodItem } from "@/lib/nutrition/types";
 import {
   SERVING_UNITS,
   type ServingUnit,
@@ -16,7 +16,7 @@ import {
 import type { MealEntry } from "@/lib/nutrition";
 
 interface ServingEditorProps {
-  item: NormalizedItem;
+  item: FoodItem;
   defaultQty?: number;
   defaultUnit?: ServingUnit;
   confirmLabel?: string;

--- a/src/lib/nutrition/types.ts
+++ b/src/lib/nutrition/types.ts
@@ -1,0 +1,43 @@
+export type NutritionSource = "USDA" | "Open Food Facts";
+
+export interface MacroBreakdown {
+  kcal: number;
+  protein: number;
+  carbs: number;
+  fat: number;
+}
+
+export interface ServingOption {
+  id: string;
+  label: string;
+  grams: number;
+  isDefault?: boolean;
+}
+
+export interface ServingInfo {
+  qty: number | null;
+  unit: string | null;
+  text?: string | null;
+}
+
+export interface ServingMacros {
+  kcal: number | null;
+  protein_g: number | null;
+  carbs_g: number | null;
+  fat_g: number | null;
+}
+
+export interface FoodItem {
+  id: string;
+  name: string;
+  brand: string | null;
+  source: NutritionSource;
+  basePer100g: MacroBreakdown;
+  servings: ServingOption[];
+  serving: ServingInfo;
+  per_serving: ServingMacros;
+  per_100g?: ServingMacros | null;
+  fdcId?: number;
+  gtin?: string;
+  raw?: unknown;
+}

--- a/src/lib/nutritionCollections.ts
+++ b/src/lib/nutritionCollections.ts
@@ -9,17 +9,17 @@ import {
   setDoc,
 } from "firebase/firestore";
 import { db, auth } from "@/lib/firebase";
-import type { NormalizedItem } from "@/lib/nutritionShim";
+import type { FoodItem } from "@/lib/nutrition/types";
 
 export interface FavoriteDoc {
   name: string;
   brand?: string;
-  item: NormalizedItem;
+  item: FoodItem;
   updatedAt?: any;
 }
 
 export interface TemplateItem {
-  item: NormalizedItem;
+  item: FoodItem;
   qty: number;
   unit: string;
 }
@@ -70,7 +70,7 @@ export function subscribeTemplates(callback: (items: TemplateDocWithId[]) => voi
   });
 }
 
-export async function saveFavorite(item: NormalizedItem) {
+export async function saveFavorite(item: FoodItem) {
   const uid = assertUid();
   const ref = doc(db, `users/${uid}/nutrition/favorites/${item.id}`);
   const payload: FavoriteDoc = {

--- a/src/lib/nutritionMath.ts
+++ b/src/lib/nutritionMath.ts
@@ -1,4 +1,4 @@
-import type { NormalizedItem } from "@/lib/nutritionShim";
+import type { FoodItem } from "@/lib/nutrition/types";
 import type { MealEntry, MealItemSnapshot } from "@/lib/nutrition";
 
 export const SERVING_UNITS = ["serving", "g", "oz", "cups", "slices", "pieces"] as const;
@@ -30,14 +30,14 @@ function normalizeUnit(unit: string | null | undefined) {
   return clean;
 }
 
-function defaultServingOption(item: NormalizedItem) {
+function defaultServingOption(item: FoodItem) {
   if (Array.isArray(item.servings) && item.servings.length) {
     return item.servings.find((option) => option.isDefault) ?? item.servings[0];
   }
   return null;
 }
 
-export function estimateServingWeight(item: NormalizedItem): number | null {
+export function estimateServingWeight(item: FoodItem): number | null {
   const defaultServing = defaultServingOption(item);
   if (defaultServing?.grams) {
     return round(defaultServing.grams, 2);
@@ -71,7 +71,7 @@ export function estimateServingWeight(item: NormalizedItem): number | null {
   return round(grams, 2);
 }
 
-function gramsForSelection(item: NormalizedItem, qty: number, unit: ServingUnit): number | null {
+function gramsForSelection(item: FoodItem, qty: number, unit: ServingUnit): number | null {
   switch (unit) {
     case "g":
       return qty;
@@ -98,7 +98,7 @@ export interface SelectionResult {
 }
 
 export function calculateSelection(
-  item: NormalizedItem,
+  item: FoodItem,
   qty: number,
   unit: ServingUnit,
 ): SelectionResult {
@@ -127,7 +127,7 @@ export function calculateSelection(
   };
 }
 
-export function snapshotFromItem(item: NormalizedItem): MealItemSnapshot {
+export function snapshotFromItem(item: FoodItem): MealItemSnapshot {
   return {
     id: item.id,
     name: item.name,
@@ -145,7 +145,7 @@ export function snapshotFromItem(item: NormalizedItem): MealItemSnapshot {
   };
 }
 
-export function normalizedFromSnapshot(snapshot: MealItemSnapshot): NormalizedItem {
+export function normalizedFromSnapshot(snapshot: MealItemSnapshot): FoodItem {
   return {
     id: snapshot.id || `snapshot-${Math.random().toString(36).slice(2, 8)}`,
     name: snapshot.name,
@@ -179,7 +179,7 @@ export function normalizedFromSnapshot(snapshot: MealItemSnapshot): NormalizedIt
 }
 
 export function buildMealEntry(
-  item: NormalizedItem,
+  item: FoodItem,
   qty: number,
   unit: ServingUnit,
   result: SelectionResult,

--- a/src/pages/BarcodeScan.tsx
+++ b/src/pages/BarcodeScan.tsx
@@ -5,7 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "@/hooks/use-toast";
-import { lookupBarcode, type NormalizedItem } from "@/lib/nutritionShim";
+import { lookupBarcode } from "@/lib/nutritionShim";
+import type { FoodItem } from "@/lib/nutrition/types";
 import { addMeal } from "@/lib/nutrition";
 import { Seo } from "@/components/Seo";
 import { defaultCountryFromLocale } from "@/lib/locale";
@@ -21,7 +22,7 @@ export default function BarcodeScan() {
   const [torchAvailable, setTorchAvailable] = useState(false);
   const [torchOn, setTorchOn] = useState(false);
   const [detectedCode, setDetectedCode] = useState<string | null>(null);
-  const [item, setItem] = useState<NormalizedItem | null>(null);
+  const [item, setItem] = useState<FoodItem | null>(null);
   const [loadingItem, setLoadingItem] = useState(false);
   const [processing, setProcessing] = useState(false);
 

--- a/src/pages/Meals.tsx
+++ b/src/pages/Meals.tsx
@@ -16,7 +16,7 @@ import {
   type MealEntry,
   type NutritionHistoryDay,
 } from "@/lib/nutrition";
-import { type NormalizedItem } from "@/lib/nutritionShim";
+import type { FoodItem } from "@/lib/nutrition/types";
 import {
   subscribeFavorites,
   subscribeTemplates,
@@ -35,11 +35,11 @@ import { ServingEditor } from "@/components/nutrition/ServingEditor";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { NutritionMacrosChart } from "@/components/charts/NutritionMacrosChart";
 
-const RECENTS_KEY = "mbs_nutrition_recents_v2";
+const RECENTS_KEY = "mbs_nutrition_recents_v3";
 const MAX_RECENTS = 50;
 const DAILY_TARGET = 2200;
 
-interface RecentItem extends NormalizedItem {}
+interface RecentItem extends FoodItem {}
 
 function readRecents(): RecentItem[] {
   if (typeof window === "undefined") return [];
@@ -76,7 +76,7 @@ export default function Meals() {
   const [favorites, setFavorites] = useState<FavoriteDocWithId[]>([]);
   const [templates, setTemplates] = useState<TemplateDocWithId[]>([]);
   const [editorOpen, setEditorOpen] = useState(false);
-  const [editorItem, setEditorItem] = useState<NormalizedItem | null>(null);
+  const [editorItem, setEditorItem] = useState<FoodItem | null>(null);
   const [editorUnit, setEditorUnit] = useState<ServingUnit>("serving");
   const [editorQty, setEditorQty] = useState<number>(1);
   const demo = useDemoMode();
@@ -122,7 +122,7 @@ export default function Meals() {
   }, []);
 
   const updateRecents = useCallback(
-    (item: NormalizedItem) => {
+    (item: FoodItem) => {
       const next = [item, ...recents.filter((recent) => recent.id !== item.id)].slice(0, MAX_RECENTS);
       setRecents(next);
       storeRecents(next);
@@ -130,7 +130,7 @@ export default function Meals() {
     [recents],
   );
 
-  const openEditor = (item: NormalizedItem, qty = 1, unit: ServingUnit = "serving") => {
+  const openEditor = (item: FoodItem, qty = 1, unit: ServingUnit = "serving") => {
     setEditorItem(item);
     setEditorQty(qty);
     setEditorUnit(unit);
@@ -231,7 +231,7 @@ export default function Meals() {
       for (const entry of template.items) {
         const unit = (entry.unit as ServingUnit) || "serving";
         const qty = entry.qty ?? 1;
-        const item = entry.item as NormalizedItem;
+        const item = entry.item as FoodItem;
         const result = calculateSelection(item, qty, unit);
         const meal = buildMealEntry(item, qty, unit, result, "template");
         await addMeal(todayISO, meal);

--- a/src/pages/MealsSearch.tsx
+++ b/src/pages/MealsSearch.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Search, Plus, Barcode, Loader2, Star, StarOff } from "lucide-react";
 import { AppHeader } from "@/components/AppHeader";
 import { BottomNav } from "@/components/BottomNav";
@@ -6,35 +6,33 @@ import { Seo } from "@/components/Seo";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import { toast } from "@/hooks/use-toast";
-import { searchFoods, type NormalizedItem } from "@/lib/nutritionShim";
-import { addMeal } from "@/lib/nutrition";
+import { fetchFoods } from "@/lib/api";
+import type { FoodItem, ServingOption } from "@/lib/nutrition/types";
 import {
   saveFavorite,
   removeFavorite,
   subscribeFavorites,
   type FavoriteDocWithId,
 } from "@/lib/nutritionCollections";
-import { ServingChooser } from "@/components/ServingChooser";
-import { calcMacrosFromGrams, fromOFF, fromSearchItem, fromUSDA, type FoodNormalized } from "@/lib/nutrition/measureMap";
+import { useDemoMode } from "@/components/DemoModeProvider";
+import { auth, db } from "@/lib/firebase";
+import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 
-const RECENTS_KEY = "mbs_nutrition_recents_v2";
+const RECENTS_KEY = "mbs_nutrition_recents_v3";
 const MAX_RECENTS = 50;
+const OUNCES_IN_GRAM = 0.0352739619;
 
-function readRecents(): NormalizedItem[] {
+function readRecents(): FoodItem[] {
   if (typeof window === "undefined") return [];
   const raw = window.localStorage.getItem(RECENTS_KEY);
   if (!raw) return [];
   try {
     const parsed = JSON.parse(raw);
     if (Array.isArray(parsed)) {
-      return parsed
-        .slice(0, MAX_RECENTS)
-        .map((item: NormalizedItem) => ({
-          ...item,
-          brand: item.brand ?? null,
-          source: item.source === "OFF" ? "Open Food Facts" : item.source,
-        }));
+      return parsed.slice(0, MAX_RECENTS);
     }
   } catch (error) {
     console.warn("recents_parse_error", error);
@@ -42,27 +40,182 @@ function readRecents(): NormalizedItem[] {
   return [];
 }
 
-function storeRecents(items: NormalizedItem[]) {
+function storeRecents(items: FoodItem[]) {
   if (typeof window === "undefined") return;
   window.localStorage.setItem(RECENTS_KEY, JSON.stringify(items.slice(0, MAX_RECENTS)));
 }
 
+function round(value: number, decimals = 1) {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function calculateMacros(base: FoodItem["basePer100g"], grams: number) {
+  if (!grams || grams <= 0) {
+    return { grams: 0, kcal: 0, protein: 0, carbs: 0, fat: 0 };
+  }
+  const factor = grams / 100;
+  return {
+    grams: round(grams, 2),
+    kcal: Math.round(base.kcal * factor),
+    protein: round(base.protein * factor),
+    carbs: round(base.carbs * factor),
+    fat: round(base.fat * factor),
+  };
+}
+
+function ouncesDisplay(grams: number) {
+  if (!grams || grams <= 0) return null;
+  return round(grams * OUNCES_IN_GRAM, 2);
+}
+
+function findCupServing(servings: ServingOption[]): ServingOption | undefined {
+  return servings.find((option) => option.label.toLowerCase().includes("cup"));
+}
+
+interface ServingModalProps {
+  item: FoodItem;
+  open: boolean;
+  busy: boolean;
+  onClose: () => void;
+  onConfirm: (payload: { grams: number; quantity: number }) => void;
+}
+
+function ServingModal({ item, open, busy, onClose, onConfirm }: ServingModalProps) {
+  const defaultServing = useMemo(() => {
+    if (!item.servings?.length) return null;
+    return item.servings.find((serving) => serving.isDefault) ?? item.servings[0]!;
+  }, [item.servings]);
+
+  const [grams, setGrams] = useState<number>(defaultServing?.grams ?? 100);
+  const [quantity, setQuantity] = useState<number>(1);
+
+  useEffect(() => {
+    const initial = item.servings?.find((option) => option.isDefault) ?? item.servings?.[0];
+    setGrams(initial?.grams ?? 100);
+    setQuantity(1);
+  }, [item]);
+
+  const totalGrams = Math.max(0, grams * quantity);
+  const macros = calculateMacros(item.basePer100g, totalGrams);
+  const ounces = ouncesDisplay(totalGrams);
+  const cupServing = useMemo(() => findCupServing(item.servings ?? []), [item.servings]);
+
+  const presets: { label: string; grams: number }[] = [
+    { label: "100 g", grams: 100 },
+    { label: "1 oz", grams: 28.35 },
+  ];
+  if (cupServing) {
+    presets.push({ label: "1 cup", grams: cupServing.grams });
+  }
+
+  const disableAdd = !grams || grams <= 0 || !quantity || quantity <= 0;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <DialogContent className="max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="flex flex-col gap-1">
+            <span>{item.name}</span>
+            <span className="text-sm font-normal text-muted-foreground">
+              {item.brand || item.source}
+            </span>
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-5">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="serving-grams">Grams per quantity</Label>
+              <Input
+                id="serving-grams"
+                type="number"
+                min="0"
+                step="0.1"
+                value={grams}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  setGrams(Number.isFinite(value) ? Math.max(0, value) : 0);
+                }}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="serving-quantity">Quantity</Label>
+              <Input
+                id="serving-quantity"
+                type="number"
+                min="0"
+                step="0.1"
+                value={quantity}
+                onChange={(event) => {
+                  const value = Number(event.target.value);
+                  setQuantity(Number.isFinite(value) ? Math.max(0, value) : 0);
+                }}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {presets.map((preset) => (
+              <Button
+                key={preset.label}
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setGrams(preset.grams)}
+              >
+                {preset.label}
+              </Button>
+            ))}
+          </div>
+
+          <div className="rounded-md bg-muted/60 p-4 text-sm">
+            <div className="font-medium text-foreground">Total</div>
+            <div className="mt-1 text-muted-foreground">
+              {macros.grams ? `${macros.grams} g` : "0 g"}
+              {ounces ? ` · ${ounces} oz` : ""}
+            </div>
+            <div className="mt-2 flex flex-wrap gap-3 text-sm text-muted-foreground">
+              <span>{macros.kcal} kcal</span>
+              <span>{macros.protein}g P</span>
+              <span>{macros.carbs}g C</span>
+              <span>{macros.fat}g F</span>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="ghost" onClick={onClose} disabled={busy}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              onClick={() => onConfirm({ grams: grams, quantity })}
+              disabled={busy || disableAdd}
+            >
+              {busy ? "Adding…" : "Add"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 export default function MealsSearch() {
+  const demo = useDemoMode();
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
-  const [results, setResults] = useState<NormalizedItem[]>([]);
-  const [recents, setRecents] = useState<NormalizedItem[]>(() => readRecents());
+  const [results, setResults] = useState<FoodItem[]>([]);
+  const [primarySource, setPrimarySource] = useState<"USDA" | "Open Food Facts" | null>(null);
+  const [recents, setRecents] = useState<FoodItem[]>(() => readRecents());
   const [favorites, setFavorites] = useState<FavoriteDocWithId[]>([]);
-  const [chooser, setChooser] = useState<{ item: NormalizedItem; food: FoodNormalized } | null>(null);
+  const [selectedItem, setSelectedItem] = useState<FoodItem | null>(null);
   const [logging, setLogging] = useState(false);
-  const today = useMemo(() => new Date().toISOString().slice(0, 10), []);
 
   useEffect(() => {
     try {
       const unsub = subscribeFavorites(setFavorites);
-      return () => {
-        unsub?.();
-      };
+      return () => unsub?.();
     } catch (error) {
       console.warn("favorites_subscribe_error", error);
       setFavorites([]);
@@ -74,103 +227,47 @@ export default function MealsSearch() {
     const trimmed = query.trim();
     if (!trimmed) {
       setResults([]);
+      setPrimarySource(null);
+      setLoading(false);
       return;
     }
+
     setLoading(true);
+    let cancelled = false;
     const handle = window.setTimeout(() => {
-      searchFoods(trimmed)
-        .then(setResults)
-        .catch((error: any) => {
-          console.error(error);
-          if (typeof error?.status === "number" && error.status >= 500) {
-            toast({
-              title: "Nutrition search temporarily unavailable.",
-              description: "Please try again later.",
-              variant: "destructive",
-            });
-          } else {
+      fetchFoods(trimmed)
+        .then((items) => {
+          if (cancelled) return;
+          setResults(items);
+          setPrimarySource(items.length ? (items[0]!.source as "USDA" | "Open Food Facts") : null);
+        })
+        .catch((error) => {
+          if (cancelled) return;
+          if (!(error instanceof DOMException && error.name === "AbortError")) {
+            console.error("nutrition_search_error", error);
             toast({ title: "Search failed", description: "Try another food", variant: "destructive" });
           }
+          setResults([]);
+          setPrimarySource(null);
         })
-        .finally(() => setLoading(false));
-    }, 250);
-    return () => window.clearTimeout(handle);
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 300);
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
   }, [query]);
 
-  const openChooser = (item: NormalizedItem) => {
-    try {
-      const food = mapToFoodNormalized(item);
-      setChooser({ item, food });
-    } catch (error) {
-      console.error("serving_chooser_error", error);
-      toast({ title: "Unable to load servings", description: "Try another food", variant: "destructive" });
-    }
+  const updateRecents = (item: FoodItem) => {
+    const next = [item, ...recents.filter((recent) => recent.id !== item.id)].slice(0, MAX_RECENTS);
+    setRecents(next);
+    storeRecents(next);
   };
 
-  const updateRecents = useCallback(
-    (item: NormalizedItem) => {
-      const next = [item, ...recents.filter((recent) => recent.id !== item.id)].slice(0, MAX_RECENTS);
-      setRecents(next);
-      storeRecents(next);
-    },
-    [recents],
-  );
-
-  const handleChooserConfirm = async (selection: { grams: number; label: string; quantity: number }) => {
-    if (!chooser || logging) return;
-    const current = chooser;
-    setChooser(null);
-    setLogging(true);
-    try {
-      const macros = calcMacrosFromGrams(current.food.basePer100g, selection.grams);
-      await addMeal(today, {
-        name: current.food.name,
-        protein: macros.protein,
-        carbs: macros.carbs,
-        fat: macros.fat,
-        calories: macros.kcal,
-        serving: {
-          qty: selection.quantity,
-          unit: selection.label,
-          grams: selection.grams,
-        },
-        item: {
-          id: current.food.id,
-          name: current.food.name,
-          brand: current.food.brand ?? null,
-          source: current.food.source,
-          serving: {
-            qty: selection.quantity,
-            unit: selection.label,
-            text: `${selection.quantity} ${selection.label}`,
-          },
-          per_serving: {
-            kcal: macros.kcal,
-            protein_g: macros.protein,
-            carbs_g: macros.carbs,
-            fat_g: macros.fat,
-          },
-          per_100g: {
-            kcal: current.food.basePer100g.kcal,
-            protein_g: current.food.basePer100g.protein,
-            carbs_g: current.food.basePer100g.carbs,
-            fat_g: current.food.basePer100g.fat,
-          },
-          fdcId: current.item.fdcId ?? null,
-          gtin: current.item.gtin,
-        },
-        entrySource: "search",
-      });
-      toast({ title: "Food logged", description: current.food.name });
-      updateRecents(current.item);
-    } catch (error: any) {
-      toast({ title: "Unable to log", description: error?.message || "Try again", variant: "destructive" });
-    } finally {
-      setLogging(false);
-    }
-  };
-
-  const toggleFavorite = async (item: NormalizedItem) => {
+  const toggleFavorite = async (item: FoodItem) => {
     try {
       const existing = favorites.find((fav) => fav.id === item.id);
       if (existing) {
@@ -178,12 +275,60 @@ export default function MealsSearch() {
         toast({ title: "Removed from favorites", description: item.name });
       } else {
         await saveFavorite(item);
-        toast({ title: "Favorited", description: item.name });
+        toast({ title: "Added to favorites", description: item.name });
       }
     } catch (error: any) {
       toast({ title: "Favorite update failed", description: error?.message || "Try again", variant: "destructive" });
     }
   };
+
+  const handleLogFood = async (item: FoodItem, grams: number, quantity: number) => {
+    if (demo) {
+      toast({ title: "Demo mode: sign in to save" });
+      return;
+    }
+
+    const user = auth.currentUser;
+    if (!user) {
+      toast({ title: "Sign in required", description: "Sign in to log meals.", variant: "destructive" });
+      return;
+    }
+
+    const totalGrams = grams * quantity;
+    const macros = calculateMacros(item.basePer100g, totalGrams);
+    const today = new Date().toISOString().slice(0, 10);
+
+    setLogging(true);
+    try {
+      const entriesRef = collection(db, `users/${user.uid}/nutritionLogs/${today}/entries`);
+      await addDoc(entriesRef, {
+        foodId: item.id,
+        name: item.name,
+        brand: item.brand ?? null,
+        grams: Math.round(totalGrams * 100) / 100,
+        kcal: macros.kcal,
+        protein: macros.protein,
+        carbs: macros.carbs,
+        fat: macros.fat,
+        source: item.source,
+        createdAt: serverTimestamp(),
+      });
+      toast({ title: "Food logged", description: item.name });
+      updateRecents(item);
+      setSelectedItem(null);
+    } catch (error: any) {
+      toast({ title: "Unable to log", description: error?.message || "Try again", variant: "destructive" });
+    } finally {
+      setLogging(false);
+    }
+  };
+
+  const primaryCaption =
+    primarySource === "Open Food Facts"
+      ? "OFF primary · USDA unavailable"
+      : "USDA primary · OFF fallback";
+
+  const favoritesMap = useMemo(() => new Map(favorites.map((fav) => [fav.id, fav])), [favorites]);
 
   return (
     <div className="min-h-screen bg-background pb-20 md:pb-0">
@@ -193,7 +338,7 @@ export default function MealsSearch() {
         <div className="space-y-2 text-center">
           <Search className="mx-auto h-10 w-10 text-primary" />
           <h1 className="text-2xl font-semibold text-foreground">Search Foods</h1>
-          <p className="text-sm text-muted-foreground">Tap a result to adjust servings. Results use kcal and US units.</p>
+          <p className="text-sm text-muted-foreground">Tap a result to adjust servings and log it to your meals.</p>
         </div>
 
         <form className="flex gap-2" onSubmit={(event) => event.preventDefault()}>
@@ -220,7 +365,7 @@ export default function MealsSearch() {
             </CardHeader>
             <CardContent className="flex flex-wrap gap-2">
               {favorites.map((fav) => (
-                <Button key={fav.id} variant="secondary" size="sm" onClick={() => openChooser(fav.item)}>
+                <Button key={fav.id} variant="secondary" size="sm" onClick={() => setSelectedItem(fav.item)}>
                   {fav.item.name}
                 </Button>
               ))}
@@ -231,13 +376,11 @@ export default function MealsSearch() {
         {recents.length > 0 && (
           <Card>
             <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-base">
-                <HistoryIcon /> Recent
-              </CardTitle>
+              <CardTitle className="flex items-center gap-2 text-base">Recent</CardTitle>
             </CardHeader>
             <CardContent className="flex flex-wrap gap-2">
               {recents.slice(0, 8).map((item) => (
-                <Button key={item.id} variant="outline" size="sm" onClick={() => openChooser(item)}>
+                <Button key={item.id} variant="outline" size="sm" onClick={() => setSelectedItem(item)}>
                   {item.name}
                 </Button>
               ))}
@@ -248,7 +391,7 @@ export default function MealsSearch() {
         <Card>
           <CardHeader className="flex items-center justify-between">
             <CardTitle>Results</CardTitle>
-            <div className="text-xs text-muted-foreground">USDA primary · OFF fallback</div>
+            <div className="text-xs text-muted-foreground">{primaryCaption}</div>
           </CardHeader>
           <CardContent className="space-y-3">
             {loading && (
@@ -256,22 +399,27 @@ export default function MealsSearch() {
                 <Loader2 className="h-4 w-4 animate-spin" /> Searching databases…
               </div>
             )}
-            {!loading && !results.length && query.trim().length > 0 && (
-              <p className="text-sm text-muted-foreground">No matches. Try another term or scan the barcode.</p>
+            {!loading && results.length === 0 && query.trim().length > 0 && (
+              <p className="text-sm text-muted-foreground">
+                No matches. Try ‘chicken breast’, ‘rice’, or scan a barcode.
+              </p>
             )}
-            {!loading && !query.trim() && <p className="text-sm text-muted-foreground">Enter a food name to begin.</p>}
+            {!loading && !query.trim() && (
+              <p className="text-sm text-muted-foreground">Enter a food name to begin.</p>
+            )}
             {results.map((item) => {
-              const favorite = favorites.find((fav) => fav.id === item.id);
-              const subtitle = item.brand ?? item.source;
+              const favorite = favoritesMap.get(item.id);
+              const subtitle = item.brand || item.source;
+              const base = item.basePer100g;
               return (
                 <Card key={item.id} className="border">
-                  <CardContent className="flex flex-col gap-2 py-4 text-sm md:flex-row md:items-center md:justify-between">
+                  <CardContent className="flex flex-col gap-3 py-4 text-sm md:flex-row md:items-center md:justify-between">
                     <div className="space-y-1">
                       <p className="font-medium text-foreground">{item.name}</p>
                       <p className="text-xs uppercase tracking-wide text-muted-foreground">{subtitle}</p>
                       <p className="text-xs text-muted-foreground">
-                        {item.per_serving.kcal ?? "—"} kcal • {item.per_serving.protein_g ?? "—"}g P • {item.per_serving.carbs_g ?? "—"}g C •
-                        {item.per_serving.fat_g ?? "—"}g F
+                        {Math.round(base.kcal)} kcal · {round(base.protein)}g P · {round(base.carbs)}g C · {round(base.fat)}g F
+                        &nbsp;<span className="text-[10px] text-muted-foreground">per 100 g</span>
                       </p>
                     </div>
                     <div className="flex flex-wrap items-center gap-2">
@@ -282,7 +430,7 @@ export default function MealsSearch() {
                           <StarOff className="h-4 w-4" />
                         )}
                       </Button>
-                      <Button size="sm" onClick={() => openChooser(item)} disabled={logging}>
+                      <Button size="sm" onClick={() => setSelectedItem(item)}>
                         <Plus className="mr-1 h-4 w-4" /> Add
                       </Button>
                     </div>
@@ -295,183 +443,15 @@ export default function MealsSearch() {
       </main>
       <BottomNav />
 
-      {chooser && (
-        <ServingChooser
-          food={chooser.food}
-          onClose={() => setChooser(null)}
-          onConfirm={handleChooserConfirm}
+      {selectedItem && (
+        <ServingModal
+          item={selectedItem}
+          open={Boolean(selectedItem)}
+          busy={logging}
+          onClose={() => (!logging ? setSelectedItem(null) : undefined)}
+          onConfirm={({ grams, quantity }) => handleLogFood(selectedItem, grams, quantity)}
         />
       )}
     </div>
   );
-}
-
-function HistoryIcon() {
-  return (
-    <svg className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-      <path d="M3 12a9 9 0 1 1 3.89 7.39" />
-      <polyline points="3 12 6 9 9 12" />
-      <line x1="12" y1="7" x2="12" y2="12" />
-      <line x1="12" y1="12" x2="15" y2="15" />
-    </svg>
-  );
-}
-
-function mapToFoodNormalized(item: NormalizedItem): FoodNormalized {
-  const hasServings = Array.isArray(item.servings) && item.servings.length > 0;
-  const baseFromItem = item.basePer100g
-    ? {
-        kcal: numberOrZero(item.basePer100g.kcal),
-        protein: numberOrZero(item.basePer100g.protein, 1),
-        carbs: numberOrZero(item.basePer100g.carbs, 1),
-        fat: numberOrZero(item.basePer100g.fat, 1),
-      }
-    : item.per_100g
-    ? {
-        kcal: numberOrZero(item.per_100g.kcal),
-        protein: numberOrZero(item.per_100g.protein_g, 1),
-        carbs: numberOrZero(item.per_100g.carbs_g, 1),
-        fat: numberOrZero(item.per_100g.fat_g, 1),
-      }
-    : null;
-
-  if (hasServings && baseFromItem) {
-    return fromSearchItem({
-      id: item.id,
-      name: item.name,
-      brand: item.brand ?? null,
-      source: item.source,
-      basePer100g: baseFromItem,
-      servings: item.servings ?? [],
-    });
-  }
-
-  if (item.source === "USDA" && item.raw) {
-    try {
-      return fromUSDA(item.raw);
-    } catch (error) {
-      console.warn("usda_map_error", error);
-    }
-  }
-  if ((item.source === "Open Food Facts" || item.source === "OFF") && item.raw) {
-    try {
-      return fromOFF(item.raw);
-    } catch (error) {
-      console.warn("off_map_error", error);
-    }
-  }
-  return fallbackFoodNormalized(item);
-}
-
-function fallbackFoodNormalized(item: NormalizedItem): FoodNormalized {
-  const base: FoodNormalized["basePer100g"] = item.basePer100g
-    ? {
-        kcal: numberOrZero(item.basePer100g.kcal),
-        protein: numberOrZero(item.basePer100g.protein, 1),
-        carbs: numberOrZero(item.basePer100g.carbs, 1),
-        fat: numberOrZero(item.basePer100g.fat, 1),
-      }
-    : {
-        kcal: numberOrZero(item.per_100g?.kcal),
-        protein: numberOrZero(item.per_100g?.protein_g, 1),
-        carbs: numberOrZero(item.per_100g?.carbs_g, 1),
-        fat: numberOrZero(item.per_100g?.fat_g, 1),
-      };
-
-  const servingGrams = parseServingGrams(item);
-  if (servingGrams && !baseHasValues(base)) {
-    const factor = 100 / servingGrams;
-    base.kcal = numberOrZero((item.per_serving.kcal ?? 0) * factor, 0);
-    base.protein = numberOrZero((item.per_serving.protein_g ?? 0) * factor, 1);
-    base.carbs = numberOrZero((item.per_serving.carbs_g ?? 0) * factor, 1);
-    base.fat = numberOrZero((item.per_serving.fat_g ?? 0) * factor, 1);
-  }
-
-  const servings: FoodNormalized["servings"] = [
-    { id: "100g", label: "100 g", grams: 100, isDefault: true },
-  ];
-
-  if (servingGrams) {
-    const label =
-      (typeof item.serving.text === "string" && item.serving.text.trim()) ||
-      buildServingLabel(item.serving.qty, item.serving.unit) ||
-      `${servingGrams} g`;
-    if (!servings.some((option) => option.label === label)) {
-      servings.push({ id: `${item.id}-serving`, label, grams: Number(servingGrams.toFixed(2)) });
-    }
-  }
-
-  return {
-    id: item.id,
-    name: item.name,
-    brand: item.brand,
-    source: item.source,
-    basePer100g: base,
-    servings,
-  };
-}
-
-function numberOrZero(value: unknown, decimals = 0): number {
-  const num = Number(value);
-  if (!Number.isFinite(num)) return 0;
-  const factor = 10 ** decimals;
-  return Math.round(num * factor) / factor;
-}
-
-function baseHasValues(base: FoodNormalized["basePer100g"]): boolean {
-  return Boolean(base.kcal || base.protein || base.carbs || base.fat);
-}
-
-function parseServingGrams(item: NormalizedItem): number | null {
-  const qty = typeof item.serving.qty === "number" ? item.serving.qty : null;
-  const unit = typeof item.serving.unit === "string" ? item.serving.unit : null;
-  const gramsFromUnit = convertToGrams(qty, unit);
-  if (gramsFromUnit) return gramsFromUnit;
-  if (typeof item.serving.text === "string") {
-    const match = item.serving.text.match(/([\d.,]+)\s*(g|oz|ml|kg|lb)/i);
-    if (match) {
-      return convertToGrams(Number(match[1].replace(/,/g, "")), match[2]);
-    }
-  }
-  return null;
-}
-
-function convertToGrams(quantity: number | null, unit: string | null): number | null {
-  if (!quantity || quantity <= 0 || !unit) return null;
-  const normalized = unit.trim().toLowerCase();
-  switch (normalized) {
-    case "g":
-    case "gram":
-    case "grams":
-      return quantity;
-    case "kg":
-    case "kilogram":
-    case "kilograms":
-      return quantity * 1000;
-    case "oz":
-    case "ounce":
-    case "ounces":
-      return quantity * 28.3495231;
-    case "lb":
-    case "lbs":
-    case "pound":
-    case "pounds":
-      return quantity * 453.59237;
-    case "ml":
-    case "milliliter":
-    case "milliliters":
-      return quantity;
-    case "l":
-    case "liter":
-    case "liters":
-      return quantity * 1000;
-    default:
-      return null;
-  }
-}
-
-function buildServingLabel(qty: number | null | undefined, unit: string | null | undefined): string | null {
-  if (!qty || !unit) return null;
-  const roundedQty = Math.round(qty * 100) / 100;
-  return `${roundedQty} ${unit}`;
 }


### PR DESCRIPTION
## Summary
- implement live USDA-first nutritionSearch Cloud Function with OFF fallback, CORS, rate limiting, and normalized payloads
- wire client nutrition search, barcode, and meals flows to new fetchFoods helper and remove mock data
- add serving editor modal and macro math updates so meals log real servings and honor demo-mode restrictions

## Testing
- `npm --prefix functions run build`
- `npm run build` *(fails: `vite` not found because npm install is blocked by registry policy for @opentelemetry/semantic-conventions)*

------
https://chatgpt.com/codex/tasks/task_e_68de71436f3c8325833aacbc0391ed12