### PR TITLE
feat: coach chat + plan, scan guardrails, test whitelist

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -27,3 +27,14 @@ npx firebase-tools deploy --only functions,hosting --project mybodyscan-f3daf --
    - Visit `https://mybodyscanapp.com/build.txt` and ensure `sha` matches the deployed commit.
 3. Smoke-test demo mode:
    - Browse `https://mybodyscanapp.com/welcome?demo=1` and confirm no seeded data appears.
+
+## Final verification checklist
+
+- Secrets in Secret Manager include: `USDA_FDC_API_KEY`, `STRIPE_SECRET`, `STRIPE_WEBHOOK`, and `OPENAI_API_KEY`.
+- Deploy command: `npx firebase-tools deploy --only functions,hosting --project mybodyscan-f3daf --force`
+- Post-deploy manual tests:
+  - https://mybodyscanapp.com → footer build tag matches latest commit.
+  - https://mybodyscanapp.com/welcome?demo=1 → browse freely, ensure write actions are blocked and no seeded calories appear.
+  - Meals search “chicken” → confirm live USDA results; Open Food Facts fallback banner shows only if USDA fails.
+  - Sign in as developer@adlrlabs.com → verify 3 free credits, run an end-to-end scan, confirm status transitions, and result saved under `users/{uid}/scans`.
+  - Coach Chat responds to a prompt and Regenerate Plan refreshes the weekly card.

--- a/firebase.json
+++ b/firebase.json
@@ -78,6 +78,13 @@
         }
       },
       {
+        "source": "/api/coach/chat",
+        "function": {
+          "functionId": "coachChat",
+          "region": "us-central1"
+        }
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }

--- a/functions/src/coachChat.ts
+++ b/functions/src/coachChat.ts
@@ -1,0 +1,198 @@
+import { onRequest, HttpsError } from "firebase-functions/v2/https";
+import type { Request as ExpressRequest, Response as ExpressResponse } from "express";
+import { Timestamp, getFirestore } from "./firebase.js";
+import { requireAuth, verifyAppCheckSoft } from "./http.js";
+import { withCors } from "./middleware/cors.js";
+import { enforceRateLimit } from "./middleware/rateLimit.js";
+
+const db = getFirestore();
+const MAX_TEXT_LENGTH = 800;
+const MIN_TEXT_LENGTH = 1;
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000;
+const RATE_LIMIT_COUNT = 30;
+const SYSTEM_PROMPT =
+  "You are a fitness coach. Provide safe, non-medical workout & nutrition suggestions in 120–160 words, using sets×reps and RPE ranges. Consider goals, time available, and experience.";
+const OPENAI_MODELS = ["gpt-4o-mini", "gpt-3.5-turbo"] as const;
+
+type OpenAiModel = (typeof OPENAI_MODELS)[number];
+
+type ChatRecord = {
+  text: string;
+  response: string;
+  createdAt: Timestamp;
+  usedLLM: boolean;
+};
+
+function sanitizeInput(raw: unknown): string {
+  if (typeof raw !== "string") {
+    throw new HttpsError("invalid-argument", "text must be a string");
+  }
+  const trimmed = raw.trim();
+  if (trimmed.length < MIN_TEXT_LENGTH || trimmed.length > MAX_TEXT_LENGTH) {
+    throw new HttpsError("invalid-argument", "text must be 1-800 characters");
+  }
+  return trimmed;
+}
+
+function buildFallbackResponse(text: string): string {
+  const lower = text.toLowerCase();
+  const needsRecovery =
+    lower.includes("sore") || lower.includes("sleep") || lower.includes("tired") || lower.includes("ache");
+
+  if (needsRecovery) {
+    return [
+      "Let's treat today as a recovery-focused reset so you can push harder later.",
+      "Start with 10 minutes of easy cardio at RPE 4-5 to raise body temperature, then move into three mobility blocks:",
+      "• Thoracic opener: 2×12 cat-cows and 2×30s child's pose with reaches.",
+      "• Lower-body flow: 2×10 walking lunges with a slow return, followed by 2×30s couch stretch per leg.",
+      "• Core stability: 3×30s dead bugs and 3×12 bird-dogs at RPE 5.",
+      "Finish with light foam rolling on quads, glutes, and lats plus a 5 minute nasal-breathing walk.",
+      "Keep protein high (~0.8g per lb) and add a colorful carb + lean protein meal within two hours.",
+      "Hydrate with 16-20 oz water and aim for 8-9 hours of sleep tonight. Not medical advice, just smart recovery guidance."
+    ].join(" ");
+  }
+
+  const splitPlan = lower.includes("time") || lower.includes("busy") ? "upper/lower" : "push/pull/legs";
+  const sessions = splitPlan === "upper/lower"
+    ? [
+        "Day 1 Upper: Bench Press 3×8 @ RPE 7, One-Arm Row 3×10 @ RPE 7, Arnold Press 3×10 @ RPE 7-8, Incline Push-Ups 2×12 @ RPE 6, Face Pulls 2×15 @ RPE 6.",
+        "Day 2 Lower: Back Squat 4×6 @ RPE 7-8, Romanian Deadlift 3×8 @ RPE 7, Walking Lunges 3×12/leg @ RPE 7, Seated Calf Raises 3×15 @ RPE 6, Hanging Knee Raises 3×12 @ RPE 6.",
+        "Day 3 Upper Repeat: Weighted Chin-Ups 4×6 @ RPE 8, DB Incline Press 3×10 @ RPE 7, Cable Row 3×12 @ RPE 7, Lateral Raise 3×15 @ RPE 6, Farmer Carry 3×40m @ RPE 7.",
+        "Day 4 Lower Repeat: Trap Bar Deadlift 3×6 @ RPE 8, Split Squat 3×10/leg @ RPE 7, Leg Curl 3×12 @ RPE 7, Glute Bridge 3×15 @ RPE 6, Plank 3×45s @ RPE 6."
+      ]
+    : [
+        "Day 1 Push: Flat Bench 4×6 @ RPE 8, Incline DB Press 3×10 @ RPE 7, Overhead Press 3×8 @ RPE 7, Cable Fly 2×15 @ RPE 6, Tricep Rope Pushdown 3×12 @ RPE 6.",
+        "Day 2 Pull: Deadlift 3×5 @ RPE 8, Chest-Supported Row 3×10 @ RPE 7, Lat Pulldown 3×12 @ RPE 7, Rear-Delt Fly 3×15 @ RPE 6, Barbell Curl 3×12 @ RPE 6.",
+        "Day 3 Legs: Back Squat 4×6 @ RPE 8, Bulgarian Split Squat 3×10/leg @ RPE 7, Romanian Deadlift 3×10 @ RPE 7, Leg Press 2×15 @ RPE 6, Standing Calf Raise 3×15 @ RPE 6.",
+        "Day 4 Optional Conditioning: 20 minute incline walk at RPE 6, then 3 rounds of kettlebell swings 12 reps @ RPE 7 and plank 45s @ RPE 6."
+      ];
+
+  const nutrition =
+    "Aim for 0.8-1.0g protein per lb, build plates around lean protein + veggies + complex carbs, and keep hydration steady (at least 90 oz water).";
+  const closer =
+    "Stick with a steady RPE ramp across the week, deload every 4 weeks, and adjust volume based on how you recover. All guidance is educational only and not medical advice.";
+
+  return ["Here's a focused " + splitPlan + " split for the next week:", ...sessions, nutrition, closer].join(" ");
+}
+
+async function callOpenAi(model: OpenAiModel, text: string): Promise<string> {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    throw new HttpsError("failed-precondition", "openai_disabled");
+  }
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      temperature: 0.6,
+      max_tokens: 320,
+      messages: [
+        { role: "system", content: SYSTEM_PROMPT },
+        { role: "user", content: text },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    console.error("coach_chat_openai_error", { status: response.status, body: error.slice(0, 200) });
+    throw new HttpsError("unavailable", "openai_failed");
+  }
+
+  const payload = (await response.json()) as any;
+  const content = payload?.choices?.[0]?.message?.content;
+  if (typeof content !== "string" || !content.trim()) {
+    console.error("coach_chat_openai_missing_content", { payload });
+    throw new HttpsError("internal", "openai_no_content");
+  }
+  return content.trim();
+}
+
+async function storeMessage(uid: string, record: ChatRecord): Promise<void> {
+  const colRef = db.collection(`users/${uid}/coach/chat`);
+  const docRef = await colRef.add(record);
+
+  const snapshot = await colRef
+    .orderBy("createdAt", "desc")
+    .offset(10)
+    .get();
+
+  const deletions = snapshot.docs.filter((doc) => doc.id !== docRef.id);
+  await Promise.allSettled(deletions.map((doc) => doc.ref.delete().catch(() => undefined)));
+}
+
+async function handleChat(req: ExpressRequest, res: ExpressResponse): Promise<void> {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "method_not_allowed" });
+    return;
+  }
+
+  await verifyAppCheckSoft(req as any);
+  const uid = await requireAuth(req as any);
+
+  const text = sanitizeInput((req.body as any)?.text);
+  await enforceRateLimit({ uid, key: "coach_chat", limit: RATE_LIMIT_COUNT, windowMs: RATE_LIMIT_WINDOW_MS });
+
+  let responseText: string;
+  let usedLLM = false;
+
+  if (process.env.OPENAI_API_KEY) {
+    for (const model of OPENAI_MODELS) {
+      try {
+        responseText = await callOpenAi(model, text);
+        usedLLM = true;
+        break;
+      } catch (err) {
+        if ((err as HttpsError)?.code === "failed-precondition") {
+          break;
+        }
+        console.warn("coach_chat_model_error", { model, message: (err as any)?.message });
+      }
+    }
+  }
+
+  if (!responseText) {
+    responseText = buildFallbackResponse(text);
+    usedLLM = false;
+  }
+
+  const record: ChatRecord = {
+    text,
+    response: responseText,
+    createdAt: Timestamp.now(),
+    usedLLM,
+  };
+
+  await storeMessage(uid, record);
+
+  res.json({ response: responseText, usedLLM });
+}
+
+export const coachChat = onRequest(
+  { invoker: "public", region: "us-central1" },
+  withCors(async (req, res) => {
+    try {
+      await handleChat(req as ExpressRequest, res as ExpressResponse);
+    } catch (err: any) {
+      if (res.headersSent) return;
+      if (err instanceof HttpsError) {
+        const statusMap: Record<string, number> = {
+          "invalid-argument": 400,
+          "unauthenticated": 401,
+          "failed-precondition": 503,
+          "resource-exhausted": 429,
+          unavailable: 503,
+        };
+        const status = statusMap[err.code] ?? 500;
+        res.status(status).json({ error: err.message, code: err.code });
+        return;
+      }
+      console.error("coach_chat_unhandled", { message: err?.message });
+      res.status(500).json({ error: "server_error" });
+    }
+  })
+);

--- a/functions/src/coachPlan.ts
+++ b/functions/src/coachPlan.ts
@@ -1,0 +1,198 @@
+import { HttpsError, onCall } from "firebase-functions/v2/https";
+import { Timestamp, getFirestore } from "./firebase.js";
+
+interface CoachProfile {
+  goal?: string;
+  activity_level?: string;
+  style?: string;
+  sex?: string;
+  weight_kg?: number;
+}
+
+type SessionBlock = {
+  title: string;
+  focus: string;
+  work: string[];
+};
+
+type SessionPlan = {
+  day: string;
+  blocks: SessionBlock[];
+};
+
+type GeneratedPlan = {
+  days: number;
+  split: string;
+  sessions: SessionPlan[];
+  progression: { deloadEvery: number };
+  calorieTarget: number;
+  proteinFloor: number;
+  disclaimer: string;
+  updatedAt: Timestamp;
+};
+
+const db = getFirestore();
+
+function resolveDays(profile: CoachProfile | null): number {
+  if (!profile) return 4;
+  if (profile.style === "all_in") return 5;
+  if (profile.activity_level === "sedentary") return 3;
+  return 4;
+}
+
+function pickSplit(dayCount: number): string {
+  if (dayCount <= 3) return "Push/Pull/Legs";
+  if (dayCount === 4) return "Upper/Lower/Upper/Lower";
+  return "Upper/Lower/Push/Pull/Legs";
+}
+
+function buildSessions(dayCount: number): SessionPlan[] {
+  const base: SessionPlan[] = [
+    {
+      day: "Day 1",
+      blocks: [
+        {
+          title: "Push Strength",
+          focus: "Compound pressing and shoulders",
+          work: [
+            "Barbell Bench Press – 4×6 @ RPE 7-8",
+            "Incline Dumbbell Press – 3×10 @ RPE 7",
+            "Seated Dumbbell Shoulder Press – 3×10 @ RPE 7",
+            "Cable Fly – 2×15 @ RPE 6",
+            "Rope Tricep Pressdown – 3×12 @ RPE 7",
+          ],
+        },
+      ],
+    },
+    {
+      day: "Day 2",
+      blocks: [
+        {
+          title: "Pull Strength",
+          focus: "Back width and posterior chain",
+          work: [
+            "Conventional Deadlift – 3×5 @ RPE 8",
+            "Chest-Supported Row – 3×10 @ RPE 7",
+            "Lat Pulldown – 3×12 @ RPE 7",
+            "Face Pull – 3×15 @ RPE 6",
+            "EZ-Bar Curl – 3×12 @ RPE 7",
+          ],
+        },
+      ],
+    },
+    {
+      day: "Day 3",
+      blocks: [
+        {
+          title: "Legs & Core",
+          focus: "Squat pattern and unilateral work",
+          work: [
+            "Back Squat – 4×6 @ RPE 7-8",
+            "Bulgarian Split Squat – 3×10/leg @ RPE 7",
+            "Romanian Deadlift – 3×10 @ RPE 7",
+            "Leg Curl – 3×15 @ RPE 6",
+            "Hanging Knee Raise – 3×15 @ RPE 6",
+          ],
+        },
+      ],
+    },
+    {
+      day: "Day 4",
+      blocks: [
+        {
+          title: "Upper Volume",
+          focus: "Horizontal pulls and delts",
+          work: [
+            "Weighted Pull-Up – 4×6 @ RPE 8",
+            "Single-Arm Dumbbell Row – 3×12/side @ RPE 7",
+            "Incline Dumbbell Fly – 3×12 @ RPE 7",
+            "Lateral Raise – 3×15 @ RPE 6",
+            "Farmer Carry – 3×40m @ RPE 7",
+          ],
+        },
+      ],
+    },
+    {
+      day: "Day 5",
+      blocks: [
+        {
+          title: "Conditioning & Glutes",
+          focus: "GPP and posterior chain accessories",
+          work: [
+            "Sled Push – 6×20m @ RPE 7",
+            "Kettlebell Swing – 4×12 @ RPE 7",
+            "Hip Thrust – 3×12 @ RPE 7",
+            "Reverse Lunge – 3×12/leg @ RPE 7",
+            "Plank – 3×60s @ RPE 6",
+          ],
+        },
+      ],
+    },
+  ];
+
+  return base.slice(0, dayCount);
+}
+
+function estimateCalories(profile: CoachProfile | null): number {
+  const baseWeight = profile?.weight_kg ?? 75;
+  const maintenance = baseWeight * 32; // rough kcal estimate
+  if (!profile) return Math.round(maintenance);
+  switch (profile.goal) {
+    case "lose_fat":
+      return Math.round(maintenance * 0.85);
+    case "gain_muscle":
+      return Math.round(maintenance * 1.08);
+    default:
+      return Math.round(maintenance);
+  }
+}
+
+function estimateProtein(profile: CoachProfile | null): number {
+  const weightKg = profile?.weight_kg ?? 75;
+  const weightLb = weightKg * 2.20462;
+  return Math.round(weightLb * 0.9);
+}
+
+async function fetchProfile(uid: string): Promise<CoachProfile | null> {
+  try {
+    const snap = await db.doc(`users/${uid}/coach/profile`).get();
+    if (!snap.exists) return null;
+    return snap.data() as CoachProfile;
+  } catch (err) {
+    console.warn("coach_plan_profile_error", { uid, message: (err as any)?.message });
+    return null;
+  }
+}
+
+function buildPlan(profile: CoachProfile | null): GeneratedPlan {
+  const days = resolveDays(profile);
+  const split = pickSplit(days);
+  const sessions = buildSessions(days);
+  const calorieTarget = estimateCalories(profile);
+  const proteinFloor = estimateProtein(profile);
+
+  return {
+    days,
+    split,
+    sessions,
+    progression: { deloadEvery: 4 },
+    calorieTarget,
+    proteinFloor,
+    disclaimer: "Training and nutrition guidance for education only – not medical advice.",
+    updatedAt: Timestamp.now(),
+  };
+}
+
+export const generatePlan = onCall({ region: "us-central1" }, async (request) => {
+  const uid = request.auth?.uid;
+  if (!uid) {
+    throw new HttpsError("unauthenticated", "Sign in to generate a plan");
+  }
+
+  const profile = await fetchProfile(uid);
+  const plan = buildPlan(profile);
+
+  await db.doc(`users/${uid}/coach/plan/current`).set(plan);
+
+  return { plan: { ...plan, updatedAt: plan.updatedAt.toMillis() } };
+});

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -14,6 +14,11 @@ export { beginPaidScan } from "./scan/beginPaidScan.js";
 export { recordGateFailure } from "./scan/recordGateFailure.js";
 export { refundIfNoResult } from "./scan/refundIfNoResult.js";
 
+// Coach
+export { coachChat } from "./coachChat.js";
+export { generatePlan } from "./coachPlan.js";
+export { ensureTestCredits } from "./testWhitelist.js";
+
 // Nutrition endpoints
 export { addFoodLog, addMeal, deleteMeal, getDayLog, getDailyLog, getNutritionHistory } from "./nutrition.js";
 export { nutritionSearch } from "./nutritionSearch.js";
@@ -22,7 +27,6 @@ export { nutritionBarcode } from "./nutritionBarcode.js";
 // Workouts / Coach
 export {
   generateWorkoutPlan,
-  generatePlan,
   getPlan,
   getCurrentPlan,
   markExerciseDone,

--- a/functions/src/testWhitelist.ts
+++ b/functions/src/testWhitelist.ts
@@ -1,0 +1,68 @@
+import { onCall, HttpsError } from "firebase-functions/v2/https";
+import { Timestamp, getFirestore } from "./firebase.js";
+import { addCredits } from "./credits.js";
+
+const db = getFirestore();
+const CONFIG_PATH = "config/app";
+const DEFAULT_WHITELIST = ["developer@adlrlabs.com"] as const;
+const MIN_TEST_CREDITS = 3;
+
+function normalizeEmails(list: unknown): string[] {
+  if (!Array.isArray(list)) return [];
+  return list
+    .map((value) => (typeof value === "string" ? value.trim().toLowerCase() : ""))
+    .filter(Boolean);
+}
+
+async function ensureConfigWhitelist(): Promise<Set<string>> {
+  const ref = db.doc(CONFIG_PATH);
+  const snap = await ref.get();
+  const existing = normalizeEmails(snap.exists ? (snap.data() as any)?.testWhitelist : []);
+  const merged = Array.from(new Set([...existing, ...DEFAULT_WHITELIST]));
+  await ref.set(
+    {
+      testWhitelist: merged,
+      updatedAt: Timestamp.now(),
+    },
+    { merge: true }
+  );
+  return new Set(merged.map((email) => email.toLowerCase()));
+}
+
+async function currentCreditTotal(uid: string): Promise<number> {
+  const ref = db.doc(`users/${uid}/private/credits`);
+  const snap = await ref.get();
+  if (!snap.exists) return 0;
+  const total = Number((snap.data() as any)?.creditsSummary?.totalAvailable ?? 0);
+  return Number.isFinite(total) ? Math.max(0, Math.floor(total)) : 0;
+}
+
+export const ensureTestCredits = onCall({ region: "us-central1" }, async (request) => {
+  const uid = request.auth?.uid;
+  const email = request.auth?.token?.email?.toLowerCase();
+  const demo = Boolean(request.data?.demo);
+
+  if (!uid || !email) {
+    throw new HttpsError("unauthenticated", "Sign in to sync credits");
+  }
+
+  if (demo) {
+    return { granted: 0, total: await currentCreditTotal(uid) };
+  }
+
+  const whitelist = await ensureConfigWhitelist();
+  if (!whitelist.has(email)) {
+    return { granted: 0, total: await currentCreditTotal(uid) };
+  }
+
+  const before = await currentCreditTotal(uid);
+  if (before >= MIN_TEST_CREDITS) {
+    return { granted: 0, total: before };
+  }
+
+  const needed = MIN_TEST_CREDITS - before;
+  await addCredits(uid, needed, "Test whitelist grant", 12);
+
+  const after = await currentCreditTotal(uid);
+  return { granted: Math.max(after - before, 0), total: after };
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,6 +58,7 @@ import Scan from "./pages/Scan";
 import Workouts from "./pages/Workouts";
 import Meals from "./pages/Meals";
 import Coach from "./pages/Coach";
+import CoachChat from "./pages/Coach/Chat";
 import CoachDay from "./pages/Coach/Day";
 import ProgramsCatalog from "./pages/Programs";
 import ProgramDetail from "./pages/Programs/Detail";
@@ -160,7 +161,7 @@ const App = () => {
             <Route
               path="/coach"
               element={
-                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}>
+                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}> 
                   <ProtectedRoute>
                     <AuthedLayout>
                       <RouteBoundary>
@@ -172,9 +173,23 @@ const App = () => {
               }
             />
             <Route
+              path="/coach/chat"
+              element={
+                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}> 
+                  <ProtectedRoute>
+                    <AuthedLayout>
+                      <RouteBoundary>
+                        <CoachChat />
+                      </RouteBoundary>
+                    </AuthedLayout>
+                  </ProtectedRoute>
+                </FeatureGate>
+              }
+            />
+            <Route
               path="/coach/day"
               element={
-                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}>
+                <FeatureGate name="coach" fallback={<Navigate to="/home" replace />}> 
                   <ProtectedRoute>
                     <AuthedLayout>
                       <RouteBoundary>

--- a/src/hooks/useUserProfile.ts
+++ b/src/hooks/useUserProfile.ts
@@ -23,15 +23,26 @@ export interface CoachProfile {
   startedAt?: string;
 }
 
+export interface CoachPlanBlock {
+  title: string;
+  focus: string;
+  work: string[];
+}
+
+export interface CoachPlanSession {
+  day: string;
+  blocks: CoachPlanBlock[];
+}
+
 export interface CoachPlan {
-  tdee: number;
-  target_kcal: number;
-  goal: string;
-  style: string;
-  protein_g: number;
-  fat_g: number;
-  carbs_g: number;
-  [k: string]: unknown;
+  days: number;
+  split: string;
+  sessions: CoachPlanSession[];
+  progression: { deloadEvery: number };
+  calorieTarget: number;
+  proteinFloor: number;
+  disclaimer?: string;
+  updatedAt?: Date;
 }
 
 export function useUserProfile() {
@@ -47,7 +58,13 @@ export function useUserProfile() {
     });
     const planRef = coachPlanDoc(uid);
     const unsub2 = onSnapshot(planRef, (snap) => {
-      setPlan((snap.data() as CoachPlan) || null);
+      if (!snap.exists) {
+        setPlan(null);
+        return;
+      }
+      const data = snap.data() as CoachPlan & { updatedAt?: { toDate?: () => Date } };
+      const updatedAt = data.updatedAt?.toDate?.() ?? data.updatedAt;
+      setPlan({ ...data, updatedAt: updatedAt instanceof Date ? updatedAt : undefined });
     });
     return () => {
       unsub1();

--- a/src/lib/db/coachPaths.ts
+++ b/src/lib/db/coachPaths.ts
@@ -2,6 +2,6 @@ import { collection, doc } from "firebase/firestore";
 
 import { db } from "@/lib/firebase";
 
-export const coachPlanDoc = (uid: string) => doc(db, "users", uid, "coach", "plan");
+export const coachPlanDoc = (uid: string) => doc(db, "users", uid, "coach", "plan", "current");
 
 export const workoutLogsCol = (uid: string) => collection(db, "users", uid, "workoutLogs");

--- a/src/pages/CapturePicker.tsx
+++ b/src/pages/CapturePicker.tsx
@@ -1,34 +1,57 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Seo } from "@/components/Seo";
 import { useNavigate } from "react-router-dom";
+import { useDemoMode } from "@/components/DemoModeProvider";
+import { demoToast } from "@/lib/demoToast";
 
 const CapturePicker = () => {
   const navigate = useNavigate();
+  const demo = useDemoMode();
+
+  const renderButton = (label: string, path: string) => {
+    if (!demo) {
+      return (
+        <Button className="w-full" onClick={() => navigate(path)}>
+          {label}
+        </Button>
+      );
+    }
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex w-full" onClick={() => demoToast()}>
+            <Button className="w-full pointer-events-none" disabled>
+              {label}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>Sign in to use</TooltipContent>
+      </Tooltip>
+    );
+  };
+
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
-      <Seo title="Choose Capture – MyBodyScan" description="Pick photos or video to start your scan." canonical={window.location.href} />
+      <Seo
+        title="Choose Capture – MyBodyScan"
+        description="Pick photos or video to start your scan."
+        canonical={window.location.href}
+      />
       <h1 className="text-2xl font-semibold mb-4">Start a Scan</h1>
       <div className="grid gap-4">
         <Card className="shadow-md">
           <CardHeader>
             <CardTitle>Photos</CardTitle>
           </CardHeader>
-          <CardContent>
-            <Button className="w-full" onClick={() => navigate("/capture/photos")}>
-              Capture Photos
-            </Button>
-          </CardContent>
+          <CardContent>{renderButton("Capture Photos", "/capture/photos")}</CardContent>
         </Card>
         <Card className="shadow-md">
           <CardHeader>
             <CardTitle>Video</CardTitle>
           </CardHeader>
-          <CardContent>
-            <Button className="w-full" onClick={() => navigate("/capture/video")}>
-              Record Video
-            </Button>
-          </CardContent>
+          <CardContent>{renderButton("Record Video", "/capture/video")}</CardContent>
         </Card>
       </div>
     </main>

--- a/src/pages/Coach/Chat.tsx
+++ b/src/pages/Coach/Chat.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useMemo, useState } from "react";
+import { httpsCallable } from "firebase/functions";
+import { collection, limit, onSnapshot, orderBy, query } from "firebase/firestore";
+import { AppHeader } from "@/components/AppHeader";
+import { BottomNav } from "@/components/BottomNav";
+import { NotMedicalAdviceBanner } from "@/components/NotMedicalAdviceBanner";
+import { Seo } from "@/components/Seo";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { useToast } from "@/hooks/use-toast";
+import { useDemoMode } from "@/components/DemoModeProvider";
+import { demoToast } from "@/lib/demoToast";
+import { auth, db, functions } from "@/lib/firebase";
+import { useUserProfile } from "@/hooks/useUserProfile";
+import type { CoachPlanSession } from "@/hooks/useUserProfile";
+import { formatDistanceToNow } from "date-fns";
+
+interface ChatMessage {
+  id: string;
+  text: string;
+  response: string;
+  createdAt: Date;
+  usedLLM: boolean;
+}
+
+function sortMessages(messages: ChatMessage[]): ChatMessage[] {
+  return [...messages].sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+}
+
+function PlanSession({ session }: { session: CoachPlanSession }) {
+  return (
+    <div className="rounded-lg border border-dashed border-muted-foreground/30 p-3">
+      <p className="font-medium text-foreground">{session.day}</p>
+      {session.blocks.map((block, idx) => (
+        <div key={idx} className="mt-2 space-y-1 text-sm">
+          <p className="font-semibold text-primary/80">{block.title}</p>
+          <p className="text-muted-foreground">{block.focus}</p>
+          <ul className="list-disc pl-4 text-muted-foreground/90">
+            {block.work.map((item, workIdx) => (
+              <li key={workIdx}>{item}</li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function CoachChatPage() {
+  const { toast } = useToast();
+  const demo = useDemoMode();
+  const { plan } = useUserProfile();
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [pending, setPending] = useState(false);
+  const [input, setInput] = useState("");
+  const [regenerating, setRegenerating] = useState(false);
+  const uid = auth.currentUser?.uid ?? null;
+
+  useEffect(() => {
+    if (!uid) {
+      setMessages([]);
+      return;
+    }
+    const chatQuery = query(
+      collection(db, "users", uid, "coach", "chat"),
+      orderBy("createdAt", "desc"),
+      limit(10)
+    );
+    const unsubscribe = onSnapshot(chatQuery, (snapshot) => {
+      const next = snapshot.docs.map((doc) => {
+        const data = doc.data() as {
+          text?: string;
+          response?: string;
+          createdAt?: { toDate?: () => Date };
+          usedLLM?: boolean;
+        };
+        const created = data.createdAt?.toDate?.() ?? new Date();
+        return {
+          id: doc.id,
+          text: data.text ?? "",
+          response: data.response ?? "",
+          createdAt: created,
+          usedLLM: Boolean(data.usedLLM),
+        } satisfies ChatMessage;
+      });
+      setMessages(sortMessages(next));
+    });
+    return () => unsubscribe();
+  }, [uid]);
+
+  const hasMessages = messages.length > 0;
+
+  const handleSend = async () => {
+    if (pending || demo) {
+      if (demo) demoToast();
+      return;
+    }
+    const trimmed = input.trim();
+    if (!trimmed) return;
+    setPending(true);
+    try {
+      const token = await auth.currentUser?.getIdToken();
+      if (!token) throw new Error("auth");
+      const response = await fetch("/api/coach/chat", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ text: trimmed }),
+      });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        const description = typeof data?.error === "string" ? data.error : "Unable to send message.";
+        toast({ title: "Message not sent", description, variant: "destructive" });
+        return;
+      }
+      setInput("");
+    } catch (error: any) {
+      toast({ title: "Message not sent", description: error?.message ?? "Check your connection.", variant: "destructive" });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const regeneratePlan = async () => {
+    if (demo) {
+      demoToast();
+      return;
+    }
+    setRegenerating(true);
+    try {
+      const callable = httpsCallable(functions, "generatePlan");
+      await callable({});
+      toast({ title: "Weekly plan updated", description: "Your coach plan was regenerated." });
+    } catch (error: any) {
+      toast({
+        title: "Unable to regenerate",
+        description: error?.message ?? "Please try again in a moment.",
+        variant: "destructive",
+      });
+    } finally {
+      setRegenerating(false);
+    }
+  };
+
+  const formattedMessages = useMemo(() => sortMessages(messages), [messages]);
+
+  return (
+    <div className="min-h-screen bg-background pb-16 md:pb-0">
+      <Seo title="Coach Chat – MyBodyScan" description="Talk to your AI coach and refresh your weekly plan." />
+      <AppHeader />
+      <main className="mx-auto flex w-full max-w-5xl flex-col gap-6 p-6">
+        <NotMedicalAdviceBanner />
+        <div className="grid gap-6 lg:grid-cols-[1.75fr,1fr]">
+          <Card className="border bg-card/60">
+            <CardHeader>
+              <CardTitle className="text-xl">Coach chat</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-lg border bg-background/60 p-4">
+                {hasMessages ? (
+                  <div className="space-y-4">
+                    {formattedMessages.map((message) => (
+                      <div key={message.id} className="space-y-2">
+                        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                          You · {formatDistanceToNow(message.createdAt, { addSuffix: true })}
+                        </div>
+                        <div className="rounded-lg bg-primary/5 p-3 text-sm text-foreground shadow-sm">
+                          {message.text}
+                        </div>
+                        <div className="flex items-center justify-between text-xs text-muted-foreground">
+                          <span>Coach response</span>
+                          <Badge variant={message.usedLLM ? "default" : "secondary"} className="uppercase tracking-wide">
+                            {message.usedLLM ? "LLM" : "Rules"}
+                          </Badge>
+                        </div>
+                        <div className="rounded-lg border border-primary/20 bg-background p-3 text-sm leading-relaxed text-foreground">
+                          {message.response}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Ask a question to get personalized training and nutrition tips.</p>
+                )}
+              </div>
+              <div className="space-y-3">
+                <Textarea
+                  value={input}
+                  onChange={(event) => setInput(event.target.value)}
+                  placeholder={demo ? "Sign in to chat with your coach" : "Share wins or ask for tweaks..."}
+                  rows={4}
+                  disabled={pending || demo}
+                />
+                <div className="flex justify-end">
+                  <Button onClick={handleSend} disabled={pending || demo || !input.trim()}>
+                    {pending ? "Sending..." : "Send"}
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="space-y-4">
+            <Card className="border bg-card/60">
+              <CardHeader className="space-y-2">
+                <CardTitle className="text-xl">Weekly plan</CardTitle>
+                {plan ? (
+                  <p className="text-sm text-muted-foreground">
+                    {plan.days} days · {plan.split} · Protein ≥ {plan.proteinFloor} g · Calories ≈ {plan.calorieTarget}
+                  </p>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Generate a plan to see your structured week.</p>
+                )}
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Button onClick={regeneratePlan} disabled={regenerating || demo} className="w-full">
+                  {regenerating ? "Regenerating..." : "Regenerate weekly plan"}
+                </Button>
+                {plan ? (
+                  <div className="space-y-3 text-sm text-muted-foreground">
+                    <p>
+                      {plan.disclaimer ?? "Training guidance for educational use only. Estimates only — not medical advice."}
+                    </p>
+                    <div className="space-y-3">
+                      {plan.sessions.slice(0, plan.days).map((session) => (
+                        <PlanSession key={session.day} session={session} />
+                      ))}
+                    </div>
+                  </div>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Tap regenerate after onboarding to receive a day-by-day split with sets × reps and RPE.
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </main>
+      <BottomNav />
+    </div>
+  );
+}

--- a/src/pages/Coach/index.tsx
+++ b/src/pages/Coach/index.tsx
@@ -7,7 +7,6 @@ import { Seo } from "@/components/Seo";
 import { NotMedicalAdviceBanner } from "@/components/NotMedicalAdviceBanner";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import { useUserProfile } from "@/hooks/useUserProfile";
@@ -55,7 +54,6 @@ export default function CoachOverview() {
   const [weekIdx, setWeekIdx] = useState(0);
   const [isSaving, setIsSaving] = useState(false);
   const [planExists, setPlanExists] = useState<boolean | null>(null);
-  const [chatMessage, setChatMessage] = useState("");
   const uid = auth.currentUser?.uid ?? null;
   const demo = useDemoMode();
 
@@ -203,16 +201,6 @@ export default function CoachOverview() {
   const handleOpenDay = (dayIdx: number) => {
     if (!program) return;
     navigate(`/coach/day?programId=${program.id}&week=${weekIdx}&day=${dayIdx}`);
-  };
-
-  const handleSendMessage = () => {
-    if (demo) {
-      demoToast();
-      return;
-    }
-    if (!chatMessage.trim()) return;
-    toast({ title: "Message sent", description: "Your coach will reply soon." });
-    setChatMessage("");
   };
 
   const currentWeek = program?.weeks[weekIdx] ?? program?.weeks[0];
@@ -400,30 +388,31 @@ export default function CoachOverview() {
         )}
 
         <Card className="border bg-card/60">
-          <CardHeader>
+          <CardHeader className="space-y-2">
             <CardTitle className="text-xl">Coach chat</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
             <p className="text-sm text-muted-foreground">
-              Ask quick questions and get guidance from your coach. Responses arrive via email and in-app notifications.
+              Get near real-time suggestions and regenerate your weekly plan. Estimates only — not medical advice.
             </p>
-            <Textarea
-              value={chatMessage}
-              onChange={(event) => setChatMessage(event.target.value)}
-              placeholder={demo ? "Sign in to chat with your coach" : "Share wins or ask for tweaks..."}
-              rows={3}
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-muted-foreground">
+              Conversations are saved to keep context for smarter tweaks.
+            </p>
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                if (demo) {
+                  demoToast();
+                  return;
+                }
+                navigate("/coach/chat");
+              }}
               disabled={demo}
-            />
-            <div className="flex justify-end">
-              <Button
-                type="button"
-                onClick={handleSendMessage}
-                disabled={demo || !chatMessage.trim()}
-                title={demo ? "Demo mode: sign in to save" : undefined}
-              >
-                Send
-              </Button>
-            </div>
+              title={demo ? "Demo mode: sign in to chat" : undefined}
+            >
+              Open chat
+            </Button>
           </CardContent>
         </Card>
       </main>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useNavigate } from "react-router-dom";
 import { Seo } from "@/components/Seo";
 import { toast } from "@/hooks/use-toast";
@@ -10,6 +11,8 @@ import { db } from "@/lib/firebase";
 import { useAuthUser } from "@/lib/auth";
 import { extractScanMetrics } from "@/lib/scans";
 import { summarizeScanMetrics } from "@/lib/scanDisplay";
+import { useDemoMode } from "@/components/DemoModeProvider";
+import { demoToast } from "@/lib/demoToast";
 
 type LastScan = {
   id: string;
@@ -21,6 +24,7 @@ type LastScan = {
 const Home = () => {
   const { user } = useAuthUser();
   const navigate = useNavigate();
+  const demo = useDemoMode();
   const [lastScan, setLastScan] = useState<LastScan | null>(null);
   const loggedOnce = useRef(false);
 
@@ -75,6 +79,34 @@ const Home = () => {
     return () => unsub();
   }, [user]);
 
+  const renderStartButton = (props: { variant?: "default" | "secondary" | "outline"; className?: string } = {}) => {
+    if (!demo) {
+      return (
+        <Button
+          variant={props.variant}
+          className={props.className}
+          onClick={() => navigate("/scan/new")}
+        >
+          Start a Scan
+        </Button>
+      );
+    }
+    const spanClass = props.className ? `inline-flex ${props.className}` : "inline-flex";
+    const buttonClass = props.className ? `${props.className} pointer-events-none` : "pointer-events-none";
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className={spanClass} onClick={() => demoToast()}>
+            <Button variant={props.variant} disabled className={buttonClass}>
+              Start a Scan
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent>Sign in to use</TooltipContent>
+      </Tooltip>
+    );
+  };
+
   return (
     <main className="min-h-screen p-6 max-w-md mx-auto">
       <Seo title="Home – MyBodyScan" description="Your latest body scan and quick actions." canonical={window.location.href} />
@@ -125,7 +157,7 @@ const Home = () => {
                   </div>
                 )}
                 <div className="flex gap-2 pt-2">
-                  <Button onClick={() => navigate("/scan/new")}>Start a Scan</Button>
+                  {renderStartButton()}
                   <Button variant="secondary" onClick={() => navigate("/history")}>View History</Button>
                 </div>
               </div>
@@ -134,7 +166,7 @@ const Home = () => {
         </Card>
 
         <div className="grid gap-3">
-          <Button onClick={() => navigate("/scan/new")}>Start a Scan</Button>
+          {renderStartButton({ className: "w-full" })}
           <a href="/onboarding" className="block text-center text-sm text-slate-500 hover:text-slate-700 mt-2">Personalize results (1 min)</a>
           <Button variant="secondary" onClick={() => navigate("/history")}>History</Button>
           <Button variant="outline" onClick={() => navigate("/plans")}>Plans</Button>

--- a/src/pages/Scan/Start.tsx
+++ b/src/pages/Scan/Start.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Seo } from "@/components/Seo";
 import { getLastWeight, setLastWeight } from "@/lib/userState";
 import { useDemoMode } from "@/components/DemoModeProvider";
@@ -78,17 +79,43 @@ export default function ScanStart() {
             />
             {error ? <p className="text-sm text-destructive">{error}</p> : null}
           </div>
-          <Button type="submit" size="lg" disabled={demo} title={demo ? "Demo mode: sign in to save" : undefined}>
-            Save and continue
-          </Button>
+          {demo ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span onClick={() => demoToast()}>
+                  <Button type="button" size="lg" disabled className="pointer-events-none">
+                    Save and continue
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>Sign in to use</TooltipContent>
+            </Tooltip>
+          ) : (
+            <Button type="submit" size="lg">
+              Save and continue
+            </Button>
+          )}
         </form>
       ) : (
         <div className="space-y-4">
           <p className="text-lg font-medium">Is your weight still {formatWeight(storedWeight!)} lb?</p>
           <div className="flex flex-wrap gap-3">
-            <Button size="lg" onClick={goToCapture} disabled={demo} title={demo ? "Demo mode: sign in to save" : undefined}>
-              Yes
-            </Button>
+            {demo ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span onClick={() => demoToast()}>
+                    <Button size="lg" disabled className="pointer-events-none">
+                      Yes
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>Sign in to use</TooltipContent>
+              </Tooltip>
+            ) : (
+              <Button size="lg" onClick={goToCapture}>
+                Yes
+              </Button>
+            )}
             <Button
               type="button"
               size="lg"


### PR DESCRIPTION
## Summary
- add a HTTPS coachChat endpoint with OpenAI + rules fallback, message history, and App Check/auth enforcement
- provide a callable generatePlan function and UI updates for chat/regeneration with demo gating and plan display
- tighten scan submission/status guardrails, ensure credit handling, and add test whitelist credit grants plus deployment checklist updates

## Testing
- npm --prefix functions run build
- npm run build *(fails: npm registry denied access to @opentelemetry/semantic-conventions)*

------
https://chatgpt.com/codex/tasks/task_e_68de7ef2f45c8325988598f36a594705