### PR TITLE
test(e2e): self-QA for routes/auth/scan/nutrition/coach with artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,57 @@
+name: E2E
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  playwright:
+    name: Playwright E2E
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+        env:
+          BASE_URL: ${{ secrets.E2E_BASE_URL || 'https://mybodyscanapp.com' }}
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report
+          retention-days: 7
+
+      - name: Upload Playwright traces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: 'test-results/**/*.zip'
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Upload Playwright screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-screenshots
+          path: 'test-results/**/*.png'
+          if-no-files-found: ignore
+          retention-days: 7

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,34 @@
+import fs from 'node:fs';
+import { defineConfig, devices } from '@playwright/test';
+
+const isCI = !!process.env.CI;
+const baseURL = process.env.BASE_URL || 'https://mybodyscanapp.com';
+const storageState = process.env.PLAYWRIGHT_STORAGE_STATE;
+const resolvedStorageState =
+  storageState && fs.existsSync(storageState) ? storageState : undefined;
+
+export default defineConfig({
+  testDir: './specs',
+  retries: isCI ? 1 : 0,
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    storageState: resolvedStorageState,
+  },
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report', open: 'never' }]],
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  outputDir: 'test-results',
+});

--- a/e2e/specs/auth.spec.ts
+++ b/e2e/specs/auth.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('Authentication page', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('shows social auth providers', async ({ page }) => {
+    await page.goto('/auth');
+
+    const googleButton = page.getByTestId('auth-google-button');
+    const appleButton = page.getByTestId('auth-apple-button');
+
+    await expect(googleButton).toBeVisible();
+
+    if (await appleButton.count()) {
+      await expect(appleButton).toBeVisible();
+    }
+  });
+});

--- a/e2e/specs/coach.spec.ts
+++ b/e2e/specs/coach.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('Coach assistant', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('exposes composer even when backend errors', async ({ page }) => {
+    await page.route('**/api/coach/**', async (route) => {
+      await route.fulfill({
+        status: 501,
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ error: 'not implemented' }),
+      });
+    });
+
+    await page.goto('/coach');
+
+    await expect(page).toHaveURL(/\/coach/);
+
+    const messageInput = page.getByTestId('coach-message-input');
+    const sendButton = page.getByTestId('coach-send-button');
+
+    await expect(messageInput).toBeVisible();
+    await expect(sendButton).toBeVisible();
+  });
+});

--- a/e2e/specs/demo-flow.spec.ts
+++ b/e2e/specs/demo-flow.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('Demo experience', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('loads demo dashboard when available', async ({ page }) => {
+    const response = await page.goto('/demo?demo=1');
+
+    if (!response || response.status() >= 400) {
+      test.skip(`Demo path unavailable (${response?.status() ?? 'no response'})`);
+    }
+
+    const todayShell = page.getByTestId('today-dashboard');
+    if (await todayShell.count()) {
+      await expect(todayShell).toBeVisible();
+    } else {
+      await expect(page.locator('[data-testid="home-dashboard"], main')).toBeVisible();
+    }
+  });
+});

--- a/e2e/specs/home.spec.ts
+++ b/e2e/specs/home.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('Home routing', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('redirects root to auth or home experience', async ({ page }) => {
+    const response = await page.goto('/');
+    expect(response?.ok() || response?.status() === 304).toBeTruthy();
+
+    await expect(page).toHaveURL(/\/(auth|home)/);
+
+    const authView = page.getByTestId('auth-view');
+    const homeDashboard = page.getByTestId('home-dashboard');
+
+    if (await authView.count()) {
+      await expect(authView).toBeVisible();
+      return;
+    }
+
+    if (await homeDashboard.count()) {
+      await expect(homeDashboard).toBeVisible();
+      return;
+    }
+
+    await expect(page.locator('main')).toBeVisible();
+  });
+});

--- a/e2e/specs/nutrition.spec.ts
+++ b/e2e/specs/nutrition.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('Nutrition planner', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('shows search and totals widgets', async ({ page }) => {
+    await page.goto('/nutrition');
+
+    await expect(page).toHaveURL(/\/nutrition/);
+
+    const searchBox = page.getByTestId('nutrition-search-input');
+    const totalsWidget = page.getByTestId('nutrition-daily-summary');
+
+    await expect(searchBox).toBeVisible();
+    await expect(totalsWidget).toBeVisible();
+  });
+});

--- a/e2e/specs/scan.spec.ts
+++ b/e2e/specs/scan.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('Scan workflow', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('renders upload inputs without starting analysis', async ({ page }) => {
+    await page.goto('/scan');
+
+    await expect(page).toHaveURL(/\/scan/);
+
+    const poseInputs = page.getByTestId('scan-upload-input');
+    await expect(poseInputs).toHaveCount(4);
+
+    const weightInput = page.getByTestId('scan-weight-input');
+    const heightInput = page.getByTestId('scan-height-input');
+    const submitButton = page.getByTestId('scan-submit-button');
+
+    if (await weightInput.count()) {
+      await expect(weightInput.first()).toBeVisible();
+    }
+
+    if (await heightInput.count()) {
+      await expect(heightInput.first()).toBeVisible();
+    }
+
+    await expect(submitButton).toBeVisible();
+  });
+});

--- a/e2e/specs/settings.spec.ts
+++ b/e2e/specs/settings.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('Settings', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('renders account settings shell', async ({ page }) => {
+    await page.goto('/settings');
+
+    await expect(page).toHaveURL(/\/settings/);
+
+    const settingsShell = page.getByTestId('settings-root');
+    await expect(settingsShell).toBeVisible();
+  });
+});

--- a/e2e/specs/system-check.spec.ts
+++ b/e2e/specs/system-check.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+import { attachConsoleGuard } from '../utils/consoleGuard';
+
+test.describe('System check utilities', () => {
+  test.beforeEach(({ page }) => {
+    attachConsoleGuard(page);
+  });
+
+  test('renders diagnostics or at least responds to health ping', async ({ page }) => {
+    const response = await page.goto('/system-check');
+
+    if (response && response.ok()) {
+      await expect(page).toHaveURL(/\/system-check/);
+      const root = page.getByTestId('system-check-root');
+      await expect(root).toBeVisible();
+      return;
+    }
+
+    const healthResponse = await page.request.get('/__/functions/health');
+    expect(healthResponse.ok()).toBeTruthy();
+  });
+});

--- a/e2e/utils/consoleGuard.ts
+++ b/e2e/utils/consoleGuard.ts
@@ -1,0 +1,27 @@
+import type { ConsoleMessage, Page } from '@playwright/test';
+
+const benignConsolePatterns: Array<RegExp> = [
+  /Extensions are not allowed/, // browser-specific noise
+  /Download the React DevTools/, // React devtools suggestion
+  /was preloaded using link preload but not used within a few seconds/,
+  /chrome-error\:\/\//,
+];
+
+function isBenign(message: ConsoleMessage): boolean {
+  const text = message.text();
+  return benignConsolePatterns.some((pattern) => pattern.test(text));
+}
+
+export function attachConsoleGuard(page: Page): void {
+  page.on('console', (message) => {
+    if (message.type() !== 'error') {
+      return;
+    }
+
+    if (isBenign(message)) {
+      return;
+    }
+
+    throw new Error(`Console error detected: ${message.text()}`);
+  });
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test:rules": "npm run test --prefix tests/rules",
     "emulators": "firebase emulators:start --only firestore,auth,storage,functions --import ./emulator-data --export-on-exit",
     "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "e2e:report": "playwright show-report",
     "pretest:e2e": "playwright install --with-deps",
     "lighthouse": "lhci autorun",
     "check:headers": "bash scripts/check-headers.sh $PREVIEW_URL",


### PR DESCRIPTION
## Summary
- add Playwright configuration and helper utilities for console guarding and optional storage state reuse
- add lightweight E2E coverage for home, auth, demo, scan, nutrition, coach, settings, and system check routes
- wire a GitHub Actions workflow to run the Playwright suite in CI and upload reports, traces, and screenshots

## Testing
- not run (requires authenticated BASE_URL)

- [ ] All specs pass against BASE_URL
- [ ] No console errors on navigation
- [ ] Reports uploaded in CI artifacts

------
https://chatgpt.com/codex/tasks/task_e_68e5b818b7e48325a576053c837336ca