### PR TITLE
chore(scripts): add setStaffClaim admin helper

### DIFF
--- a/functions/scripts/setStaffClaim.ts
+++ b/functions/scripts/setStaffClaim.ts
@@ -1,16 +1,9 @@
-/**
- * Usage:
- *  npx ts-node scripts/setStaffClaim.ts developer@adlrlabs.com
- */
 import * as admin from "firebase-admin";
 
-if (!admin.apps.length) {
-  admin.initializeApp();
-}
-
 async function main() {
+  if (!admin.apps.length) admin.initializeApp();
   const arg = process.argv[2];
-  if (!arg) throw new Error("Provide UID or email");
+  if (!arg) throw new Error("Provide a UID or email");
   const auth = admin.auth();
   const uid = arg.includes("@") ? (await auth.getUserByEmail(arg)).uid : arg;
   const user = await auth.getUser(uid);
@@ -18,8 +11,4 @@ async function main() {
   await auth.setCustomUserClaims(uid, claims);
   console.log(`✅ set { staff:true } for uid=${uid}`);
 }
-
-main().catch((error) => {
-  console.error(error);
-  process.exit(1);
-});
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- initialize the Firebase admin app inside the staff claim helper
- streamline argument validation message when no UID or email is provided

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e055fa967c832586da361f9c88c821