### PR TITLE
chore(docs): go-live runbook + secrets quick reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,16 @@ Stripe webhook requests now require a valid signature. Invalid signatures return
    - your Lovable preview domain
 4) Rebuild locally: `npm ci && npm run build && npm run preview`
 5) Deploy: `npx firebase-tools deploy --only hosting --project mybodyscan-f3daf --force`
+
+## Secrets & Deploy Quick Reference
+
+- List secrets: `firebase functions:secrets:list --project <projectId>`
+- Set secrets (one at a time):
+  - `firebase functions:secrets:set HOST_BASE_URL --project <projectId>`
+  - `firebase functions:secrets:set APP_CHECK_ALLOWED_ORIGINS --project <projectId>`
+  - `firebase functions:secrets:set APP_CHECK_ENFORCE_SOFT --project <projectId>`
+  - `firebase functions:secrets:set OPENAI_API_KEY --project <projectId>`
+  - Optional: `firebase functions:secrets:set STRIPE_SECRET --project <projectId>`
+  - Optional: `firebase functions:secrets:set STRIPE_SECRET_KEY --project <projectId>`
+- Run Playwright end-to-end tests locally: `BASE_URL=https://mybodyscanapp.com npm run test:e2e`
+- Full go-live runbook: see [`docs/GO-LIVE.md`](docs/GO-LIVE.md)

--- a/docs/GO-LIVE.md
+++ b/docs/GO-LIVE.md
@@ -1,0 +1,41 @@
+# Go-Live Runbook
+
+This guide lets an operator ship production updates without touching a local terminal.
+
+## 1. Configure secrets
+Create or verify the following secrets in GitHub Actions or Firebase Functions. Keep only the names—never paste real values in documentation.
+
+```
+HOST_BASE_URL=https://mybodyscanapp.com
+APP_CHECK_ALLOWED_ORIGINS=https://mybodyscanapp.com,https://www.mybodyscanapp.com,https://mybodyscan-f3daf.web.app,https://mybodyscan-f3daf.firebaseapp.com
+APP_CHECK_ENFORCE_SOFT=true
+OPENAI_API_KEY=*****
+# Optional
+STRIPE_SECRET=*****
+STRIPE_SECRET_KEY=*****
+```
+
+## 2. Deploy
+Preferred: trigger **Firebase Deploy** workflow in GitHub Actions (`.github/workflows/firebase-deploy.yml`).
+
+1. Navigate to **Actions → Firebase Deploy → Run workflow**.
+2. Ensure the desired branch is selected (default: `work`).
+3. Press **Run workflow** for a one-click deploy.
+
+Fallback: run `firebase deploy --only functions,hosting` via the Firebase CLI with the same secrets configured locally.
+
+## 3. Post-deploy checks
+Perform these immediately after the deployment finishes:
+
+- Load `https://mybodyscanapp.com/` — login or home screen should render.
+- Confirm Google and Apple authentication buttons are visible.
+- Navigate to **Scan**, **Nutrition**, **Coach**, and **Settings** pages and watch the console for errors (should be clean).
+- Trigger a scan; without an `OPENAI_API_KEY` the app should return the mock response rather than failing.
+- Call payments endpoints; when Stripe secrets are absent the API should respond with HTTP `501 Not Implemented`.
+
+## 4. Smoke tests
+For automated coverage, run the Playwright E2E suite locally when needed:
+
+```bash
+BASE_URL=https://mybodyscanapp.com npm run test:e2e
+```


### PR DESCRIPTION
## Summary
- add production go-live runbook with deploy flow and verification steps
- document secrets management commands and e2e smoke tests in README

## Testing
- not run (docs only)

## Checklist
- [ ] Operators can deploy from Actions or CLI without guesswork
- [ ] Post-deploy checks documented and simple

------
https://chatgpt.com/codex/tasks/task_e_68e5b8234ebc832582a2b9df6ec4a676