### PR TITLE
Fix native Firebase guard to avoid false appId hard-fail on iOS boot

### DIFF
--- a/src/lib/firebase/config.ts
+++ b/src/lib/firebase/config.ts
@@ -88,7 +88,6 @@ const nativeRequiredKeys = [
   "apiKey",
   "authDomain",
   "projectId",
-  "appId",
 ] as const;
 const warningKeys = [
   "storageBucket",
@@ -177,10 +176,30 @@ function buildFirebaseConfigSummary(): Record<string, string> {
   return summary;
 }
 
+
+
+let loggedNativeOptionalWarning = false;
+function logNativeOptionalConfigWarning(): void {
+  if (!isCapacitorNative() || loggedNativeOptionalWarning) return;
+  const missingOptional = warningKeys.filter((key) => {
+    const value = (firebaseConfig as any)?.[key];
+    return isMissing(value);
+  });
+  if (!missingOptional.length) return;
+  if (typeof console !== "undefined") {
+    console.warn(
+      "[firebase] Optional native Firebase config keys missing; continuing with degraded capability",
+      missingOptional
+    );
+  }
+  loggedNativeOptionalWarning = true;
+}
+
 export function logFirebaseConfigSummary(): void {
   if (loggedConfigSummary) return;
   loggedConfigSummary = true;
   try {
+    logNativeOptionalConfigWarning();
     console.info("[firebase] config", buildFirebaseConfigSummary());
     if (firebaseConfigWarningKeys.length) {
       console.warn(


### PR DESCRIPTION
### Motivation
- The Capacitor/iOS build was showing a blocking configuration error for `appId` even though core Firebase initialization can proceed with the actual required keys, causing a false negative on startup.
- Make native boot robust: only hard-fail when truly required runtime keys are missing and surface missing optional keys as warnings.

### Description
- Removed `appId` from the native hard-required key list so native builds only require `apiKey`, `authDomain`, and `projectId` to block startup (`src/lib/firebase/config.ts`).
- Kept `appId`, `storageBucket`, `messagingSenderId`, and `measurementId` as optional warning-only keys and added a `logNativeOptionalConfigWarning()` routine to emit a single native-only warning when optional keys are missing (`src/lib/firebase/config.ts`).
- Wire the new native-optional warning into the existing `logFirebaseConfigSummary()` flow so Capacitor builds warn instead of hard-failing when optional metadata is absent (`src/lib/firebase/config.ts`).

### Testing
- Ran unit tests: `npm run test -- src/components/BootGate.test.tsx` and the suite passed (2 tests, 0 failures).
- Verified the modified code compiles in the test environment and logging for missing optional native keys appears instead of a blocking error in native-mode code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1ffccb7688325af3684ec0066f899)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Firebase configuration handling for native builds—`appId` is no longer required.
  * Added console warnings to alert when optional Firebase configuration keys are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->