### PR TITLE
fix(auth): restore Apple Sign-In (popup/redirect) + domain association path

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,13 @@ Create a `.env.local` for development based on `.env.example` and a `.env.produc
 - `VITE_FUNCTIONS_BASE_URL`
 - `VITE_RECAPTCHA_V3_SITE_KEY` *(App Check; soft in dev/demo if missing)*
 - `VITE_DEMO_MODE` *(optional; demo auto-enables on localhost/lovable or with `?demo=1`)*
-- `VITE_APPLE_ENABLED` *(optional; gate Apple sign-in button)*
+
+### Enable Sign in with Apple (Web)
+
+1. Firebase Console → **Auth** → **Apple** → Enable. Provide your Team ID, Key ID, Services ID, and upload the `.p8` key.
+2. Add authorized domains: `mybodyscan.app`, `mybodyscan-f3daf.web.app`, `mybodyscan-f3daf.firebaseapp.com`.
+3. Copy the redirect handler URL(s) from Firebase (e.g., `https://<auth-domain>/__/auth/handler`) and add them to Apple Developer → **Identifiers** → your Services ID → **Return URLs**.
+4. Optional: place Apple's association file at `/.well-known/apple-developer-domain-association.txt` on Firebase Hosting (replace the placeholder committed in `public/.well-known/`).
 
 Cloud Functions read Stripe credentials from Firebase Secrets Manager entries named `STRIPE_SECRET` (Stripe API key) and `STRIPE_WEBHOOK` (signing secret). Configure them with `firebase functions:secrets:set` (see Deployment).
 

--- a/public/.well-known/apple-developer-domain-association.txt
+++ b/public/.well-known/apple-developer-domain-association.txt
@@ -1,0 +1,2 @@
+# Upload Apple's domain association token in this file when enabling Sign in with Apple (Web).
+# Keep this placeholder committed so Firebase Hosting serves /.well-known/apple-developer-domain-association.txt.

--- a/src/lib/firebaseAuthConfig.ts
+++ b/src/lib/firebaseAuthConfig.ts
@@ -1,0 +1,180 @@
+import { firebaseConfig } from "@/lib/firebase";
+
+const AUTH_CONFIG_ENDPOINT = "https://identitytoolkit.googleapis.com/v2";
+
+export type FirebaseAuthClientConfig = {
+  authorizedDomains: string[];
+  providerIds: string[];
+};
+
+let cachedConfigPromise: Promise<FirebaseAuthClientConfig> | null = null;
+
+function parseAuthorizedDomains(payload: any): string[] {
+  if (!payload) return [];
+  const domains = payload.authorizedDomains;
+  if (Array.isArray(domains)) {
+    return domains.filter((domain): domain is string => typeof domain === "string" && domain.length > 0);
+  }
+  return [];
+}
+
+function coerceProviderId(candidate: any): string | null {
+  if (!candidate) return null;
+  if (typeof candidate === "string") return candidate;
+  if (typeof candidate !== "object") return null;
+  return (
+    candidate.providerId ||
+    candidate.provider ||
+    candidate.id ||
+    candidate.identifier ||
+    candidate.providerIdForDisplay ||
+    null
+  );
+}
+
+function isProviderEnabled(candidate: any): boolean {
+  if (!candidate || typeof candidate !== "object") return true;
+  if ("enabled" in candidate && candidate.enabled === false) return false;
+  if ("enable" in candidate && candidate.enable === false) return false;
+  if ("isEnabled" in candidate && candidate.isEnabled === false) return false;
+  if ("disabled" in candidate && candidate.disabled === true) return false;
+  return true;
+}
+
+function parseProviders(payload: any): string[] {
+  const ids = new Set<string>();
+  if (!payload) return Array.from(ids);
+
+  const maybeArrays = [
+    payload.providerConfigs,
+    payload.signInMethodConfigs,
+    payload.signIn?.providers,
+    payload.signIn?.providerConfigs,
+    payload.signIn?.oauthProviders,
+    payload.signIn?.federatedSignInConfigs,
+    payload.signIn?.federated?.providers,
+    payload.oauthIdpConfigs,
+    payload.federatedProviderConfigs,
+  ];
+
+  for (const source of maybeArrays) {
+    if (!source) continue;
+    if (Array.isArray(source)) {
+      for (const entry of source) {
+        const id = coerceProviderId(entry);
+        if (!id) continue;
+        if (!isProviderEnabled(entry)) continue;
+        ids.add(id);
+      }
+      continue;
+    }
+    if (typeof source === "object") {
+      for (const [key, entry] of Object.entries(source)) {
+        const id = coerceProviderId(entry) ?? key;
+        if (!id) continue;
+        if (!isProviderEnabled(entry)) continue;
+        ids.add(id);
+      }
+    }
+  }
+
+  const appleFlags = [
+    payload.appleSignInConfig?.enabled,
+    payload.signIn?.apple?.enabled,
+    payload.signIn?.apple,
+    payload.appleSignIn,
+  ];
+  if (appleFlags.some((flag) => flag === true)) {
+    ids.add("apple.com");
+  }
+
+  return Array.from(ids);
+}
+
+function withEnvFallback(config: FirebaseAuthClientConfig): FirebaseAuthClientConfig {
+  const envFlag = import.meta.env.VITE_APPLE_ENABLED as string | undefined;
+  const forceOn = envFlag === "true";
+  const forceOff = envFlag === "false";
+
+  if (forceOn && !config.providerIds.includes("apple.com")) {
+    config.providerIds = [...config.providerIds, "apple.com"];
+  }
+  if (forceOff) {
+    config.providerIds = config.providerIds.filter((id) => id !== "apple.com");
+  }
+  return config;
+}
+
+export async function loadFirebaseAuthClientConfig(): Promise<FirebaseAuthClientConfig> {
+  if (cachedConfigPromise) return cachedConfigPromise;
+
+  if (typeof window === "undefined") {
+    cachedConfigPromise = Promise.resolve(
+      withEnvFallback({ authorizedDomains: [], providerIds: [] })
+    );
+    return cachedConfigPromise;
+  }
+
+  const apiKey = firebaseConfig.apiKey;
+  const projectId = firebaseConfig.projectId;
+
+  if (!apiKey || !projectId) {
+    cachedConfigPromise = Promise.resolve(
+      withEnvFallback({ authorizedDomains: [], providerIds: [] })
+    );
+    return cachedConfigPromise;
+  }
+
+  const url = `${AUTH_CONFIG_ENDPOINT}/projects/${encodeURIComponent(projectId)}/clientConfig?key=${encodeURIComponent(apiKey)}`;
+
+  cachedConfigPromise = fetch(url)
+    .then(async (res) => {
+      if (!res.ok) {
+        throw new Error(`Failed to load Firebase Auth client config (${res.status})`);
+      }
+      return res.json();
+    })
+    .then((payload) => {
+      const authorizedDomains = parseAuthorizedDomains(payload);
+      const providerIds = parseProviders(payload);
+      return withEnvFallback({ authorizedDomains, providerIds });
+    })
+    .catch((err) => {
+      if (import.meta.env.DEV) {
+        console.warn("[auth] Unable to load Firebase Auth client config:", err);
+      }
+      return withEnvFallback({ authorizedDomains: [], providerIds: [] });
+    });
+
+  return cachedConfigPromise;
+}
+
+function domainMatches(host: string, domain: string): boolean {
+  const trimmed = domain.trim().toLowerCase();
+  if (!trimmed) return false;
+  const hostLower = host.toLowerCase();
+  if (hostLower === trimmed) return true;
+  if (hostLower.endsWith(`.${trimmed}`)) return true;
+  return false;
+}
+
+export function warnIfDomainUnauthorized(): void {
+  if (!import.meta.env.DEV) return;
+  if (typeof window === "undefined") return;
+
+  void loadFirebaseAuthClientConfig().then((config) => {
+    if (!config.authorizedDomains.length) return;
+    const host = window.location.hostname;
+    const isAuthorized = config.authorizedDomains.some((domain) => domainMatches(host, domain));
+    if (!isAuthorized) {
+      console.warn(
+        `[auth] ${window.location.origin} is not in your Firebase authorized domains. Add it via Firebase Console → Auth → Settings → Authorized domains.`
+      );
+    }
+  });
+}
+
+export function isProviderEnabled(providerId: string, config: FirebaseAuthClientConfig): boolean {
+  return config.providerIds.includes(providerId);
+}
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,8 +5,10 @@ import "./index.css";
 import { AppErrorBoundary } from "./app/AppErrorBoundary";
 import { initAppCheck } from "./appCheck";
 import { killSW } from "./lib/killSW";
+import { warnIfDomainUnauthorized } from "./lib/firebaseAuthConfig";
 
 killSW();
+warnIfDomainUnauthorized();
 void initAppCheck().catch((e) => console.warn("AppCheck init skipped:", e?.message || e));
 
 ReactDOM.createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## Summary
- detect Apple provider availability via the Firebase Auth client config and wire the login button to the new popup/redirect helper with friendly error handling
- persist OAuth redirect targets, resolve Apple redirect results, and warn during development when the current origin is not in the authorized domain list
- add the `.well-known/apple-developer-domain-association.txt` placeholder and document the Apple web setup runbook in the README

## CSP
- No changes needed; existing directives already allow required Apple assets.

## Runbook
- Firebase Console → **Auth** → **Apple** → Enable. Provide your Team ID, Key ID, Services ID, and upload the `.p8` key.
- Add authorized domains: `mybodyscan.app`, `mybodyscan-f3daf.web.app`, `mybodyscan-f3daf.firebaseapp.com`.
- Copy the redirect handler URL(s) from Firebase (e.g., `https://<auth-domain>/__/auth/handler`) and add them to Apple Developer → **Identifiers** → your Services ID → **Return URLs**.
- Optional: place Apple's association file at `/.well-known/apple-developer-domain-association.txt` on Firebase Hosting (replace the placeholder committed in `public/.well-known/`).

## Testing
- `npm run build` *(fails: vite binary not present in container)*

## QA Checklist
- [ ] Apple button visible on login page when provider is enabled.
- [ ] Desktop Chrome uses popup successfully; iOS Safari uses redirect and signs in.
- [ ] After redirect, user lands signed in on the intended route.
- [ ] No crashes; friendly toasts on errors.
- [ ] /.well-known path exists for Apple domain verification.
- [ ] CSP remains strict; only img-src for Apple if needed.


------
https://chatgpt.com/codex/tasks/task_e_68e39d1866288325a649fbbc9431f503

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added smoother “Sign in with Apple” on web, with automatic fallback for iOS Safari and popup-blocked cases.
  - Post-login returns you to your intended page automatically.
- Improvements
  - Apple sign-in button now appears only when available for your domain/config.
  - Default post-auth destination updated to “Today”.
- Documentation
  - Expanded setup for “Sign in with Apple (Web)” including Firebase, domain whitelisting, return URLs, and optional association file.
  - Added guidance for Functions environment variables and secrets, plus broader Firebase Web config and deployment notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->