### PR TITLE
Fix native function routing, add coach fallback, and native API retry

### DIFF
--- a/functions/test/apiRoutes.test.js
+++ b/functions/test/apiRoutes.test.js
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+const { apiAppForTest } = await import('../lib/index.js');
+
+function postJson(base, path) {
+  return fetch(`${base}${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({})
+  });
+}
+
+test('api router supports /getPlan and /api/getPlan', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async (url, init) => {
+    const u = String(url);
+    if (u.startsWith("http://127.0.0.1:")) {
+      return originalFetch(url, init);
+    }
+    const fnName = u.split('/').pop();
+    return new Response(JSON.stringify({ fnName }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  const server = http.createServer(apiAppForTest);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const address = server.address();
+  const base = `http://127.0.0.1:${address.port}`;
+
+  try {
+    for (const path of ['/getPlan', '/api/getPlan', '/applyCatalogPlan', '/api/applyCatalogPlan']) {
+      const res = await postJson(base, path);
+      assert.equal(res.status, 200);
+      assert.match(res.headers.get('content-type') || '', /application\/json/);
+      const payload = await res.json();
+      assert.equal(payload.ok, true);
+      assert.ok(payload.data);
+    }
+  } finally {
+    global.fetch = originalFetch;
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/src/lib/backend/callBackend.ts
+++ b/src/lib/backend/callBackend.ts
@@ -23,7 +23,7 @@ export async function callRequestFunction<TRes = unknown>(
   await ensureAppCheck();
   const token = await requireIdToken();
   const appCheck = await getAppCheckTokenHeader();
-  return fetchJson<TRes>(`/${name}`, {
+  return fetchJson<TRes>(`/api/${name}`, {
     method,
     headers: {
       Authorization: `Bearer ${token}`,
@@ -35,6 +35,6 @@ export async function callRequestFunction<TRes = unknown>(
 }
 
 export async function backendHealthCheck(timeoutMs = 2500): Promise<{ ok: boolean }> {
-  return fetchJson<{ ok: boolean }>("/health", { method: "GET" }, timeoutMs);
+  return fetchJson<{ ok: boolean }>("/api/health", { method: "GET" }, timeoutMs);
 }
 

--- a/src/lib/backend/functionsOrigin.ts
+++ b/src/lib/backend/functionsOrigin.ts
@@ -1,4 +1,5 @@
 import { APP_CONFIG } from "@/generated/appConfig";
+import { isCapacitorNative } from "@/lib/platform/isNative";
 
 const envSource: Record<string, string | number | boolean | undefined> =
   ((import.meta as any)?.env ?? {}) as Record<string, string | number | boolean | undefined>;
@@ -29,11 +30,17 @@ function normalizeUrlBase(raw: string): string {
 }
 
 export function getFunctionsOrigin(): string {
+  const native = isCapacitorNative();
+  if (!native) {
+    return "";
+  }
+
   const configuredOrigin = readEnv("VITE_FUNCTIONS_ORIGIN");
   if (configuredOrigin) {
     const parsed = normalizeUrlBase(configuredOrigin);
     try {
-      return new URL(parsed).origin;
+      const url = new URL(parsed);
+      return url.origin;
     } catch {
       return parsed;
     }
@@ -43,7 +50,8 @@ export function getFunctionsOrigin(): string {
   if (configuredUrl) {
     const parsed = normalizeUrlBase(configuredUrl);
     try {
-      return new URL(parsed).origin;
+      const url = new URL(parsed);
+      return url.origin;
     } catch {
       return parsed;
     }
@@ -60,6 +68,7 @@ export function getFunctionsOrigin(): string {
 }
 
 export function getFunctionsBaseUrl(): string {
+  if (!isCapacitorNative()) return "/api";
   const functionsUrl = readEnv("VITE_FUNCTIONS_URL");
   if (functionsUrl) {
     return normalizeUrlBase(functionsUrl);


### PR DESCRIPTION
### Motivation
- Native iOS was calling cloud function URLs without the hosting `/api` prefix and receiving “Cannot POST” because the Express gateway only handled `/api/*` routes.  The coach chat and nutrition flows also needed resilient behavior when upstream AI or food APIs are unavailable. 

### Description
- Reworked Functions gateway to mount a single router at both `/` and `/api`, add explicit gateway CORS/preflight handling, and standardize responses to JSON envelopes `{ ok: true, data }` / `{ ok: false, error: { code, message, ref } }` for easier native consumption (`functions/src/index.ts`).
- Added a deterministic fallback coach response (with debug id) when OpenAI/upstream is missing or unavailable so the Coach UI receives a useful reply instead of a generic internal error (`functions/src/coachChat.ts`).
- Frontend API layer now uses web-relative `/api/<name>` paths and a native-aware origin resolver; added a defensive native retry: if native fetch to a direct function URL returns 404, retry once using the `/api/*` prefix (`src/lib/backend/callBackend.ts`, `src/lib/backend/fetchJson.ts`, `src/lib/backend/functionsOrigin.ts`).
- Added a small test that starts the Express app and verifies both `/getPlan` and `/api/getPlan` (and `applyCatalogPlan` variants) return 200 JSON envelopes; added `apiAppForTest` export to the gateway to enable this (`functions/test/apiRoutes.test.js`, `functions/src/index.ts`).

Files changed (key):
- functions/src/index.ts — dual-mounted router, CORS, JSON error envelopes, `apiAppForTest` export
- functions/src/coachChat.ts — deterministic fallback for AI unavailability
- src/lib/backend/callBackend.ts — call functions via `/api/<name>` (web-relative)
- src/lib/backend/fetchJson.ts — native 404->`/api/*` retry and dev logging
- src/lib/backend/functionsOrigin.ts — native-aware origin/base resolution
- functions/test/apiRoutes.test.js — regression test for both route forms

### Testing
- Ran functions TypeScript build: `npm --prefix functions run build` — succeeded.
- Ran functions unit tests: `npm --prefix functions test` and `node --test functions/test/apiRoutes.test.js` — all function tests including the new route test passed.
- Ran repo typecheck: `npm run typecheck` — succeeded.
- Attempted web build: `npm run build` — failed in this environment with `sh: 1: vite: not found` / npm registry `403 Forbidden` when trying to restore dev dependency, so a full web bundle could not be generated here; the changes made avoid requiring secrets at web build time.

All changes were implemented to support both hosting-rewrite `/api/*` and direct Cloud Functions invocation paths and to keep UI behavior graceful when upstream services are misconfigured or unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fe3c9e2b0832584a8e179d5165b2a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful fallback responses when service is temporarily unavailable.
  * Improved native platform compatibility and routing.

* **Bug Fixes**
  * Enhanced error handling with consistent error reporting and unique identifiers.
  * Added automatic retry logic for improved resilience.

* **Chores**
  * Added API routing tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->