### PR TITLE
feat(rate-limit): throttle nutritionSearch (20/min) & coachChat (6/min)

### DIFF
--- a/functions/src/rateLimit.ts
+++ b/functions/src/rateLimit.ts
@@ -1,0 +1,38 @@
+import * as admin from "firebase-admin";
+if (!admin.apps.length) admin.initializeApp();
+import { FieldValue } from "firebase-admin/firestore";
+
+type Opts = { key: string; max: number; windowSeconds: number };
+
+export async function verifyRateLimit(req: any, opts: Opts) {
+  const uid = (req as any).auth?.uid || (req as any).user?.uid || "";
+  const ip = (req.headers["x-forwarded-for"] || req.socket?.remoteAddress || "")
+    .toString()
+    .split(",")[0]
+    .trim();
+  const id = uid || ip || "anon";
+  const key = `${opts.key}:${id}`;
+  const now = Date.now();
+
+  const ref = admin.firestore().collection("ratelimits").doc(key);
+  await admin.firestore().runTransaction(async (tx) => {
+    const snap = await tx.get(ref);
+    const data = snap.exists ? (snap.data() as any) : { count: 0, windowStart: now };
+    const elapsed = now - (data.windowStart || now);
+    if (elapsed > opts.windowSeconds * 1000) {
+      tx.set(ref, { count: 1, windowStart: now, updatedAt: FieldValue.serverTimestamp() });
+      return;
+    }
+    const next = (data.count || 0) + 1;
+    tx.set(
+      ref,
+      { count: next, windowStart: data.windowStart, updatedAt: FieldValue.serverTimestamp() },
+      { merge: true },
+    );
+    if (next > opts.max) {
+      const e: any = new Error("Too Many Requests");
+      e.status = 429;
+      throw e;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a reusable Firestore-backed rate limiter helper for HTTP functions
- enforce a 20 requests/minute limit on nutritionSearch with 429 responses when exceeded
- throttle coachChat requests to 6 per minute while keeping the existing hourly cap

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68e063670fb88325bdb65bb19d12bd44