### PR TITLE
PASS 1: Harden nutrition totals and enforce 4-photo scan messaging

### DIFF
--- a/src/content/howItWorks.ts
+++ b/src/content/howItWorks.ts
@@ -1,7 +1,7 @@
 export const HOW_IT_WORKS = [
   {
     step: "1) Capture",
-    text: "Choose a photo option: • 4 photos (front, left, right, back) for best accuracy • Quick 2-photo scan (front + side) for speed.",
+    text: "Complete your scan with 4 required photos: front, left, right, and back.",
   },
   {
     step: "2) Process",

--- a/src/lib/nutritionBackend.ts
+++ b/src/lib/nutritionBackend.ts
@@ -63,12 +63,16 @@ export interface NutritionHistoryDay {
 
 export function normalizeDailyTotals(raw: any): NutritionHistoryDay["totals"] {
   const source = raw && typeof raw === "object" ? raw : {};
+  const finite = (value: unknown): number => {
+    const n = Number(value);
+    return Number.isFinite(n) ? n : 0;
+  };
   return {
-    calories: Number(source.calories ?? source.totalCalories ?? source.kcal) || 0,
-    protein: Number(source.protein ?? source.totalProtein ?? source.protein_g) || 0,
-    carbs: Number(source.carbs ?? source.totalCarbs ?? source.carbs_g) || 0,
-    fat: Number(source.fat ?? source.totalFat ?? source.fat_g) || 0,
-    alcohol: Number(source.alcohol ?? source.alcohol_g) || 0,
+    calories: finite(source.calories ?? source.totalCalories ?? source.kcal),
+    protein: finite(source.protein ?? source.totalProtein ?? source.protein_g),
+    carbs: finite(source.carbs ?? source.totalCarbs ?? source.carbs_g),
+    fat: finite(source.fat ?? source.totalFat ?? source.fat_g),
+    alcohol: finite(source.alcohol ?? source.alcohol_g),
   };
 }
 

--- a/src/pages/Meals.tsx
+++ b/src/pages/Meals.tsx
@@ -380,7 +380,7 @@ export default function Meals() {
       setLog((prev) => ({
         ...prev,
         meals: (prev.meals ?? []).filter((m) => m.id !== mealId),
-        totals: (result as any)?.totals ?? prev.totals,
+        totals: normalizeDailyTotals((result as any)?.totals ?? prev.totals),
       }));
       refreshHistory();
     } catch (error: any) {

--- a/src/pages/PublicLanding.tsx
+++ b/src/pages/PublicLanding.tsx
@@ -19,7 +19,7 @@ const PublicLanding = () => {
     <>
       <Seo
         title="Body scans from your phone – MyBodyScan"
-        description="Estimate body fat %, weight, and BMI from either a 4-photo scan or quick 2-photo scan. Track progress over time."
+        description="Estimate body fat %, weight, and BMI from a required 4-photo scan (front, left, right, back). Track progress over time."
         canonical="https://mybodyscanapp.com/"
       />
       <section className="py-8">
@@ -29,9 +29,8 @@ const PublicLanding = () => {
               Body scans from your phone
             </h1>
             <p className="mt-3 text-muted-foreground">
-              Estimate body fat %, weight, and BMI from 4 photos (front, left,
-              right, back) or a quick 2-photo scan (front + side). Track
-              progress over time.
+              Estimate body fat %, weight, and BMI from a required 4-photo
+              scan (front, left, right, back). Track progress over time.
             </p>
             <div className="mt-6 flex flex-wrap items-center gap-3">
               <Button size="lg" onClick={handleLaunch}>


### PR DESCRIPTION
### Motivation
- Stabilize meal/nutrition UI and coach context by preventing non-finite totals (NaN/undefined) from being displayed or used in downstream logic.
- Align product copy and user expectations to the current product decision that scans require 4 photos (front, left, right, back) and remove misleading “quick 2-photo” messaging.

### Description
- Hardened daily totals normalization in `src/lib/nutritionBackend.ts` by introducing a finite-safe coercion helper so calories/protein/carbs/fat/alcohol always return numeric `0` when the backend provides non-finite values. (`normalizeDailyTotals`)
- Ensured meal deletion updates always pass returned totals through `normalizeDailyTotals` in `src/pages/Meals.tsx` so the local state remains stable after deletes. (`handleDelete`)
- Updated user-facing copy to require 4 photos by editing `src/content/howItWorks.ts` and `src/pages/PublicLanding.tsx` to remove references to a quick 2-photo flow and make messaging consistent with product policy. 
- No function exports, Firestore/storage rules, or env keys were added or changed in this PR.

### Testing
- Built the web app with `npm run -s build` and the production build completed successfully. 
- The build run includes TypeScript checks as part of the bundling step (no runtime test failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c762e141c83259886d9671ecdd8bb)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nutrition totals normalization when deleting meals.

* **Documentation**
  * Clarified that photo scans require 4 mandatory images (front, left, right, and back) in instructional content and landing page descriptions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Antisgoat/mybodyscan/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->