### PR TITLE
chore(scripts): add setStaffClaim admin helper + npm script

### DIFF
--- a/functions/scripts/setStaffClaim.ts
+++ b/functions/scripts/setStaffClaim.ts
@@ -1,5 +1,4 @@
 import * as admin from "firebase-admin";
-
 async function main() {
   if (!admin.apps.length) admin.initializeApp();
   const arg = process.argv[2];
@@ -9,6 +8,6 @@ async function main() {
   const user = await auth.getUser(uid);
   const claims = { ...(user.customClaims || {}), staff: true };
   await auth.setCustomUserClaims(uid, claims);
-  console.log(`✅ set { staff:true } for uid=${uid}`);
+  console.log(`set { staff:true } for uid=${uid}`);
 }
 main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
- add an admin helper script to set the staff custom claim for a user
- wire the helper into the functions package scripts list for easy execution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0695b1f9c832587887cd78aabf66f