### PR TITLE
fix: resolve Coach Chat and MealsSearch merge conflicts

### DIFF
--- a/src/pages/MealsSearch.tsx
+++ b/src/pages/MealsSearch.tsx
@@ -352,6 +352,7 @@ export default function MealsSearch() {
       : "USDA primary · OFF fallback";
 
   const favoritesMap = useMemo(() => new Map(favorites.map((fav) => [fav.id, fav])), [favorites]);
+  const searchNotice = null;
 
   return (
     <div className="min-h-screen bg-background pb-20 md:pb-0">
@@ -426,7 +427,13 @@ export default function MealsSearch() {
                 <Loader2 className="h-4 w-4 animate-spin" /> Searching databases…
               </div>
             )}
-            {!loading && appCheckReady && results.length === 0 && query.trim().length > 0 && (
+            {loading && searchNotice && (
+              <p className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900">
+                {searchNotice}
+              </p>
+            )}
+
+            {loading && !searchNotice && appCheckReady && results.length === 0 && query.trim().length > 0 && (
               <p className="text-sm text-muted-foreground">
                 No matches. Try ‘chicken breast’, ‘rice’, or scan a barcode.
               </p>


### PR DESCRIPTION
## Summary
- align the Coach Chat screen with the intended auth/app-check readiness handling and sanitized send logic
- restore MealsSearch loading notice handling before showing the "No matches" empty state

## Testing
- npm run typecheck *(fails: repository snapshot lacks React/TS dependencies required by tsc)*

------
https://chatgpt.com/codex/tasks/task_e_68e5c35cee2c8325bc1a9c6c6634f30d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Chat: Sanitizes messages, ignores empty submissions, and shows a “Still connecting” notice until ready.
  - Chat: Displays clearer, coach-specific unavailability messages instead of generic errors.
  - Meals Search: Adds an optional notice during loading.

- Bug Fixes
  - Chat: Prevents sending messages before authentication and app check are ready; preserves pending state during send.
  - Meals Search: Refines “No matches” timing to avoid premature messages, only showing it when loading completes, app check is ready, the query is non-empty, and no results are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->