### PR TITLE
chore(ci): make Firebase preview non-blocking without creds; deploy when secrets exist

### DIFF
--- a/.github/workflows/firebase-preview.yml
+++ b/.github/workflows/firebase-preview.yml
@@ -1,0 +1,98 @@
+name: Firebase Hosting Preview
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      FIREBASE_PROJECT: mybodyscan-f3daf
+      PREVIEW_CHANNEL: pr-${{ github.event.number }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Detect Firebase credentials
+        id: creds
+        shell: bash
+        run: |
+          set -euo pipefail
+          HAS_CREDS="false"
+          MODE=""
+          if [ -n "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}" ]; then
+            HAS_CREDS="true"
+            MODE="sa"
+          elif [ -n "${{ secrets.FIREBASE_TOKEN }}" ]; then
+            HAS_CREDS="true"
+            MODE="token"
+          fi
+          echo "has=${HAS_CREDS}" >> "$GITHUB_OUTPUT"
+          echo "mode=${MODE}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize preview plan
+        if: always()
+        run: |
+          {
+            echo "### Firebase Preview"
+            echo ""
+            if [ "${{ steps.creds.outputs.has }}" != "true" ]; then
+              echo "🔸 No credentials configured (FIREBASE_SERVICE_ACCOUNT or FIREBASE_TOKEN)."
+              echo "This job will **skip deploy** and succeed so PRs aren't blocked."
+              echo ""
+              echo "How to enable preview deploys:"
+              echo "1) Add repo secret FIREBASE_SERVICE_ACCOUNT (raw JSON or base64)."
+              echo "   –or– add FIREBASE_TOKEN from \`firebase login:ci\`."
+            else
+              echo "✅ Credentials detected. Mode: **${{ steps.creds.outputs.mode }}**."
+              echo "Project: $FIREBASE_PROJECT"
+              echo "Channel: $PREVIEW_CHANNEL"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Prepare Firebase credentials (optional)
+        if: ${{ steps.creds.outputs.has == 'true' }}
+        shell: bash
+        env:
+          FIREBASE_SERVICE_ACCOUNT: ${{ secrets.FIREBASE_SERVICE_ACCOUNT }}
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -n "${FIREBASE_SERVICE_ACCOUNT:-}" ]; then
+            KEY_PATH="$RUNNER_TEMP/firebase.json"
+            if [[ "$FIREBASE_SERVICE_ACCOUNT" == \{* ]]; then
+              printf '%s' "$FIREBASE_SERVICE_ACCOUNT" > "$KEY_PATH"
+            else
+              printf '%s' "$FIREBASE_SERVICE_ACCOUNT" | base64 --decode > "$KEY_PATH"
+            fi
+            echo "GOOGLE_APPLICATION_CREDENTIALS=$KEY_PATH" >> "$GITHUB_ENV"
+            echo "FB_AUTH_MODE=sa" >> "$GITHUB_ENV"
+          elif [ -n "${FIREBASE_TOKEN:-}" ]; then
+            echo "FIREBASE_TOKEN=$FIREBASE_TOKEN" >> "$GITHUB_ENV"
+            echo "FB_AUTH_MODE=token" >> "$GITHUB_ENV"
+          fi
+
+      - name: Install Firebase CLI
+        if: ${{ steps.creds.outputs.has == 'true' }}
+        run: npm i -g firebase-tools
+
+      - name: Install deps and build web
+        run: |
+          (npm ci || npm install --prefer-online)
+          npm run build
+
+      - name: Deploy Hosting preview
+        if: ${{ steps.creds.outputs.has == 'true' && github.event.pull_request.head.repo.fork == false }}
+        run: |
+          firebase hosting:channel:deploy "$PREVIEW_CHANNEL" --project "$FIREBASE_PROJECT" --json > preview.json
+          URL=$(node -e "const j=require('./preview.json');console.log(j.result?.url || j.result?.channels?.[0]?.url || '')")
+          echo "Preview URL: $URL"
+          echo "🔗 **Preview URL**: $URL" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Mark preview skipped (no credentials)
+        if: ${{ steps.creds.outputs.has != 'true' || github.event.pull_request.head.repo.fork == true }}
+        run: echo "Preview deploy skipped."

--- a/README.md
+++ b/README.md
@@ -154,6 +154,18 @@ scripts/setup-eventarc.sh
 firebase deploy --only functions:processQueuedScan
 ```
 
+## CI Deploy Setup
+
+- PR previews succeed even without credentials (skipped).
+- To enable deploys, add repo secret **FIREBASE_SERVICE_ACCOUNT** (raw JSON or base64) or **FIREBASE_TOKEN**.
+- Minimal roles for the service account:
+  * Firebase Hosting Admin
+  * Cloud Functions Admin
+  * Cloud Build Editor
+  * Service Account User
+  * Artifact Registry Writer
+- Forked PRs never deploy (skipped by design).
+
 ## Deployment
 
 Deploy Functions and Hosting after setting Stripe keys and webhook secret via `firebase functions:secrets:set`:


### PR DESCRIPTION
## Summary
- add a Firebase preview workflow that detects secrets, builds the web app, and deploys Hosting previews when credentials are configured
- skip deployment gracefully without secrets or on forks while surfacing the plan in the job summary
- document the credential requirements in [CI Deploy Setup](README.md#ci-deploy-setup)

## Testing
- not run (CI only)

## Checklist
- [ ] Preview succeeds (deploys when secrets exist; otherwise skips with summary)
- [ ] Forked PRs skip gracefully
- [ ] Production deploy workflow unchanged
- [ ] No effect on app code or runtime

------
https://chatgpt.com/codex/tasks/task_e_68e3d61372708325904a3c2de87f1f5f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a GitHub Actions workflow to generate Firebase Hosting preview deployments for pull requests, with clear summaries indicating when previews are deployed or skipped (e.g., missing credentials or forked PRs).

* **Documentation**
  * Updated README with CI deploy setup instructions, including required repository secrets, minimal roles for service accounts, and notes on behavior for forked pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->