### PR TITLE
build(functions): late-load env + safe mock payments + deploy without root install

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -125,7 +125,7 @@
   "functions": {
     "source": "functions",
     "predeploy": [
-      "npm --prefix \"$RESOURCE_DIR\" run build"
+      "npm --prefix \"$RESOURCE_DIR\" ci && npm --prefix \"$RESOURCE_DIR\" run build"
     ]
   },
   "firestore": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,8 +11,8 @@
     "set:staff": "ts-node scripts/setStaffClaim.ts"
   },
   "dependencies": {
-    "firebase-admin": "^12.5.0",
-    "firebase-functions": "^4.6.0",
+    "firebase-admin": "^12.6.0",
+    "firebase-functions": "^5.1.0",
     "stripe": "^16.0.0"
   },
   "devDependencies": {

--- a/functions/src/appCheck.ts
+++ b/functions/src/appCheck.ts
@@ -1,20 +1,70 @@
 import * as admin from "firebase-admin";
+import { HttpsError } from "firebase-functions/v2/https";
+
+import { getBool, getEnvOrDefault } from "./env.js";
 
 if (!admin.apps.length) {
   admin.initializeApp();
 }
 
+const allowedOrigins = new Set(
+  getEnvOrDefault("APP_CHECK_ALLOWED_ORIGINS", "")
+    .split(",")
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+);
+
+const softEnforcement = getBool("APP_CHECK_ENFORCE_SOFT", true);
+
+function shouldEnforceStrict(origin?: string | null): boolean {
+  if (softEnforcement) {
+    return false;
+  }
+  if (!allowedOrigins.size) {
+    return true;
+  }
+  if (!origin) {
+    return false;
+  }
+  return allowedOrigins.has(origin);
+}
+
+export function readAppCheckOrigin(req: any): string | undefined {
+  if (!req?.get) {
+    return undefined;
+  }
+  return req.get("Origin") ?? req.get("origin") ?? undefined;
+}
+
+export function shouldStrictlyEnforceAppCheck(origin?: string | null): boolean {
+  return shouldEnforceStrict(origin ?? null);
+}
+
 /** Throws 401-like error if missing/invalid App Check token */
 export async function verifyAppCheckFromHeader(req: any) {
-  const token = req.header("X-Firebase-AppCheck");
+  const token = req?.header ? req.header("X-Firebase-AppCheck") : undefined;
+  const origin = readAppCheckOrigin(req) ?? null;
+  const path = typeof req?.path === "string" ? req.path : null;
+  const strict = shouldStrictlyEnforceAppCheck(origin);
+
   if (!token) {
-    console.warn("AppCheck: soft mode (missing)");
+    const payload = { origin, path };
+    if (strict) {
+      console.warn("AppCheck: strict reject (missing)", payload);
+      throw new HttpsError("unauthenticated", "Missing App Check token");
+    }
+    console.warn("AppCheck: soft mode (missing)", payload);
     return;
   }
+
   try {
     await admin.appCheck().verifyToken(token);
   } catch (error) {
-    console.warn("AppCheck: soft mode (invalid)", { message: (error as Error)?.message });
-    return;
+    const payload = { origin, path, message: (error as Error)?.message };
+    if (strict) {
+      console.warn("AppCheck: strict reject (invalid)", payload);
+      throw new HttpsError("unauthenticated", "Invalid App Check token");
+    }
+    console.warn("AppCheck: soft mode (invalid)", payload);
   }
 }

--- a/functions/src/env.ts
+++ b/functions/src/env.ts
@@ -5,6 +5,13 @@ function isEmulator(): boolean {
 }
 
 const validatedKeys = new Set<string>();
+const warnedKeys = new Set<string>();
+
+function markValidated(name: string, value: string | undefined): void {
+  if (value) {
+    validatedKeys.add(name);
+  }
+}
 
 export function requireEnv(name: string, context: string): string {
   const value = process.env[name];
@@ -16,7 +23,7 @@ export function requireEnv(name: string, context: string): string {
     }
   }
   if (value) {
-    validatedKeys.add(name);
+    markValidated(name, value);
     return value;
   }
   return "";
@@ -40,4 +47,34 @@ export function reportMissingEnv(name: string, context: string): void {
   if (!isEmulator()) {
     throw new Error(message);
   }
+}
+
+export function getEnvOrDefault(name: string, fallback: string): string {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  markValidated(name, raw);
+  return raw;
+}
+
+export function getBool(name: string, fallback: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw === "") {
+    return fallback;
+  }
+  const normalized = raw.trim().toLowerCase();
+  if (["1", "true", "t", "yes", "y", "on"].includes(normalized)) {
+    markValidated(name, raw);
+    return true;
+  }
+  if (["0", "false", "f", "no", "n", "off"].includes(normalized)) {
+    markValidated(name, raw);
+    return false;
+  }
+  if (!warnedKeys.has(name)) {
+    logger.warn(`${name}: unable to parse boolean value (${raw}); falling back to ${fallback}`);
+    warnedKeys.add(name);
+  }
+  return fallback;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
         "prettier": "^3.3.3",
         "tailwindcss": "^3.4.13",
         "tailwindcss-animate": "^1.0.7",
+        "rimraf": "^4.4.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.38.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "typecheck": "tsc -b --noEmit",
     "qa": "bash scripts/qa.sh",
     "deploy:functions": "firebase deploy --only functions",
-    "deploy:hosting": "firebase deploy --only hosting"
+    "deploy:hosting": "firebase deploy --only hosting",
+    "ci:clean": "npm config set fetch-retry-maxtimeout 600000 && npm cache clean --force && rimraf node_modules && npm ci --prefer-online"
   },
   "dependencies": {
     "@capacitor/cli": "^6.2.1",
@@ -108,6 +109,7 @@
     "prettier": "^3.3.3",
     "tailwindcss": "^3.4.13",
     "tailwindcss-animate": "^1.0.7",
+    "rimraf": "^4.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",


### PR DESCRIPTION
## Summary
- late-load Cloud Functions configuration, adding helpers for optional env defaults and stricter App Check enforcement
- upgrade the Functions runtime to firebase-functions v5 on Node 20 and add a mock Stripe payment fallback when secrets are absent
- document the new deploy workflow and add a root ci:clean script so functions deploys no longer depend on the web install

## Secrets
- OPENAI_API_KEY
- STRIPE_SECRET
- STRIPE_SECRET_KEY
- HOST_BASE_URL
- APP_CHECK_ALLOWED_ORIGINS
- APP_CHECK_ENFORCE_SOFT

## Testing
- `npm --prefix functions run build`

## Acceptance Criteria
- [ ] Functions import without STRIPE secrets does not crash (mock mode).
- [ ] APP_CHECK_ALLOWED_ORIGINS missing no longer throws; soft-enforce works.
- [ ] Deploying --only functions succeeds without root npm ci.
- [ ] firebase-functions upgraded; Node 20 target retained; builds pass.
- [ ] CSP intact; web build unaffected.


------
https://chatgpt.com/codex/tasks/task_e_68e2eb0ecac4832598fb82c2d09d029a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configurable App Check enforcement by origin with soft/strict modes via environment settings.
  - Payments now supports “mock mode” when Stripe is not configured, with graceful fallback URLs for checkout and customer portal.
  - More robust environment variable handling with sensible defaults and boolean parsing.

- Documentation
  - Added Functions environment/secrets guidance and deployment notes.
  - Clarified Stripe webhook signature validation and de-duplication.
  - Added troubleshooting for local integrity cache issues.

- Chores
  - Predeploy now runs CI before build.
  - Added ci:clean script; introduced rimraf.
  - Updated Firebase-related dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->