### PR TITLE
chore(scripts): add npm script for staff claim helper

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,8 @@
 {
   "type": "module",
-  "engines": { "node": "20" },
+  "engines": {
+    "node": "20"
+  },
   "main": "lib/index.js",
   "scripts": {
     "clean": "rimraf lib",


### PR DESCRIPTION
## Summary
- add a set:staff helper script to the functions package to run the staff claim script via ts-node
- include ts-node as a development dependency for the functions project

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0625aba508325bbeaf58e8798b370