### PR TITLE
fix(app): nutrition totals precision; coach graceful fallback; scan credits/idempotency UX

### DIFF
--- a/functions/src/validation/beginPaidScan.ts
+++ b/functions/src/validation/beginPaidScan.ts
@@ -5,11 +5,13 @@ export interface BeginPaidScanPayload {
   hashes: string[];
   gateScore: number;
   mode: "2" | "4";
+  idempotencyKey?: string;
 }
 
 const MAX_SCAN_ID = 128;
 const MAX_HASH_LENGTH = 256;
 const MAX_HASHES = 10;
+const MAX_IDEMPOTENCY_KEY = 128;
 
 function sanitizeToken(value: string, maxLength: number): string {
   return value
@@ -42,6 +44,9 @@ export function validateBeginPaidScanPayload(input: unknown): ValidationResult<B
     errors.push("scanId");
   }
 
+  const idKeyRaw = typeof body.idempotencyKey === "string" ? body.idempotencyKey.trim() : "";
+  const idempotencyKey = idKeyRaw ? sanitizeToken(idKeyRaw, MAX_IDEMPOTENCY_KEY) : undefined;
+
   const hashesInput = Array.isArray(body.hashes) ? body.hashes : [];
   const sanitizedHashes = hashesInput
     .map((hash) => sanitizeHash(hash))
@@ -72,6 +77,7 @@ export function validateBeginPaidScanPayload(input: unknown): ValidationResult<B
       hashes: Array.from(new Set(sanitizedHashes)),
       gateScore: Math.round(gateScore),
       mode,
+      ...(idempotencyKey ? { idempotencyKey } : {}),
     },
   };
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -323,6 +323,7 @@ export async function beginPaidScan(payload: {
   hashes: string[];
   gateScore: number;
   mode: "2" | "4";
+  idempotencyKey?: string;
 }) {
   const response = await authedFetch(`/beginPaidScan`, {
     method: "POST",

--- a/src/pages/ScanResult.tsx
+++ b/src/pages/ScanResult.tsx
@@ -166,6 +166,11 @@ export default function ScanResult() {
           </Link>
         </CardHeader>
         <CardContent className="space-y-4">
+          {scan.provider === "mock" && (
+            <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-xs text-amber-900">
+              Vision unavailable; using mock
+            </div>
+          )}
           {scan.status !== "completed" && (
             <div className="flex items-center gap-2 rounded-lg border border-dashed p-3 text-sm text-muted-foreground">
               <RefreshCcw className="h-4 w-4" />


### PR DESCRIPTION
- [x] Nutrition totals match item sums (expected rounding)
- [x] Coach returns result or friendly fallback without crashing
- [x] Scan shows credits and handles mock results cleanly

------
https://chatgpt.com/codex/tasks/task_e_68e5b80db15483259a7581e499e2773a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Scan screen shows current credits with loading state.
  - Scan results display a notice when using a mock vision provider.
  - Meals and Nutrition pages now present consistently rounded calories and macros.

- Bug Fixes
  - Chat input is sanitized; per-message errors appear inline for client-side issues.
  - Meals Search shows a temporary-busy notice for 429/503 and ignores canceled searches.
  - Image uploads now block non-image files with a clear message.
  - Scan flow is more reliable across retries, with improved authorization state handling and lifecycle cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->