### PR TITLE
Fix Tailwind border class usage

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -45,7 +45,7 @@ export function AppHeader() {
   };
 
   return (
-    <header className="border-b border-border bg-card">
+    <header className="border-b bg-card">
       <div className="max-w-md mx-auto p-4">
         <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-4">

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -33,7 +33,7 @@ export function BottomNav() {
   const filteredNavItems = navItems.filter((item) => !item.feature || isFeatureEnabled(item.feature));
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 bg-card border-t border-border md:hidden">
+    <nav className="fixed bottom-0 left-0 right-0 bg-card border-t md:hidden">
       <div className="flex items-center justify-around">
         {filteredNavItems.map(({ path, icon: Icon, label }) => {
           const isActive =

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -172,9 +172,10 @@ const ChartTooltipContent = React.forwardRef<
       <div
         ref={ref}
         className={cn(
-          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+          "grid min-w-[8rem] items-start gap-1.5 rounded-lg border bg-background px-2.5 py-1.5 text-xs shadow-xl",
           className
         )}
+        style={{ borderColor: "hsl(var(--border) / 0.5)" }}
       >
         {!nestLabel ? tooltipLabel : null}
         <div className="grid gap-1.5">

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -13,7 +13,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       toastOptions={{
         classNames: {
           toast:
-            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border-border group-[.toaster]:shadow-lg",
+            "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:shadow-lg",
           description: "group-[.toast]:text-muted-foreground",
           actionButton:
             "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",

--- a/src/layouts/AuthedLayout.tsx
+++ b/src/layouts/AuthedLayout.tsx
@@ -113,7 +113,7 @@ export default function AuthedLayout({ children }: AuthedLayoutProps) {
                     <nav className="flex flex-col gap-2 text-sm">
                       <NavLinks mobile />
                     </nav>
-                    <hr className="border-border" />
+                    <hr className="border-t" />
                     <div className="flex flex-col gap-2 text-sm">
                       <button
                         className="text-left py-2 opacity-80 hover:opacity-100 transition-opacity"

--- a/src/pages/HealthSync.tsx
+++ b/src/pages/HealthSync.tsx
@@ -95,7 +95,7 @@ export default function HealthSync() {
               Sync yesterday
             </Button>
             {sync && (
-              <div className="grid grid-cols-3 gap-3 rounded-md border border-border p-3 text-center text-xs">
+              <div className="grid grid-cols-3 gap-3 rounded-md border p-3 text-center text-xs">
                 <div>
                   <div className="text-muted-foreground">Steps</div>
                   <div className="text-lg font-semibold">{sync.steps}</div>

--- a/src/pages/PhotoCapture.tsx
+++ b/src/pages/PhotoCapture.tsx
@@ -115,9 +115,9 @@ const PhotoCapture = () => {
                 <div 
                   key={s} 
                   className={`rounded-md border p-2 transition-colors ${
-                    isComplete 
-                      ? "border-primary bg-primary/10 text-primary" 
-                      : "border-border"
+                    isComplete
+                      ? "border-primary bg-primary/10 text-primary"
+                      : "border"
                   }`}
                 >
                   {isComplete && <span className="block text-xs">✓</span>}

--- a/src/pages/Plans.tsx
+++ b/src/pages/Plans.tsx
@@ -199,7 +199,7 @@ export default function Plans() {
               <span className="text-muted-foreground">📊 DEXA scans</span>
               <span className="font-semibold">~$150/scan</span>
             </div>
-            <hr className="border-border my-2" />
+            <hr className="my-2 border-t" />
             <div className="flex justify-between items-center py-2 text-lg">
               <span className="text-primary font-bold">MyBodyScan</span>
               <div className="text-right">

--- a/src/pages/WorkoutsLibrary.tsx
+++ b/src/pages/WorkoutsLibrary.tsx
@@ -52,7 +52,7 @@ export default function WorkoutsLibrary() {
                 <p className="text-muted-foreground">{plan.today.summary}</p>
                 <ul className="space-y-2">
                   {plan.today.exercises.map((exercise) => (
-                    <li key={exercise.id} className="flex flex-col rounded-md border border-border p-3">
+                    <li key={exercise.id} className="flex flex-col rounded-md border p-3">
                       <div className="text-sm font-semibold text-foreground">{exercise.name}</div>
                       <div className="text-xs text-muted-foreground">
                         {exercise.sets} sets × {exercise.reps} • {exercise.focus}
@@ -78,7 +78,7 @@ export default function WorkoutsLibrary() {
               </CardHeader>
               <CardContent className="space-y-3">
                 {plan.library.map((session) => (
-                  <div key={session.id} className="rounded-md border border-border p-3">
+                  <div key={session.id} className="rounded-md border p-3">
                     <div className="flex items-center justify-between text-sm">
                       <div>
                         <div className="font-medium text-foreground">{session.name}</div>


### PR DESCRIPTION
## Summary
- replace uses of the non-existent `border-border` utility with supported Tailwind border utilities or inline border colors
- update tooltip styling to use raw CSS for the semi-transparent border color
- ensure horizontal rule and navigation components rely on standard border utilities to avoid Tailwind build failures

## Testing
- `npm run build` *(fails: vite executable missing because dependencies could not be installed in the execution environment)*
- `npm install` *(fails: npm registry access for @opentelemetry/semantic-conventions is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e078fcda2c8325b2f91ff5e5dd5e16