### PR TITLE
chore(hosting): remove legacy /food/** rewrite; unify nutrition API route

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -53,8 +53,10 @@
     "rewrites": [
       {
         "source": "/api/nutrition/search",
-        "function": "nutritionSearch",
-        "functionRegion": "us-central1"
+        "function": {
+          "functionId": "nutritionSearch",
+          "region": "us-central1"
+        }
       },
       {
         "source": "/api/scan/start",


### PR DESCRIPTION
## Summary
- update Firebase hosting rewrites to remove legacy /food/** mapping and explicitly route HTTPS functions
- add a centralized nutritionSearch helper that targets /api/nutrition/search and wire fetchFoods through it

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68df0870a2588325a3bbcdfbd4b59cbf