### PR TITLE
Upgrade premium scan results and add Transformation Preview foundation

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -334,6 +334,14 @@ service cloud.firestore {
         allow write: if !isDemoUser() && isOwner(uid);
       }
 
+      // Client-created request + server-updated preview output.
+      match /transformationPreviews/{scanId} {
+        allow read: if isOwner(uid);
+        allow create: if !isDemoUser() && isOwner(uid);
+        allow update: if !isDemoUser() && isOwner(uid);
+        allow delete: if false;
+      }
+
       match /meta/onboarding {
         allow read: if isOwner(uid);
         allow write: if isOwner(uid) && isValidOnboardingMetaWrite();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import CapturePicker from "./pages/CapturePicker";
 import PhotoCapture from "./pages/PhotoCapture";
 import Processing from "./pages/Processing";
 import Results from "./pages/Results";
+import TransformationPreviewPage from "./pages/TransformationPreview";
 import HistoryPage from "./pages/History";
 import Settings from "./pages/Settings";
 import SettingsAccountPrivacyPage from "@/pages/SettingsAccountPrivacy";
@@ -800,6 +801,20 @@ const App = () => (
                 <AuthedLayout>
                   <Suspense fallback={<PageSkeleton />}>
                     <Results />
+                  </Suspense>
+                </AuthedLayout>
+              </PersonalizationGate>
+            </ProtectedRoute>
+          }
+        />
+        <Route
+          path="/results/:scanId/transformation-preview"
+          element={
+            <ProtectedRoute>
+              <PersonalizationGate>
+                <AuthedLayout>
+                  <Suspense fallback={<PageSkeleton />}>
+                    <TransformationPreviewPage />
                   </Suspense>
                 </AuthedLayout>
               </PersonalizationGate>

--- a/src/hooks/useLatestScanForUser.ts
+++ b/src/hooks/useLatestScanForUser.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import {
+  doc,
   onSnapshot,
   query,
   orderBy,
@@ -27,7 +28,7 @@ type ScanData = {
   [key: string]: any;
 };
 
-export function useLatestScanForUser() {
+export function useLatestScanForUser(scanId?: string) {
   const [scan, setScan] = useState<ScanData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -61,6 +62,27 @@ export function useLatestScanForUser() {
       return;
     }
 
+    if (scanId) {
+      const scanRef = doc(db, "users", user.uid, "scans", scanId);
+      const unsubscribe = onSnapshot(
+        scanRef,
+        (snapshot) => {
+          if (!snapshot.exists()) {
+            setScan(null);
+          } else {
+            setScan({ id: snapshot.id, ...snapshot.data() } as ScanData);
+          }
+          setLoading(false);
+        },
+        (err) => {
+          console.error("Error fetching scan:", err);
+          setError(err.message);
+          setLoading(false);
+        }
+      );
+      return () => unsubscribe();
+    }
+
     const scansQuery = query(
       collection(db, "users", user.uid, "scans"),
       orderBy("createdAt", "desc"),
@@ -73,8 +95,8 @@ export function useLatestScanForUser() {
         if (snapshot.empty) {
           setScan(null);
         } else {
-          const doc = snapshot.docs[0];
-          setScan({ id: doc.id, ...doc.data() } as ScanData);
+          const row = snapshot.docs[0];
+          setScan({ id: row.id, ...row.data() } as ScanData);
         }
         setLoading(false);
       },
@@ -86,7 +108,7 @@ export function useLatestScanForUser() {
     );
 
     return () => unsubscribe();
-  }, [user]);
+  }, [user, scanId]);
 
   return { scan, loading, error, user };
 }

--- a/src/lib/nutritionBackend.ts
+++ b/src/lib/nutritionBackend.ts
@@ -61,6 +61,17 @@ export interface NutritionHistoryDay {
   };
 }
 
+export function normalizeDailyTotals(raw: any): NutritionHistoryDay["totals"] {
+  const source = raw && typeof raw === "object" ? raw : {};
+  return {
+    calories: Number(source.calories ?? source.totalCalories ?? source.kcal) || 0,
+    protein: Number(source.protein ?? source.totalProtein ?? source.protein_g) || 0,
+    carbs: Number(source.carbs ?? source.totalCarbs ?? source.carbs_g) || 0,
+    fat: Number(source.fat ?? source.totalFat ?? source.fat_g) || 0,
+    alcohol: Number(source.alcohol ?? source.alcohol_g) || 0,
+  };
+}
+
 function round(value: number, decimals = 0) {
   const factor = 10 ** decimals;
   return Math.round(value * factor) / factor;
@@ -164,12 +175,6 @@ export async function getNutritionHistory(
   const list = Array.isArray(response?.days) ? response.days : [];
   return list.map((day: any) => ({
     date: day.date,
-    totals: {
-      calories: Number(day?.totals?.calories) || 0,
-      protein: Number(day?.totals?.protein) || 0,
-      carbs: Number(day?.totals?.carbs) || 0,
-      fat: Number(day?.totals?.fat) || 0,
-      alcohol: Number(day?.totals?.alcohol) || 0,
-    },
+    totals: normalizeDailyTotals(day?.totals),
   }));
 }

--- a/src/lib/transformationPreview.ts
+++ b/src/lib/transformationPreview.ts
@@ -1,0 +1,152 @@
+import {
+  doc,
+  onSnapshot,
+  serverTimestamp,
+  setDoc,
+  type Unsubscribe,
+} from "firebase/firestore";
+import { db } from "@/lib/firebase";
+
+export type TransformationPreviewStatus =
+  | "not_started"
+  | "queued"
+  | "processing"
+  | "ready"
+  | "failed";
+
+export type TransformationPreviewGoal =
+  | "lose_fat"
+  | "gain_muscle"
+  | "recomp"
+  | "maintain"
+  | "performance";
+
+export type TransformationPreviewDocument = {
+  scanId: string;
+  status: TransformationPreviewStatus;
+  goal: TransformationPreviewGoal;
+  timelineWeeks: number;
+  disclaimer: string;
+  requestedAt?: Date | null;
+  updatedAt?: Date | null;
+  readyAt?: Date | null;
+  imageUrl?: string | null;
+  compareImageUrl?: string | null;
+  promptSummary?: string | null;
+  failureReason?: string | null;
+};
+
+function toDateOrNull(value: unknown): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  if (typeof (value as any)?.toDate === "function") {
+    try {
+      return (value as any).toDate();
+    } catch {
+      return null;
+    }
+  }
+  if (typeof value === "string" || typeof value === "number") {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  return null;
+}
+
+function normalize(raw: any, scanId: string): TransformationPreviewDocument {
+  const statusRaw = String(raw?.status || "not_started").toLowerCase();
+  const status: TransformationPreviewStatus =
+    statusRaw === "queued" ||
+    statusRaw === "processing" ||
+    statusRaw === "ready" ||
+    statusRaw === "failed"
+      ? (statusRaw as TransformationPreviewStatus)
+      : "not_started";
+
+  const goalRaw = String(raw?.goal || "recomp").toLowerCase();
+  const goal: TransformationPreviewGoal =
+    goalRaw === "lose_fat" ||
+    goalRaw === "gain_muscle" ||
+    goalRaw === "maintain" ||
+    goalRaw === "performance" ||
+    goalRaw === "recomp"
+      ? (goalRaw as TransformationPreviewGoal)
+      : "recomp";
+
+  return {
+    scanId,
+    status,
+    goal,
+    timelineWeeks:
+      typeof raw?.timelineWeeks === "number" && Number.isFinite(raw.timelineWeeks)
+        ? Math.min(52, Math.max(2, Math.round(raw.timelineWeeks)))
+        : 12,
+    disclaimer:
+      typeof raw?.disclaimer === "string" && raw.disclaimer.trim().length
+        ? raw.disclaimer.trim()
+        : "Transformation Preview is a motivational projection based on your scan and plan. Results vary by adherence, recovery, and consistency.",
+    requestedAt: toDateOrNull(raw?.requestedAt),
+    updatedAt: toDateOrNull(raw?.updatedAt),
+    readyAt: toDateOrNull(raw?.readyAt),
+    imageUrl: typeof raw?.imageUrl === "string" ? raw.imageUrl : null,
+    compareImageUrl:
+      typeof raw?.compareImageUrl === "string" ? raw.compareImageUrl : null,
+    promptSummary: typeof raw?.promptSummary === "string" ? raw.promptSummary : null,
+    failureReason: typeof raw?.failureReason === "string" ? raw.failureReason : null,
+  };
+}
+
+export function transformationPreviewDoc(uid: string, scanId: string) {
+  return doc(db, "users", uid, "transformationPreviews", scanId);
+}
+
+export function subscribeTransformationPreview(
+  uid: string,
+  scanId: string,
+  onValue: (value: TransformationPreviewDocument | null) => void,
+  onError?: (error: Error) => void
+): Unsubscribe {
+  const ref = transformationPreviewDoc(uid, scanId);
+  return onSnapshot(
+    ref,
+    (snap) => {
+      if (!snap.exists()) {
+        onValue(null);
+        return;
+      }
+      onValue(normalize(snap.data(), scanId));
+    },
+    (error) => {
+      onError?.(error as Error);
+    }
+  );
+}
+
+export async function requestTransformationPreview(params: {
+  uid: string;
+  scanId: string;
+  goal: TransformationPreviewGoal;
+  timelineWeeks: number;
+  planSummary?: string | null;
+}) {
+  const ref = transformationPreviewDoc(params.uid, params.scanId);
+  const timelineWeeks = Math.min(52, Math.max(2, Math.round(params.timelineWeeks || 12)));
+  await setDoc(
+    ref,
+    {
+      scanId: params.scanId,
+      status: "queued",
+      goal: params.goal,
+      timelineWeeks,
+      promptSummary:
+        typeof params.planSummary === "string" && params.planSummary.trim().length
+          ? params.planSummary.trim().slice(0, 240)
+          : null,
+      disclaimer:
+        "Transformation Preview is a motivational projection based on your scan and plan. Results vary by adherence, recovery, and consistency.",
+      requestedAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true }
+  );
+}

--- a/src/pages/Meals.tsx
+++ b/src/pages/Meals.tsx
@@ -29,6 +29,7 @@ import {
   deleteMeal,
   getDailyLog,
   getNutritionHistory,
+  normalizeDailyTotals,
   type MealEntry,
   type NutritionHistoryDay,
 } from "@/lib/nutritionBackend";
@@ -201,16 +202,13 @@ export default function Meals() {
           setLog({ totals: { calories: 0 }, meals: [] });
           return;
         }
-        const totals =
-          typeof data.totals === "object" && data.totals !== null
-            ? data.totals
-            : { calories: 0 };
+        const totals = normalizeDailyTotals(data.totals);
         const meals = Array.isArray(data.meals) ? data.meals : [];
         setLog({ totals, meals });
       })
       .catch((error) => {
         console.warn("meals.refreshLog", error);
-        setLog({ totals: { calories: 0 }, meals: [] });
+        setLog({ totals: normalizeDailyTotals(null), meals: [] });
       })
       .finally(() => setLoading(false));
   }, [demo, dateISO]);
@@ -633,10 +631,11 @@ export default function Meals() {
   const targetCarbs = computedGoals.carbsGrams || 0;
   const targetFat = computedGoals.fatGrams || 0;
 
-  const consumedCalories = safeNumber(log.totals?.calories);
-  const consumedProtein = safeNumber(log.totals?.protein);
-  const consumedCarbs = safeNumber(log.totals?.carbs);
-  const consumedFat = safeNumber(log.totals?.fat);
+  const normalizedTotals = normalizeDailyTotals(log.totals);
+  const consumedCalories = safeNumber(normalizedTotals.calories);
+  const consumedProtein = safeNumber(normalizedTotals.protein);
+  const consumedCarbs = safeNumber(normalizedTotals.carbs);
+  const consumedFat = safeNumber(normalizedTotals.fat);
   const exerciseCalories = 0;
   const remainingCalories = Math.round(
     Math.max(0, targetCalories - consumedCalories + exerciseCalories)
@@ -675,10 +674,10 @@ export default function Meals() {
       month: "short",
       day: "numeric",
     }),
-    calories: day.totals.calories || 0,
-    protein: day.totals.protein || 0,
-    carbs: day.totals.carbs || 0,
-    fat: day.totals.fat || 0,
+    calories: normalizeDailyTotals(day.totals).calories || 0,
+    protein: normalizeDailyTotals(day.totals).protein || 0,
+    carbs: normalizeDailyTotals(day.totals).carbs || 0,
+    fat: normalizeDailyTotals(day.totals).fat || 0,
   }));
 
   return (

--- a/src/pages/Results.demo-timestamps.test.tsx
+++ b/src/pages/Results.demo-timestamps.test.tsx
@@ -27,6 +27,10 @@ vi.mock("@/hooks/useLatestScanForUser", () => ({
 vi.mock("@/lib/demoFlag", () => ({ isDemo: () => true }));
 
 vi.mock("@/lib/demoDataset", () => ({
+  demoMeals: {
+    totals: { calories: 0, protein: 0, carbs: 0, fat: 0 },
+    meals: [],
+  },
   demoLatestScan: {
     id: "demo-scan-missing-ts",
     status: "complete",
@@ -59,4 +63,3 @@ describe("Results (demo timestamps)", () => {
     expect(screen.getByText(/Results/i)).toBeTruthy();
   });
 });
-

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,10 +1,12 @@
-import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useState, useEffect, useMemo } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Sparkles, ArrowRight, Lock, Dumbbell, Apple, Flame } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { Separator } from "@/components/ui/separator";
 import { Seo } from "@/components/Seo";
 import { toast } from "@/hooks/use-toast";
 import { useLatestScanForUser } from "@/hooks/useLatestScanForUser";
@@ -21,477 +23,201 @@ import { scanStatusLabel } from "@/lib/scanStatus";
 import { useUnits } from "@/hooks/useUnits";
 import { kgToLb } from "@/lib/units";
 import { demoToast } from "@/lib/demoToast";
-// Helper function to format dates
+import { deriveNutritionGoals } from "@/lib/nutritionGoals";
+import { useUserProfile } from "@/hooks/useUserProfile";
+import { hasPro } from "@/lib/entitlements/pro";
+import { useEntitlements } from "@/lib/entitlements/store";
+
 const formatDate = (timestamp: any) => {
   if (!timestamp) return "—";
   if (timestamp.toDate) return timestamp.toDate().toLocaleString();
   if (timestamp instanceof Date) return timestamp.toLocaleString();
-  if (typeof timestamp === "number") {
-    const date = new Date(timestamp);
-    return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
-  }
-  if (typeof timestamp === "string") {
+  if (typeof timestamp === "number" || typeof timestamp === "string") {
     const date = new Date(timestamp);
     return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString();
   }
   return "—";
 };
 
-// Processing UI component
-const ProcessingUI = () => {
-  const [progress, setProgress] = useState(0);
-  const [messageIndex, setMessageIndex] = useState(0);
-
-  const messages = [
-    "Lining up your measurements…",
-    "Estimating body fat…",
-    "Checking symmetry and posture…",
-    "Crunching numbers…",
-    "Almost there!",
-  ];
-
-  useEffect(() => {
-    // Progress bar: 0→100% over 90s
-    const progressInterval = setInterval(() => {
-      setProgress((prev) => Math.min(prev + 100 / 90, 100));
-    }, 1000);
-
-    // Message rotation: every 8s
-    const messageInterval = setInterval(() => {
-      setMessageIndex((prev) => (prev + 1) % messages.length);
-    }, 8000);
-
-    return () => {
-      clearInterval(progressInterval);
-      clearInterval(messageInterval);
-    };
-  }, []);
-
-  return (
-    <div className="text-center py-8">
-      <div className="max-w-xs mx-auto mb-6">
-        <div className="w-full bg-muted rounded-full h-2 mb-3">
-          <div
-            className="bg-primary h-2 rounded-full transition-all duration-1000 ease-out"
-            style={{ width: `${progress}%` }}
-          />
-        </div>
-        <p className="text-sm font-medium mb-2">{Math.round(progress)}%</p>
-      </div>
-      <p className="text-muted-foreground animate-fade-in">
-        {messages[messageIndex]}
-      </p>
-      <p className="text-xs text-muted-foreground mt-2">
-        This usually takes ~1–2 minutes.
-      </p>
-    </div>
-  );
-};
-
 const Results = () => {
   const navigate = useNavigate();
-  const { scan, loading, error, user } = useLatestScanForUser();
+  const { scanId } = useParams();
+  const { scan, loading, error, user } = useLatestScanForUser(scanId);
   const [note, setNote] = useState("");
   const [saving, setSaving] = useState(false);
   const demo = isDemo();
   const readOnlyDemo = demo && !user;
   const activeScan = scan ?? (demo ? (demoLatestScan as any) : null);
   const { units } = useUnits();
+  const { profile, plan } = useUserProfile();
+  const { entitlements } = useEntitlements();
+  const pro = hasPro(entitlements);
 
-  // Initialize note from scan data
   useEffect(() => {
-    if (activeScan?.note) {
-      setNote(activeScan.note);
-    }
+    if (activeScan?.note) setNote(activeScan.note);
   }, [activeScan?.note]);
 
   const onSaveNote = async () => {
     if (!user || !scan || !note.trim()) return;
-
     setSaving(true);
     try {
       const scanRef = doc(db, "users", user.uid, "scans", scan.id);
-      await updateDoc(scanRef, {
-        note: note.trim(),
-        noteUpdatedAt: serverTimestamp(),
-      });
-      toast({ title: "Note saved successfully" });
-    } catch (err: any) {
-      console.error("Error saving note:", err);
+      await updateDoc(scanRef, { note: note.trim(), noteUpdatedAt: serverTimestamp() });
+      toast({ title: "Note saved" });
+    } catch {
       toast({ title: "Failed to save note", variant: "destructive" });
     } finally {
       setSaving(false);
     }
   };
 
-  // Redirect to auth if not signed in
+  const metrics = extractScanMetrics(activeScan || {});
+  const summary = summarizeScanMetrics(metrics, units);
+  const statusMeta = activeScan
+    ? scanStatusLabel(activeScan.status, activeScan.completedAt ?? activeScan.updatedAt ?? activeScan.createdAt)
+    : null;
+
+  const nutritionGoals = useMemo(
+    () =>
+      deriveNutritionGoals({
+        weightKg: profile?.weight_kg ?? null,
+        heightCm: profile?.height_cm ?? null,
+        age: profile?.age ?? null,
+        sex: profile?.sex ?? null,
+        goalWeightKg: profile?.goal_weight_kg ?? null,
+        goal:
+          profile?.goal === "lose_fat"
+            ? "lose_fat"
+            : profile?.goal === "gain_muscle"
+              ? "gain_muscle"
+              : null,
+        activityLevel: profile?.activity_level ?? null,
+        overrides: {
+          calories: plan?.calorieTarget,
+          proteinGrams: plan?.proteinFloor,
+        },
+      }),
+    [plan?.calorieTarget, plan?.proteinFloor, profile]
+  );
+
   if (!user && !demo && !loading) {
-    return (
-      <main className="min-h-screen p-6 max-w-md mx-auto">
-        <Seo
-          title="Results – MyBodyScan"
-          description="Review your body scan results and add notes."
-          canonical={window.location.href}
-        />
-        <DemoBanner />
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Results</h1>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-muted-foreground mb-4">
-                Sign in required to view your results.
-              </p>
-              <Button onClick={() => navigate("/auth")} className="w-full">
-                Sign In
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </main>
-    );
+    return <main className="min-h-screen p-6 max-w-md mx-auto"><Button onClick={() => navigate("/auth")}>Sign In</Button></main>;
   }
 
-  // Signed-in users can legitimately have zero scans; never crash on a missing scan doc.
-  if (!activeScan) {
-    return (
-      <main className="min-h-screen p-6 max-w-md mx-auto">
-        <Seo
-          title="Results – MyBodyScan"
-          description="Review your body scan results and add notes."
-          canonical={window.location.href}
-        />
-        <DemoBanner />
-        <h1 className="text-2xl font-semibold mb-6">Results</h1>
-        <Card>
-          <CardContent className="pt-6 space-y-3">
-            <p className="text-muted-foreground">
-              No scans yet — start your first scan to see results here.
-            </p>
-            <Button
-              onClick={() => navigate(readOnlyDemo ? "/auth" : "/scan/new")}
-              className="w-full"
-            >
-              {readOnlyDemo ? "Sign in to start" : "Start a Scan"}
-            </Button>
-          </CardContent>
-        </Card>
-      </main>
-    );
-  }
-
-  // Loading state
   if (loading && !demo) {
     return (
       <main className="min-h-screen p-6 max-w-md mx-auto">
-        <Seo
-          title="Results – MyBodyScan"
-          description="Review your body scan results and add notes."
-          canonical={window.location.href}
-        />
+        <Seo title="Results – MyBodyScan" description="Review scan results." canonical={window.location.href} />
+        <Skeleton className="h-40 w-full" />
+      </main>
+    );
+  }
+
+  if (error || !activeScan) {
+    return (
+      <main className="min-h-screen p-6 max-w-md mx-auto space-y-4">
+        <Seo title="Results – MyBodyScan" description="Review scan results." canonical={window.location.href} />
         <DemoBanner />
-        <h1 className="text-2xl font-semibold mb-6">Results</h1>
-
-        <Card className="mb-6">
-          <CardHeader>
-            <Skeleton className="h-6 w-32" />
-            <Skeleton className="h-4 w-24" />
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-3 gap-4">
-              <div className="text-center">
-                <Skeleton className="h-12 w-16 mx-auto mb-2" />
-                <Skeleton className="h-4 w-16 mx-auto" />
-              </div>
-              <div className="text-center">
-                <Skeleton className="h-12 w-16 mx-auto mb-2" />
-                <Skeleton className="h-4 w-16 mx-auto" />
-              </div>
-              <div className="text-center">
-                <Skeleton className="h-12 w-16 mx-auto mb-2" />
-                <Skeleton className="h-4 w-16 mx-auto" />
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+        <Card><CardContent className="pt-6">Unable to load results.</CardContent></Card>
+        <Button onClick={() => navigate(readOnlyDemo ? "/auth" : "/scan/new")} className="w-full">
+          {readOnlyDemo ? "Sign in to start" : "Start a Scan"}
+        </Button>
       </main>
     );
   }
 
-  // Error state
-  if (error) {
-    return (
-      <main className="min-h-screen p-6 max-w-md mx-auto">
-        <Seo
-          title="Results – MyBodyScan"
-          description="Review your body scan results and add notes."
-          canonical={window.location.href}
-        />
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Results</h1>
-          <Card>
-            <CardContent className="pt-6">
-              <p className="text-muted-foreground mb-4">
-                Unable to load your results. Please try again.
-              </p>
-              <Button
-                onClick={() => window.location.reload()}
-                variant="outline"
-                className="w-full"
-              >
-                Retry
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </main>
-    );
-  }
-
-  // No scans exist
-  if (!activeScan) {
-    return (
-      <main className="min-h-screen p-6 max-w-md mx-auto">
-        <Seo
-          title="Results – MyBodyScan"
-          description="Review your body scan results and add notes."
-          canonical={window.location.href}
-        />
-        <div className="space-y-4">
-          <h1 className="text-2xl font-semibold">Results</h1>
-          <Card>
-            <CardContent className="pt-6 text-center">
-              <p className="text-muted-foreground mb-4">
-                No scans yet. Start your first body scan to see results here.
-              </p>
-              <Button
-                onClick={() => {
-                  if (readOnlyDemo) {
-                    demoToast();
-                    return;
-                  }
-                  navigate("/scan/new");
-                }}
-                className="w-full"
-              >
-                Start Your First Scan
-              </Button>
-            </CardContent>
-          </Card>
-        </div>
-      </main>
-    );
-  }
-
-  const metrics = extractScanMetrics(activeScan);
-  const summary = summarizeScanMetrics(metrics, units);
-  const bodyFatText =
-    summary.bodyFatPercent != null
-      ? `${summary.bodyFatPercent.toFixed(1)}%`
-      : "—";
-  const weightDisplay = summary.weightText;
-  const bmiDisplay = summary.bmiText;
-  const leanMassKg =
-    typeof (activeScan as any)?.estimate?.leanMassKg === "number"
-      ? Number((activeScan as any).estimate.leanMassKg)
-      : typeof (activeScan as any)?.metrics?.leanMassKg === "number"
-        ? Number((activeScan as any).metrics.leanMassKg)
-        : null;
-  const fatMassKg =
-    typeof (activeScan as any)?.estimate?.fatMassKg === "number"
-      ? Number((activeScan as any).estimate.fatMassKg)
-      : typeof (activeScan as any)?.metrics?.fatMassKg === "number"
-        ? Number((activeScan as any).metrics.fatMassKg)
-        : null;
-  const leanMassDisplay =
-    leanMassKg != null
-      ? units === "us"
-        ? `${kgToLb(leanMassKg).toFixed(1)} lb`
-        : `${leanMassKg.toFixed(1)} kg`
-      : null;
-  const fatMassDisplay =
-    fatMassKg != null
-      ? units === "us"
-        ? `${kgToLb(fatMassKg).toFixed(1)} lb`
-        : `${fatMassKg.toFixed(1)} kg`
-      : null;
-  const statusMeta = scanStatusLabel(
-    activeScan.status,
-    activeScan.completedAt ?? activeScan.updatedAt ?? activeScan.createdAt
-  );
+  const leanMassKg = Number((activeScan as any)?.estimate?.leanMassKg ?? (activeScan as any)?.metrics?.leanMassKg);
+  const fatMassKg = Number((activeScan as any)?.estimate?.fatMassKg ?? (activeScan as any)?.metrics?.fatMassKg);
 
   return (
-    <main className="min-h-screen p-6 max-w-md mx-auto">
-      <Seo
-        title="Results – MyBodyScan"
-        description="Review your body scan results and add notes."
-        canonical={window.location.href}
-      />
+    <main className="min-h-screen p-4 md:p-6 max-w-3xl mx-auto space-y-4">
+      <Seo title="Results – MyBodyScan" description="Premium body composition results." canonical={window.location.href} />
       <DemoBanner />
 
-      <h1 className="text-2xl font-semibold mb-6">Results</h1>
-
-      {/* Status Card */}
-      <Card className="mb-6">
+      <Card className="bg-gradient-to-b from-zinc-900 via-zinc-950 to-black border-zinc-800 text-zinc-100">
         <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg">
-              {formatDate(activeScan.completedAt || activeScan.createdAt)}
-            </CardTitle>
-            <Badge variant={statusMeta.badgeVariant}>{statusMeta.label}</Badge>
+          <div className="flex items-center justify-between gap-2">
+            <CardTitle className="text-xl">Scan Results</CardTitle>
+            <Badge variant={statusMeta?.badgeVariant}>{statusMeta?.label}</Badge>
           </div>
+          <p className="text-xs text-zinc-400">{formatDate(activeScan.completedAt || activeScan.createdAt)}</p>
         </CardHeader>
+        <CardContent className="space-y-4">
+          {statusMeta?.showMetrics ? (
+            <>
+              <div className="grid grid-cols-3 gap-2">
+                <Card className="bg-zinc-900/70 border-zinc-800"><CardContent className="py-4 text-center"><div className="text-2xl font-semibold">{summary.bodyFatPercent != null ? `${summary.bodyFatPercent.toFixed(1)}%` : "—"}</div><div className="text-xs text-zinc-400">Body Fat</div></CardContent></Card>
+                <Card className="bg-zinc-900/70 border-zinc-800"><CardContent className="py-4 text-center"><div className="text-2xl font-semibold">{summary.weightText}</div><div className="text-xs text-zinc-400">Weight</div></CardContent></Card>
+                <Card className="bg-zinc-900/70 border-zinc-800"><CardContent className="py-4 text-center"><div className="text-2xl font-semibold">{summary.bmiText}</div><div className="text-xs text-zinc-400">BMI</div></CardContent></Card>
+              </div>
 
-        <CardContent>
-          {!statusMeta.showMetrics ? (
-            statusMeta.canonical === "error" || statusMeta.recommendRescan ? (
-              <div className="text-center py-6 space-y-3">
-                <p className="text-destructive">{statusMeta.label}</p>
-                <p className="text-sm text-muted-foreground">
-                  {activeScan.error ||
-                    activeScan.errorMessage ||
-                    statusMeta.helperText ||
-                    "We couldn't process your scan. Please try again."}
-                </p>
-                <Button
-                  onClick={() => {
-                    if (readOnlyDemo) {
-                      demoToast();
-                      return;
-                    }
-                    navigate("/scan/new");
-                  }}
-                  variant="outline"
-                >
-                  Try Again
-                </Button>
+              <div className="grid sm:grid-cols-2 gap-2 text-sm">
+                <Card className="bg-zinc-900/60 border-zinc-800"><CardContent className="py-3">Lean mass: {Number.isFinite(leanMassKg) ? (units === "us" ? `${kgToLb(leanMassKg).toFixed(1)} lb` : `${leanMassKg.toFixed(1)} kg`) : "—"}</CardContent></Card>
+                <Card className="bg-zinc-900/60 border-zinc-800"><CardContent className="py-3">Fat mass: {Number.isFinite(fatMassKg) ? (units === "us" ? `${kgToLb(fatMassKg).toFixed(1)} lb` : `${fatMassKg.toFixed(1)} kg`) : "—"}</CardContent></Card>
               </div>
-            ) : (
-              <div className="space-y-4">
-                <ProcessingUI />
-                <p className="text-center text-xs text-muted-foreground">
-                  {statusMeta.helperText}
-                </p>
-              </div>
-            )
+            </>
           ) : (
-            <div className="space-y-2">
-              <div className="grid grid-cols-3 gap-4 text-center">
-                <Card>
-                  <CardContent className="pt-4 pb-4">
-                    <p className="text-3xl font-semibold text-primary">
-                      {bodyFatText}
-                    </p>
-                    <p className="text-sm text-muted-foreground mt-1">
-                      Body Fat %
-                    </p>
-                  </CardContent>
-                </Card>
-
-                <Card>
-                  <CardContent className="pt-4 pb-4">
-                    <p className="text-3xl font-semibold text-primary">
-                      {weightDisplay}
-                    </p>
-                    <p className="text-sm text-muted-foreground mt-1">Weight</p>
-                  </CardContent>
-                </Card>
-
-                <Card>
-                  <CardContent className="pt-4 pb-4">
-                    <p className="text-3xl font-semibold text-primary">
-                      {bmiDisplay}
-                    </p>
-                    <p className="text-sm text-muted-foreground mt-1">BMI</p>
-                  </CardContent>
-                </Card>
-              </div>
-              {(leanMassDisplay || fatMassDisplay) && (
-                <p className="text-xs text-muted-foreground text-center mt-2">
-                  {leanMassDisplay ? `Lean mass est: ${leanMassDisplay}` : ""}
-                  {leanMassDisplay && fatMassDisplay ? " · " : ""}
-                  {fatMassDisplay ? `Fat mass est: ${fatMassDisplay}` : ""}
-                </p>
-              )}
-            </div>
+            <p className="text-sm text-zinc-400">{statusMeta?.helperText || "Your scan is processing."}</p>
           )}
         </CardContent>
       </Card>
 
-      {statusMeta.showMetrics && activeScan.planMarkdown ? (
-        <Card className="mb-6">
+      {statusMeta?.showMetrics && (
+        <Card className="border-zinc-800 bg-zinc-950/70">
           <CardHeader>
-            <CardTitle className="text-lg">Program & macros</CardTitle>
+            <CardTitle className="text-base text-zinc-100">Transformation Preview</CardTitle>
           </CardHeader>
-          <CardContent>
-            <pre className="whitespace-pre-wrap text-sm text-left">
-              {activeScan.planMarkdown}
-            </pre>
-          </CardContent>
-        </Card>
-      ) : null}
-
-      {/* Notes section - only show for completed scans */}
-      {statusMeta.showMetrics && (
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="text-lg">Notes</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-3">
-              <Textarea
-                placeholder={
-                  readOnlyDemo
-                    ? "Demo preview — notes are read-only."
-                    : "Add a note about this scan..."
-                }
-                value={note}
-                onChange={(e) => setNote(e.target.value)}
-                className="min-h-[80px]"
-                readOnly={readOnlyDemo}
-                disabled={readOnlyDemo}
-              />
-              <DemoWriteButton
-                onClick={onSaveNote}
-                disabled={!note.trim() || saving || readOnlyDemo}
-                title={
-                  readOnlyDemo
-                    ? "Demo preview — sign up to save notes"
-                    : undefined
-                }
-                variant="secondary"
-                className="w-full"
-              >
-                {saving
-                  ? "Saving..."
-                  : readOnlyDemo
-                    ? "Sign up to save notes"
-                    : "Save Note"}
-              </DemoWriteButton>
+          <CardContent className="space-y-3 text-sm text-zinc-300">
+            <div className="flex items-start gap-3">
+              <Sparkles className="h-4 w-4 mt-0.5 text-primary" />
+              <p>
+                Realistic premium projection based on your scan metrics, goal timeline, and current program. Same person, same look, same context.
+              </p>
             </div>
+            <Button
+              className="w-full"
+              onClick={() => navigate(`/results/${activeScan.id}/transformation-preview`)}
+              variant={pro ? "default" : "secondary"}
+            >
+              {pro ? "Open Transformation Preview" : "Unlock Transformation Preview"}
+              {pro ? <ArrowRight className="ml-2 h-4 w-4" /> : <Lock className="ml-2 h-4 w-4" />}
+            </Button>
+            <p className="text-xs text-zinc-500">Motivational projection. Not a medical prediction.</p>
           </CardContent>
         </Card>
       )}
 
-      {/* Navigation buttons */}
-      <div className="grid gap-3 sm:grid-cols-3">
-        <Button variant="secondary" onClick={() => navigate("/")}>
-          Home
-        </Button>
-        <Button variant="secondary" onClick={() => navigate("/history")}>
-          History
-        </Button>
-        <Button
-          variant="outline"
-          onClick={() => {
-            if (readOnlyDemo) {
-              demoToast();
-              return;
-            }
-            navigate("/scan/new");
-          }}
-        >
-          New Scan
-        </Button>
+      {statusMeta?.showMetrics && (
+        <Card>
+          <CardHeader><CardTitle className="text-base">Plan summary</CardTitle></CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              <div className="rounded-md border p-3"><div className="flex items-center gap-2"><Flame className="h-4 w-4" />Calories</div><div className="text-lg font-semibold">{nutritionGoals.calories ?? "—"}</div></div>
+              <div className="rounded-md border p-3"><div className="flex items-center gap-2"><Dumbbell className="h-4 w-4" />Protein</div><div className="text-lg font-semibold">{nutritionGoals.proteinGrams ?? "—"}g</div></div>
+              <div className="rounded-md border p-3"><div className="flex items-center gap-2"><Apple className="h-4 w-4" />Carb/Fat</div><div className="text-lg font-semibold">{nutritionGoals.carbsGrams ?? 0}g / {nutritionGoals.fatGrams ?? 0}g</div></div>
+            </div>
+            {activeScan.planMarkdown ? <pre className="whitespace-pre-wrap text-xs text-muted-foreground">{activeScan.planMarkdown}</pre> : null}
+          </CardContent>
+        </Card>
+      )}
+
+      {statusMeta?.showMetrics && (
+        <Card>
+          <CardHeader><CardTitle className="text-base">Notes</CardTitle></CardHeader>
+          <CardContent className="space-y-2">
+            <Textarea value={note} onChange={(e) => setNote(e.target.value)} placeholder="Add context for your next check-in..." />
+            <DemoWriteButton onClick={onSaveNote} disabled={!note.trim() || saving || readOnlyDemo} className="w-full">
+              {saving ? "Saving..." : "Save Note"}
+            </DemoWriteButton>
+          </CardContent>
+        </Card>
+      )}
+
+      <Separator />
+      <div className="grid gap-2 sm:grid-cols-3">
+        <Button variant="secondary" onClick={() => navigate("/")}>Home</Button>
+        <Button variant="secondary" onClick={() => navigate("/history")}>History</Button>
+        <Button variant="outline" onClick={() => (readOnlyDemo ? demoToast() : navigate("/scan/new"))}>New Scan</Button>
       </div>
     </main>
   );

--- a/src/pages/TransformationPreview.tsx
+++ b/src/pages/TransformationPreview.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { Download, Lock, Share2, Sparkles } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Seo } from "@/components/Seo";
+import { useAuthUser } from "@/auth/mbs-auth";
+import { useEntitlements } from "@/lib/entitlements/store";
+import { hasPro } from "@/lib/entitlements/pro";
+import { useLatestScanForUser } from "@/hooks/useLatestScanForUser";
+import {
+  requestTransformationPreview,
+  subscribeTransformationPreview,
+  type TransformationPreviewGoal,
+} from "@/lib/transformationPreview";
+import { toast } from "@/hooks/use-toast";
+
+const GOAL_TO_COPY: Record<TransformationPreviewGoal, string> = {
+  lose_fat: "Reduce fat while preserving muscle.",
+  gain_muscle: "Build lean mass while keeping waist controlled.",
+  recomp: "Trade fat mass for lean tissue gradually.",
+  maintain: "Maintain composition and improve definition.",
+  performance: "Build a stronger athletic shape for performance.",
+};
+
+export default function TransformationPreviewPage() {
+  const { scanId = "" } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuthUser();
+  const { entitlements } = useEntitlements();
+  const { scan } = useLatestScanForUser(scanId);
+  const pro = hasPro(entitlements);
+  const [state, setState] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+  const [requesting, setRequesting] = useState(false);
+
+  useEffect(() => {
+    if (!user?.uid || !scanId) {
+      setLoading(false);
+      return;
+    }
+    const unsub = subscribeTransformationPreview(
+      user.uid,
+      scanId,
+      (next) => {
+        setState(next);
+        setLoading(false);
+      },
+      () => setLoading(false)
+    );
+    return () => unsub();
+  }, [user?.uid, scanId]);
+
+  const goal = useMemo<TransformationPreviewGoal>(() => {
+    const raw = String((scan as any)?.goalType || (scan as any)?.goal || "recomp").toLowerCase();
+    if (raw.includes("lose")) return "lose_fat";
+    if (raw.includes("gain")) return "gain_muscle";
+    if (raw.includes("maintain")) return "maintain";
+    if (raw.includes("perform")) return "performance";
+    return "recomp";
+  }, [scan]);
+
+  const onRequest = async () => {
+    if (!user?.uid || !scanId) return;
+    setRequesting(true);
+    try {
+      await requestTransformationPreview({
+        uid: user.uid,
+        scanId,
+        goal,
+        timelineWeeks: Number((scan as any)?.timelineWeeks) || 12,
+        planSummary: (scan as any)?.planMarkdown || null,
+      });
+      toast({ title: "Transformation Preview queued" });
+    } catch (error: any) {
+      toast({ title: "Unable to queue preview", description: error?.message, variant: "destructive" });
+    } finally {
+      setRequesting(false);
+    }
+  };
+
+  return (
+    <main className="min-h-screen p-4 md:p-6 max-w-3xl mx-auto space-y-4">
+      <Seo title="Transformation Preview – MyBodyScan" description="Premium transformation projection" canonical={window.location.href} />
+      <Card className="bg-gradient-to-b from-zinc-900 to-black border-zinc-800 text-zinc-100">
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-xl flex items-center gap-2"><Sparkles className="h-5 w-5 text-primary" /> Transformation Preview</CardTitle>
+            <Badge variant={pro ? "default" : "secondary"}>{pro ? "Premium" : "Locked"}</Badge>
+          </div>
+          <p className="text-xs text-zinc-400">Realistic visual projection tied to your current plan and timeline.</p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!pro ? (
+            <Card className="border-zinc-700 bg-zinc-900/60"><CardContent className="pt-6 space-y-3 text-sm text-zinc-300"><div className="flex gap-2 items-start"><Lock className="h-4 w-4 mt-0.5" />Premium members unlock Transformation Preview immediately after each scan.</div><Button className="w-full" onClick={() => navigate("/plans")}>Upgrade to Premium</Button></CardContent></Card>
+          ) : state?.status === "ready" && state?.imageUrl ? (
+            <div className="space-y-3">
+              <img src={state.imageUrl} alt="Transformation preview" className="w-full rounded-xl border border-zinc-700 object-cover" />
+              <div className="grid grid-cols-2 gap-2">
+                <Button variant="secondary"><Download className="h-4 w-4 mr-1" />Download</Button>
+                <Button variant="secondary"><Share2 className="h-4 w-4 mr-1" />Share</Button>
+              </div>
+            </div>
+          ) : (
+            <Card className="border-zinc-700 bg-zinc-900/40"><CardContent className="pt-6 space-y-3 text-sm text-zinc-300">
+              <p>{GOAL_TO_COPY[goal]}</p>
+              <p className="text-zinc-400">{loading ? "Loading preview status..." : state?.status === "queued" || state?.status === "processing" ? "Your preview is being generated. Keep this plan for the most realistic progression." : "No preview generated yet for this scan."}</p>
+              <Button onClick={onRequest} disabled={requesting || state?.status === "queued" || state?.status === "processing"} className="w-full">{requesting ? "Queuing..." : "Generate Transformation Preview"}</Button>
+            </CardContent></Card>
+          )}
+          <p className="text-xs text-zinc-500">Transformation Preview is a motivational projection based on your scan and plan. Results vary by adherence, recovery, and consistency.</p>
+        </CardContent>
+      </Card>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Make the scan-result moment feel premium, mobile-first and product-ready for a paid "Transformation Preview" hero feature while avoiding unstable API/client behavior.
- Reduce high-risk production failures in scan→results, meals totals, and route/data contract mismatches that cause crashes or confusing UX.
- Provide a safe, typed client-side scaffold for Transformation Preview that is gated for paid users and does not fake backend image generation.

### Description
- Redesigned the Results screen into a premium hierarchy: key metrics first, a Transformation Preview CTA, plan/macros summary, and notes, and added a new full-screen preview route at `/results/:scanId/transformation-preview` (files: `src/pages/Results.tsx`, `src/App.tsx`, `src/pages/TransformationPreview.tsx`).
- Added a typed Transformation Preview client model, Firestore doc helpers, subscription and request writer for `users/{uid}/transformationPreviews/{scanId}` to queue/observe preview work without producing images locally (`src/lib/transformationPreview.ts`).
- Fixed a route/data contract gap by updating `useLatestScanForUser` to optionally subscribe to an explicit `scanId` document (stabilizes `/results/:scanId` and downstream UX) (`src/hooks/useLatestScanForUser.ts`).
- Hardened meals/daily-totals handling by normalizing various backend key shapes (`calories`, `totalCalories`, legacy names) and using a single normalization helper in the diary and history chart (`src/lib/nutritionBackend.ts`, `src/pages/Meals.tsx`).
- Added Firestore rules to allow owners to create/read/update `transformationPreviews` docs (client-created request, server-updated output) and updated demo test fixtures to match the changed imports (`firestore.rules`, `src/pages/Results.demo-timestamps.test.tsx`).
- Kept existing callable/function names intact and avoided changing deployed function contract names to preserve production stability.

### Testing
- Ran static type checks with `npm run -s typecheck` and it succeeded.
- Ran unit tests: `npm run -s test -- src/lib/scans.test.ts` and `npm run -s test -- src/pages/Results.demo-timestamps.test.tsx`, both succeeded after updating fixtures.
- Performed local sanity verification of the changes (route wiring, gating states, and normalization paths); no automated UI screenshots produced in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d54e6049cc83259b5700664dc3617a)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Transformation Preview feature, allowing Pro users to visualize potential body transformation outcomes with customizable fitness goals and timelines.
  * Added new Transformation Preview page accessible from results with download and share capabilities.

* **Improvements**
  * Enhanced nutrition data normalization for more reliable calorie and macro tracking across the app.
  * Redesigned Results page with streamlined layout, improved metrics display, and integrated Transformation Preview section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->