### PR TITLE
PASS 1B: Stabilize coach and workouts fallback + actionable coach errors

### DIFF
--- a/src/lib/workouts.ts
+++ b/src/lib/workouts.ts
@@ -17,6 +17,7 @@ import {
   buildCustomPlanTitleFromPrefs,
   generateCustomPlanDaysFromLibrary,
 } from "@/lib/workoutsCustomGenerator";
+import { CORE_WORKOUT_FALLBACK, toWorkoutSummaryFallback } from "@/lib/workoutsFallback";
 
 export interface WorkoutExercise {
   id: string;
@@ -166,7 +167,7 @@ async function fetchPlanFromFirestore() {
     return { id: planId, ...data };
   } catch (error) {
     console.warn("workouts.plan_fallback_failed", error);
-    return null;
+    return CORE_WORKOUT_FALLBACK;
   }
 }
 
@@ -226,7 +227,7 @@ export async function getPlan() {
       if (fallback) return fallback;
       throw new Error("workouts_disabled_missing_fn");
     }
-    return null;
+    return toWorkoutSummaryFallback();
   }
 }
 

--- a/src/lib/workoutsFallback.ts
+++ b/src/lib/workoutsFallback.ts
@@ -1,0 +1,41 @@
+type WorkoutExercise = { id: string; name: string; sets?: number; reps?: number | string };
+type WorkoutDay = { day: string; exercises: WorkoutExercise[] };
+type WorkoutSummary = { planId: string | null; days: WorkoutDay[]; progress: Record<string, string[]> };
+
+export const CORE_WORKOUT_FALLBACK: { id: string; title: string; days: WorkoutDay[] } = {
+  id: "fallback-evidence-plan-v1",
+  title: "Foundational Strength + Conditioning",
+  days: [
+    {
+      day: "Mon",
+      exercises: [
+        { id: "goblet-squat", name: "Squat pattern (goblet/back squat)", sets: 4, reps: "6-10" },
+        { id: "hinge-rdl", name: "Romanian deadlift or hip hinge", sets: 3, reps: "8-10" },
+        { id: "push-horizontal", name: "Push-up or bench press", sets: 4, reps: "6-12" },
+        { id: "row-horizontal", name: "Row variation", sets: 4, reps: "8-12" },
+      ],
+    },
+    {
+      day: "Wed",
+      exercises: [
+        { id: "lunge-split", name: "Split squat or reverse lunge", sets: 3, reps: "8-12/side" },
+        { id: "pull-vertical", name: "Lat pulldown or assisted pull-up", sets: 4, reps: "6-10" },
+        { id: "press-vertical", name: "Dumbbell overhead press", sets: 3, reps: "8-12" },
+        { id: "core-carry", name: "Plank + loaded carry", sets: 3, reps: "30-60s" },
+      ],
+    },
+    {
+      day: "Fri",
+      exercises: [
+        { id: "deadlift-variant", name: "Trap-bar deadlift or kettlebell deadlift", sets: 3, reps: "5-8" },
+        { id: "single-leg-hinge", name: "Single-leg RDL", sets: 3, reps: "8-10/side" },
+        { id: "incline-press", name: "Incline press or push-up progression", sets: 3, reps: "8-12" },
+        { id: "pulldown-row", name: "Chest-supported row or cable row", sets: 3, reps: "8-12" },
+      ],
+    },
+  ],
+};
+
+export function toWorkoutSummaryFallback(): WorkoutSummary {
+  return { planId: CORE_WORKOUT_FALLBACK.id, days: CORE_WORKOUT_FALLBACK.days, progress: {} };
+}

--- a/src/pages/Coach/Chat.tsx
+++ b/src/pages/Coach/Chat.tsx
@@ -846,7 +846,7 @@ export default function CoachChatPage() {
       const fallback =
         code === "invalid_message"
           ? "Please enter a question for the coach."
-          : "Coach is unavailable right now; please try again shortly.";
+          : "Coach is temporarily unavailable. Check your connection, then retry. If this persists, sign out/in and verify your plan is active in Billing.";
       const debugId = (error as any)?.debugId;
       const message = debugId
         ? `${errMessage || fallback} (ref ${debugId.slice(0, 8)})`


### PR DESCRIPTION
### Motivation
- Prevent core workout UI from breaking into a null/empty state when backend callables or network are transient by providing a deterministic, evidence-based fallback plan.
- Make coach chat failures actionable for end users by replacing vague "unavailable" copy with clear recovery steps (retry, sign out/in, verify billing/entitlements).
- Harden client-side plan fetch and Firestore fallback paths so authenticated users (including paid/unlimited) are not blocked by transient backend faults.

### Description
- Added a deterministic workout fallback in `src/lib/workoutsFallback.ts` that provides a 3-day foundational strength+conditioning plan with exercises, sets, and reps.
- Wired the fallback into the client workouts code by importing `CORE_WORKOUT_FALLBACK` / `toWorkoutSummaryFallback()` and returning a stable summary from `getPlan()` and from the Firestore plan fetch failure path in `src/lib/workouts.ts`.
- Improved coach send error UX in `src/pages/Coach/Chat.tsx` to show an actionable message: "Check your connection, retry, sign out/in, and verify plan in Billing" instead of a generic dead-end.
- No function exports or Firestore/Storage rules were changed in this pass; changes are frontend-only files: `src/lib/workouts.ts`, `src/lib/workoutsFallback.ts` (new), and `src/pages/Coach/Chat.tsx`.

### Testing
- Ran TypeScript typecheck with `npm run typecheck`, which completed successfully.
- Built the web app with `npm run build` (Vite production build), which completed successfully.
- Built Cloud Functions with `npm --prefix functions run build`, which completed successfully in this environment even though no function code was modified.
- No automated unit/e2e tests were added in this PR; the above compilation and build steps passed and verify the changed frontend code compiles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c7f4067b48325bfc3e8d444df2871)