### PR TITLE
fix(tailwind): ensure shadcn tokens + JS configs so `border-border` compiles

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,6 +1,6 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},
   },
-}
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,5 @@
-import type { Config } from "tailwindcss";
-
-const config: Config = {
+/** @type {import('tailwindcss').Config} */
+module.exports = {
   darkMode: ["class"],
   content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
   theme: {
@@ -63,5 +62,3 @@ const config: Config = {
   },
   plugins: [require("tailwindcss-animate")],
 };
-
-export default config;


### PR DESCRIPTION
## Summary
- replace the TypeScript Tailwind config with an equivalent CommonJS file so Tailwind picks up the shadcn token definitions
- switch the PostCSS config to CommonJS for compatibility with the new tooling setup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e070205b8c8325b30c7135586462d6