### PR TITLE
feat(app-check): enforce strict App Check on nutrition and coach APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-trick
 
 ## App Check
 
-To harden client requests, this project can enable Firebase App Check with reCAPTCHA Enterprise. Set `VITE_APPCHECK_SITE_KEY` in your environment (see `.env.development`) to initialize App Check. After verifying legitimate clients, enforce App Check in the Firebase console.
+To harden client requests, this project can enable Firebase App Check with reCAPTCHA Enterprise. Set `VITE_APPCHECK_SITE_KEY` in your environment (see `.env.development`) to initialize App Check. After verifying legitimate clients, enforce App Check in the Firebase console. The `/api/nutrition/search` and `/api/coach/chat` endpoints now require a valid App Check token and will also expect a Firebase Auth ID token whenever user-protected data is requested.
 
 ## Environment variables
 
@@ -88,7 +88,7 @@ Create a `.env.local` for development based on `.env.example` and a `.env.produc
 - `VITE_FIREBASE_APP_ID`
 - `VITE_FIREBASE_MEASUREMENT_ID`
 - `VITE_FUNCTIONS_BASE_URL`
-- `VITE_APPCHECK_SITE_KEY` *(optional but recommended)*
+- `VITE_APPCHECK_SITE_KEY` *(required when deploying with enforced App Check)*
 
 Cloud Functions read Stripe credentials from secrets named `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET`. Configure them with `firebase functions:secrets:set` (see Deployment).
 

--- a/functions/src/appCheck.ts
+++ b/functions/src/appCheck.ts
@@ -1,0 +1,11 @@
+import { getAppCheck } from "firebase-admin/app-check";
+
+export async function requireAppCheckFromHeader(req: any) {
+  const token = req.header("X-Firebase-AppCheck");
+  if (!token) throw Object.assign(new Error("missing app check"), { status: 401 });
+  try {
+    await getAppCheck().verifyToken(token);
+  } catch {
+    throw Object.assign(new Error("invalid app check"), { status: 401 });
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable App Check verifier for HTTP handlers and wire it into the nutrition search and coach chat endpoints
- attach App Check and ID tokens to client fetches for nutrition search, chat, and scan APIs so the stricter checks succeed
- document the new App Check requirements in the README for environment setup

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68df0ded37c88325bebb3119bb0bd10b