### PR TITLE
chore: add cursor PR automation helper

### DIFF
--- a/docs/cursor-pr-automation.md
+++ b/docs/cursor-pr-automation.md
@@ -1,0 +1,70 @@
+# Cursor Pull Request Automation Guide
+
+This guide explains how to ensure the Cursor editor can automatically open pull requests for the `Antisgoat/mybodyscan` repository. The automation script in `scripts/cursor_pr_automation.sh` performs the full workflow, including authentication checks, branch creation, commit creation, push, and PR creation with a REST API fallback.
+
+## Prerequisites
+
+- Cursor installed on macOS (Homebrew installs GitHub CLI under `/opt/homebrew/bin`).
+- GitHub CLI (`gh`) installed via Homebrew: `brew install gh`.
+- Git configured with access to the repository.
+- Python 3 and `curl` available (pre-installed on macOS).
+
+## Usage
+
+1. **Expose `/opt/homebrew/bin` to Cursor**
+   - Cursor usually launches a non-login shell. The script determines the appropriate init file (`~/.zshrc`, `~/.bash_profile`, or `~/.profile`) and appends `export PATH="/opt/homebrew/bin:$PATH"` if missing.
+   - If `/opt/homebrew/bin` is not present (for example on Intel Macs or Linux), the script simply logs a notice and continues.
+
+2. **Verify `gh` visibility**
+   - Run the automation script from the repository root: `bash scripts/cursor_pr_automation.sh`.
+   - The script first checks whether `gh` is already visible. If not, it updates the PATH and prompts the user to install `gh` if required.
+
+3. **Authenticate `gh`**
+   - The script runs `gh auth status -h github.com`. If authentication is missing, it launches `gh auth login -h github.com -s repo,workflow,read:org --web`, ensuring Cursor uses the same browser-based login as other workflows.
+
+4. **Create a test branch and commit**
+   - A branch named `fix/cursor-pr-test-<today>` is created (or re-used if it already exists).
+   - The script writes `tests/cursor-pr-environment.md`, capturing the PATH and `gh` binary location to confirm environment visibility.
+   - The file is committed as `test: add cursor PR environment check` and pushed to `origin`.
+
+5. **Open the pull request**
+   - First attempt: `gh pr create --base main --head fix/cursor-pr-test-<today> --title "test: verify Cursor PR creation" --body "Testing Cursor PR creation automation."`
+   - Fallback: If `gh pr create` fails (for example, because of a bug or rate limit), the script reads the authenticated token (`gh auth token` or `GITHUB_TOKEN`) and calls the GitHub REST API (`POST /repos/{owner}/{repo}/pulls`).
+   - On success, the script prints the PR URL and exits. On failure, errors are surfaced in the console so Cursor can report them directly.
+
+6. **Termination behaviour**
+   - The script stops after outputting the PR link. Cursor can parse the last line to confirm success.
+
+## Manual execution steps (if you prefer not to run the script)
+
+1. Add `/opt/homebrew/bin` to the appropriate shell init file and restart Cursor.
+2. Verify `gh` is available: `which gh`.
+3. Authenticate: `gh auth login -h github.com -s repo,workflow,read:org --web`.
+4. Run:
+   ```bash
+   git checkout -b fix/cursor-pr-test-$(date +%Y%m%d)
+   printf '# Cursor PR test\n' > tests/cursor-pr-environment.md
+   git add tests/cursor-pr-environment.md
+   git commit -m "test: add cursor PR environment check"
+   git push -u origin HEAD
+   gh pr create --base main --title "test: verify Cursor PR creation" --body "Testing Cursor PR creation automation."
+   ```
+5. If `gh pr create` fails, use the REST API fallback described earlier.
+
+## Cleaning up
+
+- After verifying automation, delete the test branch locally and remotely:
+  ```bash
+  git checkout main
+  git branch -D fix/cursor-pr-test-<today>
+  git push origin --delete fix/cursor-pr-test-<today>
+  ```
+- Remove `tests/cursor-pr-environment.md` if it is no longer needed.
+
+## Troubleshooting
+
+- **`gh` still not found**: Confirm that the init file is sourced by the shell Cursor launches. Cursor’s settings allow specifying an additional PATH; ensure `/opt/homebrew/bin` is listed.
+- **Authentication loops**: Delete the `~/.config/gh/hosts.yml` entry for `github.com` and re-run the script.
+- **REST API errors**: Ensure `gh auth token` returns a token or set `GITHUB_TOKEN` with `repo` scope manually.
+
+By following this guide and using the provided script, Cursor gains a deterministic workflow for creating pull requests with a GitHub CLI fallback.

--- a/scripts/cursor_pr_automation.sh
+++ b/scripts/cursor_pr_automation.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly BASE_BRANCH="main"
+readonly TITLE="test: verify Cursor PR creation"
+readonly BODY="Testing Cursor PR creation automation."
+
+log() {
+  printf '[cursor-pr] %s\n' "$*"
+}
+
+err() {
+  printf '[cursor-pr][error] %s\n' "$*" >&2
+}
+
+shell_init_file() {
+  local shell_path
+  shell_path=${SHELL:-}
+  case "${shell_path}" in
+    */zsh)
+      printf '%s/.zshrc' "${ZDOTDIR:-$HOME}"
+      ;;
+    */bash)
+      if [[ -f "$HOME/.bash_profile" ]]; then
+        printf '%s/.bash_profile' "$HOME"
+      elif [[ -f "$HOME/.bash_login" ]]; then
+        printf '%s/.bash_login' "$HOME"
+      elif [[ -f "$HOME/.profile" ]]; then
+        printf '%s/.profile' "$HOME"
+      else
+        printf '%s/.bash_profile' "$HOME"
+      fi
+      ;;
+    *)
+      printf '%s/.profile' "$HOME"
+      ;;
+  esac
+}
+
+ensure_homebrew_path() {
+  local init_file path_entry
+  init_file=$(shell_init_file)
+  path_entry='export PATH="/opt/homebrew/bin:$PATH"'
+
+  if [[ ! -d /opt/homebrew/bin ]]; then
+    log "Homebrew path /opt/homebrew/bin not found on this system; skipping PATH update."
+    return
+  fi
+
+  mkdir -p "$(dirname "$init_file")"
+  if [[ -f "$init_file" ]] && grep -Fq "/opt/homebrew/bin" "$init_file"; then
+    log "Homebrew path already present in ${init_file}."
+  else
+    log "Adding /opt/homebrew/bin to PATH inside ${init_file}."
+    {
+      printf '\n# Added by scripts/cursor_pr_automation.sh to expose GitHub CLI for Cursor\n'
+      printf '%s\n' "$path_entry"
+    } >> "$init_file"
+  fi
+
+  # shellcheck disable=SC1090
+  source "$init_file" || true
+}
+
+ensure_gh_in_path() {
+  if command -v gh >/dev/null 2>&1; then
+    log "GitHub CLI already available as $(command -v gh)."
+    return 0
+  fi
+
+  ensure_homebrew_path
+
+  if command -v gh >/dev/null 2>&1; then
+    log "GitHub CLI found after PATH update: $(command -v gh)."
+    return 0
+  fi
+
+  err "GitHub CLI (gh) not found even after updating PATH. Install it with Homebrew (brew install gh) or make sure it is on the PATH."
+  return 1
+}
+
+ensure_gh_authenticated() {
+  if gh auth status -h github.com >/dev/null 2>&1; then
+    log "GitHub CLI already authenticated for github.com."
+    return 0
+  fi
+
+  log "Authenticating GitHub CLI for github.com with repo,workflow,read:org scopes."
+  gh auth login -h github.com -s repo,workflow,read:org --web
+}
+
+current_branch() {
+  git rev-parse --abbrev-ref HEAD
+}
+
+checkout_branch() {
+  local branch
+  branch=$1
+  if git show-ref --verify --quiet "refs/heads/${branch}"; then
+    git checkout "$branch"
+  else
+    git checkout -b "$branch"
+  fi
+}
+
+create_test_file() {
+  local file
+  file="tests/cursor-pr-environment.md"
+  mkdir -p "$(dirname "$file")"
+  cat <<FILE_CONTENT > "$file"
+# Cursor Pull Request Environment Check
+
+- Generated at: $(date -Iseconds)
+- PATH: \`\$PATH\`
+- gh location: \`$(command -v gh || echo "gh not found")\`
+
+This file confirms that the automation script successfully created a test branch and staged content.
+FILE_CONTENT
+}
+
+commit_test_file() {
+  git add tests/cursor-pr-environment.md
+  if git diff --cached --quiet; then
+    log "No staged changes to commit."
+    return 1
+  fi
+  git commit -m "test: add cursor PR environment check"
+}
+
+push_branch() {
+  local branch
+  branch=$1
+  git push -u origin "$branch"
+}
+
+parse_owner_repo() {
+  local remote url regex
+  remote=${1:-origin}
+  url=$(git remote get-url "$remote")
+  regex='github.com[:/](.+)/([^/]+?)(\\.git)?$'
+  if [[ $url =~ $regex ]]; then
+    printf '%s %s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}"
+    return 0
+  fi
+  err "Unable to parse owner/repo from remote URL: $url"
+  return 1
+}
+
+create_pr_with_gh() {
+  local branch=$1
+  if gh pr create --base "$BASE_BRANCH" --head "$branch" --title "$TITLE" --body "$BODY"; then
+    return 0
+  fi
+  return 1
+}
+
+create_pr_with_api() {
+  local branch=$1 owner repo token api_url payload response pr_url
+  read -r owner repo < <(parse_owner_repo origin)
+  token=$(gh auth token 2>/dev/null || true)
+  if [[ -z ${token} ]]; then
+    token=${GITHUB_TOKEN:-}
+  fi
+  if [[ -z ${token} ]]; then
+    err "No GitHub token available for API fallback. Set GITHUB_TOKEN or authenticate gh."
+    return 1
+  fi
+
+  api_url="https://api.github.com/repos/${owner}/${repo}/pulls"
+  payload=$(cat <<JSON
+{
+  "title": "${TITLE//"/\"}",
+  "head": "${branch//"/\"}",
+  "base": "${BASE_BRANCH//"/\"}",
+  "body": "${BODY//"/\"}"
+}
+JSON
+  )
+
+  response=$(curl -sS -X POST "$api_url" -H "Authorization: Bearer ${token}" -H "Accept: application/vnd.github+json" -d "$payload")
+
+  pr_url=$(python3 - <<'PY'
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as exc:
+    sys.stderr.write(f'Failed to parse GitHub API response: {exc}\n')
+    sys.exit(1)
+if 'html_url' in data:
+    print(data['html_url'])
+    sys.exit(0)
+if 'message' in data:
+    sys.stderr.write(f"GitHub API error: {data['message']}\n")
+    if 'errors' in data:
+        sys.stderr.write(json.dumps(data['errors'], indent=2) + '\n')
+    sys.exit(2)
+sys.stderr.write('Unexpected API response without html_url.\n')
+sys.exit(3)
+PY
+  <<<"$response")
+
+  local status=$?
+  if [[ $status -ne 0 ]]; then
+    err "GitHub API PR creation failed."
+    return 1
+  fi
+
+  printf '%s\n' "$pr_url"
+}
+
+main() {
+  ensure_gh_in_path
+  ensure_gh_authenticated
+
+  local today branch pr_url
+  today=$(date +%Y%m%d)
+  branch="fix/cursor-pr-test-${today}"
+
+  checkout_branch "$branch"
+  create_test_file
+  commit_test_file || log "Commit skipped because working tree already contains the test file."
+  push_branch "$branch"
+
+  if pr_url=$(create_pr_with_gh "$branch"); then
+    log "Pull request created successfully via gh: $pr_url"
+    printf '%s\n' "$pr_url"
+    exit 0
+  fi
+
+  log "gh pr create failed, attempting REST API fallback."
+  if pr_url=$(create_pr_with_api "$branch"); then
+    log "Pull request created via REST API fallback: $pr_url"
+    printf '%s\n' "$pr_url"
+    exit 0
+  fi
+
+  err "Failed to create pull request with both gh and REST API."
+  exit 1
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Summary
- add a bash automation script that ensures Cursor can expose the GitHub CLI, authenticate, and create a PR with REST API fallback
- document the workflow for maintaining Cursor's environment and executing the helper script

## Testing
- not run (documentation and scripting only)


------
https://chatgpt.com/codex/tasks/task_e_68e2f8b086408325997368f7b427de8b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a PR automation workflow tool that verifies environment, authenticates with GitHub, creates a branch, captures runtime details, commits, pushes, and opens a pull request with a fallback to the GitHub API. Provides clear logs, success URL output, and robust error handling.

* **Documentation**
  * Added a step-by-step guide covering prerequisites, setup, usage, manual execution, cleanup, and troubleshooting for the PR automation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->