### PR TITLE
Scan: enforce fail-on-timeout, refund charged credits, canonicalize result model, and scaffold premium UX

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -334,6 +334,14 @@ service cloud.firestore {
         allow write: if !isDemoUser() && isOwner(uid);
       }
 
+      // Transformation Preview is read-only for clients. Request, status, provider,
+      // output URLs, prompts, and generated content must be written only by
+      // trusted server code when generation is implemented.
+      match /transformationPreviews/{scanId} {
+        allow read: if isOwner(uid);
+        allow create, update, delete: if false;
+      }
+
       match /meta/onboarding {
         allow read: if isOwner(uid);
         allow write: if isOwner(uid) && isValidOnboardingMetaWrite();

--- a/firestore.rules
+++ b/firestore.rules
@@ -334,12 +334,12 @@ service cloud.firestore {
         allow write: if !isDemoUser() && isOwner(uid);
       }
 
-      // Client-created request + server-updated preview output.
+      // Transformation Preview is read-only for clients. Request, status, provider,
+      // output URLs, prompts, and generated content must be written only by
+      // trusted server code when generation is implemented.
       match /transformationPreviews/{scanId} {
         allow read: if isOwner(uid);
-        allow create: if !isDemoUser() && isOwner(uid);
-        allow update: if !isDemoUser() && isOwner(uid);
-        allow delete: if false;
+        allow create, update, delete: if false;
       }
 
       match /meta/onboarding {

--- a/functions/src/scan/analysis.ts
+++ b/functions/src/scan/analysis.ts
@@ -8,7 +8,11 @@ import {
   type ChatContentPart,
 } from "../openai/client.js";
 import type { EngineConfig } from "./engineConfig.js";
-import type { ScanEstimate, ScanNutritionPlan, ScanWorkoutPlan } from "../types.js";
+import type {
+  ScanEstimate,
+  ScanNutritionPlan,
+  ScanWorkoutPlan,
+} from "../types.js";
 import { scanPhotosPrefix } from "./paths.js";
 
 const storage = getStorage();
@@ -42,7 +46,9 @@ function clamp(value: number, min: number, max: number): number {
   return Math.min(Math.max(value, min), max);
 }
 
-function sanitizeEstimate(raw: Partial<ScanEstimate> | undefined): ScanEstimate {
+function sanitizeEstimate(
+  raw: Partial<ScanEstimate> | undefined
+): ScanEstimate {
   const source = raw as any;
   const bodyFatPercent = clamp(
     Number(raw?.bodyFatPercent ?? source?.body_fat ?? source?.bodyFat),
@@ -64,7 +70,9 @@ function sanitizeEstimate(raw: Partial<ScanEstimate> | undefined): ScanEstimate 
         : null;
   const keyObservationsRaw =
     (Array.isArray(source?.keyObservations) ? source.keyObservations : null) ??
-    (Array.isArray(source?.key_observations) ? source.key_observations : null) ??
+    (Array.isArray(source?.key_observations)
+      ? source.key_observations
+      : null) ??
     [];
   const keyObservations = (keyObservationsRaw as unknown[])
     .map((entry) => (typeof entry === "string" ? entry.trim() : ""))
@@ -73,7 +81,8 @@ function sanitizeEstimate(raw: Partial<ScanEstimate> | undefined): ScanEstimate 
     .filter((entry) => entry.length > 0)
     .slice(0, 5);
   const goalRecommendations = sanitizeRecommendations(
-    (source as any)?.goalRecommendations ?? (source as any)?.goal_recommendations
+    (source as any)?.goalRecommendations ??
+      (source as any)?.goal_recommendations
   );
   return {
     bodyFatPercent: Number(bodyFatPercent.toFixed(1)),
@@ -85,7 +94,9 @@ function sanitizeEstimate(raw: Partial<ScanEstimate> | undefined): ScanEstimate 
   };
 }
 
-function sanitizeWorkout(raw: Partial<ScanWorkoutPlan> | undefined): ScanWorkoutPlan {
+function sanitizeWorkout(
+  raw: Partial<ScanWorkoutPlan> | undefined
+): ScanWorkoutPlan {
   const weeks = Array.isArray(raw?.weeks) ? raw.weeks : [];
   const progressionRules = Array.isArray((raw as any)?.progressionRules)
     ? (raw as any).progressionRules
@@ -143,7 +154,10 @@ function sanitizeNutrition(
     0,
     Number(raw?.proteinGrams ?? source?.protein_grams ?? 0)
   );
-  const carbs = Math.max(0, Number(raw?.carbsGrams ?? source?.carbs_grams ?? 0));
+  const carbs = Math.max(
+    0,
+    Number(raw?.carbsGrams ?? source?.carbs_grams ?? 0)
+  );
   const fats = Math.max(0, Number(raw?.fatsGrams ?? source?.fats_grams ?? 0));
   const adjustmentRules = Array.isArray(source?.adjustmentRules)
     ? source.adjustmentRules
@@ -169,7 +183,12 @@ function sanitizeNutrition(
 
   const sanitizeDay = (
     dayRaw: any,
-    fallback: { calories: number; proteinGrams: number; carbsGrams: number; fatsGrams: number }
+    fallback: {
+      calories: number;
+      proteinGrams: number;
+      carbsGrams: number;
+      fatsGrams: number;
+    }
   ) => {
     const day = {
       calories: clamp(
@@ -177,14 +196,22 @@ function sanitizeNutrition(
         800,
         8000
       ),
-      proteinGrams: Number(dayRaw?.proteinGrams ?? dayRaw?.protein ?? fallback.proteinGrams),
-      carbsGrams: Number(dayRaw?.carbsGrams ?? dayRaw?.carbs ?? fallback.carbsGrams),
+      proteinGrams: Number(
+        dayRaw?.proteinGrams ?? dayRaw?.protein ?? fallback.proteinGrams
+      ),
+      carbsGrams: Number(
+        dayRaw?.carbsGrams ?? dayRaw?.carbs ?? fallback.carbsGrams
+      ),
       fatsGrams: Number(dayRaw?.fatsGrams ?? dayRaw?.fat ?? fallback.fatsGrams),
     };
     return {
-      calories: Math.round(Number.isFinite(day.calories) ? day.calories : fallback.calories),
+      calories: Math.round(
+        Number.isFinite(day.calories) ? day.calories : fallback.calories
+      ),
       proteinGrams: Math.round(
-        Number.isFinite(day.proteinGrams) ? day.proteinGrams : fallback.proteinGrams
+        Number.isFinite(day.proteinGrams)
+          ? day.proteinGrams
+          : fallback.proteinGrams
       ),
       carbsGrams: Math.round(
         Number.isFinite(day.carbsGrams) ? day.carbsGrams : fallback.carbsGrams
@@ -214,7 +241,10 @@ function sanitizeNutrition(
     proteinGrams: Math.round(protein),
     carbsGrams: Math.round(carbs),
     fatsGrams: Math.round(fats),
-    trainingDay: sanitizeDay(source?.trainingDay ?? source?.training_day, baseDay),
+    trainingDay: sanitizeDay(
+      source?.trainingDay ?? source?.training_day,
+      baseDay
+    ),
     restDay: sanitizeDay(source?.restDay ?? source?.rest_day, restFallback),
     adjustmentRules:
       cleanedAdjustments.length > 0
@@ -254,9 +284,13 @@ function validateVisionPayload(raw: unknown): OpenAIResult {
     workoutPlan: coerce(payload.workoutPlan),
     nutritionPlan: coerce(payload.nutritionPlan),
     recommendations: payload.recommendations,
-    goalRecommendations: (payload as any).goalRecommendations ?? (payload as any).goal_recommendations,
-    keyObservations: (payload as any).keyObservations ?? (payload as any).key_observations,
-    improvementAreas: (payload as any).improvementAreas ?? (payload as any).improvement_areas,
+    goalRecommendations:
+      (payload as any).goalRecommendations ??
+      (payload as any).goal_recommendations,
+    keyObservations:
+      (payload as any).keyObservations ?? (payload as any).key_observations,
+    improvementAreas:
+      (payload as any).improvementAreas ?? (payload as any).improvement_areas,
   };
 }
 
@@ -280,7 +314,8 @@ export async function buildImageInputs(
           file.download(),
         ]);
         const contentType =
-          typeof metadata?.contentType === "string" && metadata.contentType.startsWith("image/")
+          typeof metadata?.contentType === "string" &&
+          metadata.contentType.startsWith("image/")
             ? metadata.contentType
             : "image/jpeg";
         const base64 = buffer.toString("base64");
@@ -383,14 +418,29 @@ export function buildAnalysisFromResult(raw: OpenAIResult): ParsedAnalysis {
     const primaryRecommendations = sanitizeRecommendations(
       raw.goalRecommendations ?? raw.recommendations
     );
-    const fallbackRecommendations = sanitizeRecommendations(raw.recommendations);
-    const recommendations = primaryRecommendations.length ? primaryRecommendations : fallbackRecommendations;
-    const improvementAreas = sanitizeRecommendations(
-      (raw as any).improvementAreas ?? raw.keyObservations ?? raw.goalRecommendations ?? raw.recommendations
+    const fallbackRecommendations = sanitizeRecommendations(
+      raw.recommendations
     );
-    return { estimate, workoutPlan, nutritionPlan, recommendations, improvementAreas };
+    const recommendations = primaryRecommendations.length
+      ? primaryRecommendations
+      : fallbackRecommendations;
+    const improvementAreas = sanitizeRecommendations(
+      (raw as any).improvementAreas ??
+        raw.keyObservations ??
+        raw.goalRecommendations ??
+        raw.recommendations
+    );
+    return {
+      estimate,
+      workoutPlan,
+      nutritionPlan,
+      recommendations,
+      improvementAreas,
+    };
   } catch (error) {
-    throw new Error(`openai_parse_failed:${(error as Error)?.message ?? "unknown"}`);
+    throw new Error(
+      `openai_parse_failed:${(error as Error)?.message ?? "unknown"}`
+    );
   }
 }
 
@@ -420,7 +470,10 @@ export function buildPlanMarkdown(params: {
     fatsGrams: params.nutritionPlan.fatsGrams,
   };
   const restDay = params.nutritionPlan.restDay ?? {
-    calories: Math.max(1200, Math.round(params.nutritionPlan.caloriesPerDay - 150)),
+    calories: Math.max(
+      1200,
+      Math.round(params.nutritionPlan.caloriesPerDay - 150)
+    ),
     proteinGrams: params.nutritionPlan.proteinGrams,
     carbsGrams: Math.max(0, Math.round(params.nutritionPlan.carbsGrams * 0.85)),
     fatsGrams: Math.max(0, Math.round(params.nutritionPlan.fatsGrams + 8)),
@@ -448,21 +501,29 @@ export function buildPlanMarkdown(params: {
   lines.push(`- Notes: ${params.estimate.notes}`);
   if (params.estimate.keyObservations?.length) {
     lines.push("- Key observations:");
-    params.estimate.keyObservations.slice(0, 5).forEach((obs) => lines.push(`  - ${obs}`));
+    params.estimate.keyObservations
+      .slice(0, 5)
+      .forEach((obs) => lines.push(`  - ${obs}`));
   }
   if (params.improvementAreas?.length) {
     lines.push("- Improvement areas:");
-    params.improvementAreas.slice(0, 5).forEach((area) => lines.push(`  - ${area}`));
+    params.improvementAreas
+      .slice(0, 5)
+      .forEach((area) => lines.push(`  - ${area}`));
   }
 
   lines.push("");
-  lines.push("## 2) Training Plan (6-day PPL split)");
+  lines.push("## 2) Training Plan");
   lines.push(`- Summary: ${params.workoutPlan.summary}`);
   const weekCount = params.workoutPlan.weeks?.length ?? 0;
-  lines.push(`- Programming weeks available: ${weekCount || "coach generated as needed"}`);
+  lines.push(
+    `- Programming weeks available: ${weekCount || "coach generated as needed"}`
+  );
   const renderWeeks = params.workoutPlan.weeks?.slice(0, 8) ?? [];
   if (!renderWeeks.length) {
-    lines.push("- Weeks 1-8: Push/Pull/Legs rotation with 4-6 days per week. Progress load weekly.");
+    lines.push(
+      "- Detailed training days are only shown after a matched plan is available."
+    );
   } else {
     for (const week of renderWeeks) {
       lines.push(`- Week ${week.weekNumber}:`);

--- a/functions/src/scan/refundIfNoResult.ts
+++ b/functions/src/scan/refundIfNoResult.ts
@@ -42,9 +42,13 @@ async function handler(req: Request, res: Response) {
       const charged = Boolean(data.charged);
       const statusValue =
         typeof data.status === "string" ? data.status.toLowerCase() : "";
+      const hasValidResult =
+        data?.usedFallback !== true &&
+        (data.result?.bf_percent != null ||
+          Number.isFinite(Number(data.estimate?.bodyFatPercent)));
       const completed =
         (statusValue === "complete" || statusValue === "completed") &&
-        data.result?.bf_percent != null;
+        hasValidResult;
       if (!charged || completed) {
         return;
       }
@@ -53,7 +57,9 @@ async function handler(req: Request, res: Response) {
         scanRef,
         {
           charged: false,
-          status: "aborted",
+          status: "error",
+          errorReason: "refunded_no_result",
+          errorMessage: "Scan did not produce a valid result. Credit refunded.",
           refundedAt: now,
           updatedAt: now,
         },

--- a/functions/src/scan/worker.ts
+++ b/functions/src/scan/worker.ts
@@ -19,6 +19,7 @@ import {
 } from "./analysis.js";
 import { getEngineConfigOrThrow } from "./engineConfig.js";
 import { openAiSecretParam } from "../openai/keys.js";
+import { refundCredit } from "./creditUtils.js";
 
 const db = getFirestore();
 const serverTimestamp = (): FirebaseFirestore.Timestamp =>
@@ -55,7 +56,11 @@ function toMillis(value: any): number | null {
   return null;
 }
 
-function withTimeout<T>(promise: Promise<T>, ms: number, tag: string): Promise<T> {
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  tag: string
+): Promise<T> {
   return new Promise<T>((resolve, reject) => {
     const timer = setTimeout(
       () => reject(new OpenAIClientError(tag, 504, `${tag}_timeout`)),
@@ -71,137 +76,6 @@ function withTimeout<T>(promise: Promise<T>, ms: number, tag: string): Promise<T
         reject(err);
       });
   });
-}
-
-function buildFallbackAnalysis(input: {
-  currentWeightKg: number;
-  goalWeightKg: number;
-  uid: string;
-}): {
-  estimate: ScanDocument["estimate"];
-  workoutPlan: NonNullable<ScanDocument["workoutPlan"]>;
-  nutritionPlan: NonNullable<ScanDocument["nutritionPlan"]>;
-  recommendations: string[];
-  improvementAreas: string[];
-  usedFallback: boolean;
-} {
-  const estimate = {
-    bodyFatPercent: 24,
-    bmi: null,
-    notes: "Fallback estimate (engine timeout).",
-  };
-  const workoutPlan = {
-    summary: "Foundational push/pull/legs split",
-    progressionRules: [
-      "Add 1-2 reps weekly until the top of the range.",
-      "Increase load 2-5% when you hit the top of the rep range.",
-      "Rest 2-3 minutes on compounds, 60-90s on accessories.",
-    ],
-    weeks: Array.from({ length: 4 }).map((_, i) => ({
-      weekNumber: i + 1,
-      days: [
-        {
-          day: "Push",
-          focus: "Chest/Shoulders",
-          exercises: [
-            { name: "Bench press", sets: 3, reps: "6-10" },
-            { name: "Overhead press", sets: 3, reps: "6-10" },
-            { name: "Dips or push-ups", sets: 3, reps: "8-12" },
-          ],
-        },
-        {
-          day: "Pull",
-          focus: "Back",
-          exercises: [
-            { name: "Deadlift or RDL", sets: 3, reps: "5-8" },
-            { name: "Row variation", sets: 3, reps: "8-12" },
-            { name: "Lat pulldown/Pull-up", sets: 3, reps: "8-12" },
-          ],
-        },
-        {
-          day: "Legs",
-          focus: "Lower body",
-          exercises: [
-            { name: "Squat or leg press", sets: 3, reps: "6-10" },
-            { name: "Lunge/step-up", sets: 3, reps: "8-12" },
-            { name: "Leg curl/hinge", sets: 3, reps: "10-15" },
-          ],
-        },
-        {
-          day: "Accessory",
-          focus: "Arms/Core",
-          exercises: [
-            { name: "Biceps + triceps superset", sets: 3, reps: "10-15" },
-            { name: "Planks/side planks", sets: 3, reps: "45-60s" },
-            { name: "Calves", sets: 3, reps: "12-20" },
-          ],
-        },
-      ],
-    })),
-  };
-  const nutritionPlan = deriveNutritionPlan({
-    weightKg: input.currentWeightKg,
-    bodyFatPercent: estimate.bodyFatPercent,
-    goalWeightKg: input.goalWeightKg,
-  });
-  const recommendations = [
-    "Walk 7-10k steps daily; add a 10-minute walk after meals.",
-    "Keep protein at every meal; track 3-4 days/week for accuracy.",
-    "Prioritize sleep and hydration to keep training quality high.",
-  ];
-  return {
-    estimate,
-    workoutPlan,
-    nutritionPlan: {
-      ...nutritionPlan,
-      adjustmentRules: [
-        "If weekly change <0.25 kg, reduce calories by 150–200.",
-        "If losing >1% body weight/week, add 150–200 calories.",
-        "Keep protein steady; adjust carbs/fats first.",
-      ],
-      trainingDay: {
-        calories: nutritionPlan.caloriesPerDay,
-        proteinGrams: nutritionPlan.proteinGrams,
-        carbsGrams: Math.round(nutritionPlan.carbsGrams * 1.05),
-        fatsGrams: Math.round(nutritionPlan.fatsGrams * 0.95),
-      },
-      restDay: {
-        calories: Math.max(1200, Math.round(nutritionPlan.caloriesPerDay - 150)),
-        proteinGrams: nutritionPlan.proteinGrams,
-        carbsGrams: Math.max(0, Math.round(nutritionPlan.carbsGrams * 0.85)),
-        fatsGrams: Math.round(nutritionPlan.fatsGrams + 8),
-      },
-      sampleDay: [
-        {
-          mealName: "Breakfast",
-          description: "Eggs + oats + berries",
-          calories: Math.round(nutritionPlan.caloriesPerDay * 0.25),
-          proteinGrams: Math.round(nutritionPlan.proteinGrams * 0.3),
-          carbsGrams: Math.round(nutritionPlan.carbsGrams * 0.25),
-          fatsGrams: Math.round(nutritionPlan.fatsGrams * 0.35),
-        },
-        {
-          mealName: "Lunch",
-          description: "Chicken, rice, veggies",
-          calories: Math.round(nutritionPlan.caloriesPerDay * 0.3),
-          proteinGrams: Math.round(nutritionPlan.proteinGrams * 0.35),
-          carbsGrams: Math.round(nutritionPlan.carbsGrams * 0.35),
-          fatsGrams: Math.round(nutritionPlan.fatsGrams * 0.25),
-        },
-        {
-          mealName: "Dinner",
-          description: "Lean protein, potatoes, salad",
-          calories: Math.round(nutritionPlan.caloriesPerDay * 0.3),
-          proteinGrams: Math.round(nutritionPlan.proteinGrams * 0.3),
-          carbsGrams: Math.round(nutritionPlan.carbsGrams * 0.3),
-          fatsGrams: Math.round(nutritionPlan.fatsGrams * 0.25),
-        },
-      ],
-    },
-    recommendations,
-    improvementAreas: recommendations,
-    usedFallback: true,
-  };
 }
 
 export const processQueuedScan = onDocumentWritten(
@@ -254,9 +128,11 @@ export const processQueuedScan = onDocumentWritten(
 
     const correlationId = scan.correlationId || processingAttemptId;
     const engine = getEngineConfigOrThrow(correlationId);
-      const queueRequestedAtMs = toMillis((scan as any).processingRequestedAt);
-      const queueDurationMs =
-        queueRequestedAtMs != null ? Math.max(0, Date.now() - queueRequestedAtMs) : null;
+    const queueRequestedAtMs = toMillis((scan as any).processingRequestedAt);
+    const queueDurationMs =
+      queueRequestedAtMs != null
+        ? Math.max(0, Date.now() - queueRequestedAtMs)
+        : null;
 
     const updateStep = async (patch: Partial<ScanDocument>) => {
       await scanRef.set(
@@ -301,7 +177,9 @@ export const processQueuedScan = onDocumentWritten(
         processingHeartbeatAt: serverTimestamp(),
       });
 
-      const photoPaths = scan.photoPaths as ScanDocument["photoPaths"] | undefined;
+      const photoPaths = scan.photoPaths as
+        | ScanDocument["photoPaths"]
+        | undefined;
       const input = scan.input as ScanDocument["input"] | undefined;
       if (!photoPaths) {
         throw new Error("missing_photo_paths");
@@ -313,11 +191,19 @@ export const processQueuedScan = onDocumentWritten(
       }
 
       // Pull height (and other profile details later) to compute BMI deterministically.
-      const profileSnap = await db.doc(`users/${uid}/coach/profile`).get().catch(() => null);
+      const profileSnap = await db
+        .doc(`users/${uid}/coach/profile`)
+        .get()
+        .catch(() => null);
       const profile = profileSnap?.exists ? (profileSnap.data() as any) : null;
-      const scanHeight = Number((input as any)?.heightCm ?? (input as any)?.height_cm);
+      const scanHeight = Number(
+        (input as any)?.heightCm ?? (input as any)?.height_cm
+      );
       const profileHeight = Number(profile?.height_cm ?? profile?.heightCm);
-      const chosenHeight = Number.isFinite(scanHeight) && scanHeight > 0 ? scanHeight : profileHeight;
+      const chosenHeight =
+        Number.isFinite(scanHeight) && scanHeight > 0
+          ? scanHeight
+          : profileHeight;
       const heightOk =
         Number.isFinite(chosenHeight) && chosenHeight > 50 && chosenHeight < 260
           ? Math.round(chosenHeight)
@@ -326,7 +212,8 @@ export const processQueuedScan = onDocumentWritten(
         heightOk != null
           ? round1(currentWeightKg / Math.pow(heightOk / 100, 2))
           : null;
-      const bmiCategoryComputed = bmiComputed != null ? bmiCategory(bmiComputed) : null;
+      const bmiCategoryComputed =
+        bmiComputed != null ? bmiCategory(bmiComputed) : null;
 
       await updateStep({
         lastStep: "Fetching photo URLs",
@@ -343,10 +230,7 @@ export const processQueuedScan = onDocumentWritten(
         progress: 40,
         processingHeartbeatAt: serverTimestamp(),
       });
-      const engine = getEngineConfigOrThrow(correlationId);
-
       startHeartbeat("Analyzing body composition", 45);
-      let usedFallback = false;
       const openAiStartedAtMs = Date.now();
       const result = await withTimeout(
         callOpenAI(
@@ -357,13 +241,7 @@ export const processQueuedScan = onDocumentWritten(
         ),
         ANALYSIS_TIMEOUT_MS,
         "analysis"
-      ).catch((err) => {
-        if (err instanceof OpenAIClientError && err.code === "openai_missing_key") {
-          throw err;
-        }
-        usedFallback = true;
-        return buildFallbackAnalysis({ currentWeightKg, goalWeightKg, uid });
-      });
+      );
       const openAiElapsedMs = Date.now() - openAiStartedAtMs;
       stopHeartbeat();
 
@@ -373,23 +251,22 @@ export const processQueuedScan = onDocumentWritten(
         processingHeartbeatAt: serverTimestamp(),
       });
 
-      const analysis = usedFallback
-        ? {
-            estimate: (result as any).estimate,
-            workoutPlan: (result as any).workoutPlan,
-            nutritionPlan: (result as any).nutritionPlan,
-            recommendations: (result as any).recommendations ?? [],
-            improvementAreas:
-              (result as any).improvementAreas ??
-              (result as any).recommendations ??
-              [],
-          }
-        : buildAnalysisFromResult(result as any);
+      const analysis = buildAnalysisFromResult(result as any);
       const leanMassKg = Number.isFinite(currentWeightKg)
-        ? Number((currentWeightKg * (1 - analysis.estimate.bodyFatPercent / 100)).toFixed(1))
+        ? Number(
+            (
+              currentWeightKg *
+              (1 - analysis.estimate.bodyFatPercent / 100)
+            ).toFixed(1)
+          )
         : null;
       const fatMassKg = Number.isFinite(currentWeightKg)
-        ? Number((currentWeightKg * (analysis.estimate.bodyFatPercent / 100)).toFixed(1))
+        ? Number(
+            (
+              currentWeightKg *
+              (analysis.estimate.bodyFatPercent / 100)
+            ).toFixed(1)
+          )
         : null;
       analysis.estimate.leanMassKg = leanMassKg;
       analysis.estimate.fatMassKg = fatMassKg;
@@ -411,9 +288,11 @@ export const processQueuedScan = onDocumentWritten(
           : null;
 
       const improvementAreas =
-        Array.isArray((analysis as any).improvementAreas) && (analysis as any).improvementAreas.length
+        Array.isArray((analysis as any).improvementAreas) &&
+        (analysis as any).improvementAreas.length
           ? (analysis as any).improvementAreas
-          : Array.isArray(analysis.estimate.keyObservations) && analysis.estimate.keyObservations.length
+          : Array.isArray(analysis.estimate.keyObservations) &&
+              analysis.estimate.keyObservations.length
             ? analysis.estimate.keyObservations
             : Array.isArray(analysis.estimate.goalRecommendations) &&
                 analysis.estimate.goalRecommendations.length
@@ -434,14 +313,25 @@ export const processQueuedScan = onDocumentWritten(
         };
         const coerceDay = (
           day: any,
-          fallback: { calories: number; proteinGrams: number; carbsGrams: number; fatsGrams: number }
+          fallback: {
+            calories: number;
+            proteinGrams: number;
+            carbsGrams: number;
+            fatsGrams: number;
+          }
         ) => ({
-          calories: Math.round(Number.isFinite(day?.calories) ? day.calories : fallback.calories),
+          calories: Math.round(
+            Number.isFinite(day?.calories) ? day.calories : fallback.calories
+          ),
           proteinGrams: Math.round(
-            Number.isFinite(day?.proteinGrams) ? day.proteinGrams : fallback.proteinGrams
+            Number.isFinite(day?.proteinGrams)
+              ? day.proteinGrams
+              : fallback.proteinGrams
           ),
           carbsGrams: Math.round(
-            Number.isFinite(day?.carbsGrams) ? day.carbsGrams : fallback.carbsGrams
+            Number.isFinite(day?.carbsGrams)
+              ? day.carbsGrams
+              : fallback.carbsGrams
           ),
           fatsGrams: Math.round(
             Number.isFinite(day?.fatsGrams) ? day.fatsGrams : fallback.fatsGrams
@@ -459,8 +349,14 @@ export const processQueuedScan = onDocumentWritten(
           proteinGrams: derived.proteinGrams,
           carbsGrams: derived.carbsGrams,
           fatsGrams: derived.fatsGrams,
-          trainingDay: coerceDay((analysis as any)?.nutritionPlan?.trainingDay, baseDay),
-          restDay: coerceDay((analysis as any)?.nutritionPlan?.restDay, restFallback),
+          trainingDay: coerceDay(
+            (analysis as any)?.nutritionPlan?.trainingDay,
+            baseDay
+          ),
+          restDay: coerceDay(
+            (analysis as any)?.nutritionPlan?.restDay,
+            restFallback
+          ),
         };
       })();
 
@@ -477,6 +373,7 @@ export const processQueuedScan = onDocumentWritten(
           input: {
             currentWeightKg,
             goalWeightKg,
+            heightCm: heightOk,
           },
           estimate: analysis.estimate,
           workoutPlan: analysis.workoutPlan,
@@ -494,7 +391,7 @@ export const processQueuedScan = onDocumentWritten(
             recommendations: analysis.recommendations,
             improvementAreas,
             input: { currentWeightKg, goalWeightKg },
-            usedFallback,
+            usedFallback: false,
           }),
           metrics: {
             leanMassKg,
@@ -504,7 +401,15 @@ export const processQueuedScan = onDocumentWritten(
             heightCm: heightOk,
             bodyFatEstimate: bfRange,
           },
-          usedFallback,
+          usedFallback: false,
+          resultSource: "ai",
+          aiProcessing: {
+            status: "succeeded",
+            provider: engine.provider,
+            model: engine.model,
+            elapsedMs: openAiElapsedMs,
+            completedAt: serverTimestamp(),
+          },
           errorMessage: null,
           errorReason: null,
           errorInfo: null,
@@ -521,7 +426,7 @@ export const processQueuedScan = onDocumentWritten(
         downloadElapsedMs,
         openAiElapsedMs,
         totalProcessingMs,
-        usedFallback,
+        usedFallback: false,
         queueDurationMs,
       });
     } catch (error: any) {
@@ -535,10 +440,12 @@ export const processQueuedScan = onDocumentWritten(
           : null;
       const effectiveReason = (() => {
         if (rawMessage?.startsWith("missing_photo_")) return "missing_photos";
-        if (rawMessage?.startsWith("invalid_photo_path_")) return "invalid_photo_paths";
+        if (rawMessage?.startsWith("invalid_photo_path_"))
+          return "invalid_photo_paths";
         if (rawMessage === "missing_photo_paths") return "missing_photo_paths";
         if (rawMessage === "missing_scan_input") return "missing_scan_input";
-        if (errorDetails?.reason === "scan_engine_not_configured") return "scan_engine_not_configured";
+        if (errorDetails?.reason === "scan_engine_not_configured")
+          return "scan_engine_not_configured";
         if (error instanceof OpenAIClientError && error.code) return error.code;
         return errorReason;
       })();
@@ -575,6 +482,7 @@ export const processQueuedScan = onDocumentWritten(
         typeof error?.stack === "string"
           ? error.stack.split("\n").slice(0, 3).join("\n")
           : undefined;
+      const failedAt = serverTimestamp();
       await scanRef
         .set(
           {
@@ -589,14 +497,61 @@ export const processQueuedScan = onDocumentWritten(
               stack,
             },
             lastStep: "error",
-            lastStepAt: serverTimestamp(),
-            updatedAt: serverTimestamp(),
-            completedAt: serverTimestamp(),
-            processingHeartbeatAt: serverTimestamp(),
+            lastStepAt: failedAt,
+            updatedAt: failedAt,
+            completedAt: failedAt,
+            processingHeartbeatAt: failedAt,
+            estimate: null,
+            workoutPlan: null,
+            workoutProgram: null,
+            nutritionPlan: null,
+            planMarkdown: null,
+            recommendations: null,
+            improvementAreas: null,
+            usedFallback: false,
+            resultSource: "failed",
+            aiProcessing: {
+              status: "failed",
+              provider: engine?.provider ?? null,
+              model: engine?.model ?? null,
+              errorCode: effectiveReason,
+              errorMessage: message,
+              failedAt,
+            },
           },
           { merge: true }
         )
         .catch(() => undefined);
+
+      if (Boolean((scan as any).charged)) {
+        await db
+          .runTransaction(async (tx) => {
+            const latest = await tx.get(scanRef);
+            const data = latest.exists ? (latest.data() as any) : null;
+            if (!data?.charged || data?.refundedAt) return;
+            const creditRef = db.doc(`users/${uid}/private/credits`);
+            await refundCredit(tx, creditRef, `scan-failed:${scanId}`);
+            tx.set(
+              scanRef,
+              {
+                charged: false,
+                refundedAt: serverTimestamp(),
+                refundReason: effectiveReason,
+                creditStatus: "refunded",
+                updatedAt: serverTimestamp(),
+              },
+              { merge: true }
+            );
+          })
+          .catch((refundError) => {
+            console.error("scan_refund_failed", {
+              uid,
+              scanId,
+              correlationId,
+              message: (refundError as Error)?.message,
+            });
+          });
+      }
       console.error("scan_processing_failed", {
         uid,
         scanId,

--- a/functions/src/scan/worker.ts
+++ b/functions/src/scan/worker.ts
@@ -523,7 +523,7 @@ export const processQueuedScan = onDocumentWritten(
         )
         .catch(() => undefined);
 
-      if (Boolean((scan as any).charged)) {
+      if ((scan as any).charged) {
         await db
           .runTransaction(async (tx) => {
             const latest = await tx.get(scanRef);

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -140,6 +140,21 @@ export interface ScanDocument {
   files?: string[];
   metrics?: Record<string, unknown>;
   usedFallback?: boolean;
+  resultSource?: "ai" | "failed" | "demo" | "fallback" | string;
+  aiProcessing?: {
+    status?: "succeeded" | "failed" | "timeout" | "processing" | string;
+    provider?: string | null;
+    model?: string | null;
+    elapsedMs?: number | null;
+    errorCode?: string | null;
+    errorMessage?: string | null;
+    completedAt?: Timestamp | null;
+    failedAt?: Timestamp | null;
+  } | null;
+  charged?: boolean;
+  refundedAt?: Timestamp | null;
+  refundReason?: string | null;
+  creditStatus?: string | null;
 }
 
 export interface NutritionItemSnapshot {

--- a/src/lib/api/scan.ts
+++ b/src/lib/api/scan.ts
@@ -36,6 +36,17 @@ export type ScanErrorInfo = {
   stack?: string;
 };
 
+export type ScanAiProcessing = {
+  status?: string;
+  provider?: string | null;
+  model?: string | null;
+  elapsedMs?: number | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+  completedAt?: Date | null;
+  failedAt?: Date | null;
+};
+
 export type WorkoutPlan = {
   summary: string;
   progressionRules: string[];
@@ -116,6 +127,12 @@ export type ScanDocument = {
   planMarkdown?: string | null;
   metrics?: Record<string, unknown> | null;
   usedFallback?: boolean | null;
+  resultSource?: string | null;
+  aiProcessing?: ScanAiProcessing | null;
+  charged?: boolean | null;
+  refundedAt?: Date | null;
+  refundReason?: string | null;
+  creditStatus?: string | null;
   photoPaths: {
     front: string;
     back: string;
@@ -246,16 +263,20 @@ function toScanDocument(
   const normalizedHeight =
     typeof input?.heightCm === "number" && Number.isFinite(input.heightCm)
       ? input.heightCm
-      : typeof (data as any)?.heightCm === "number" && Number.isFinite((data as any).heightCm)
+      : typeof (data as any)?.heightCm === "number" &&
+          Number.isFinite((data as any).heightCm)
         ? ((data as any).heightCm as number)
-        : typeof (data as any)?.height_cm === "number" && Number.isFinite((data as any).height_cm)
+        : typeof (data as any)?.height_cm === "number" &&
+            Number.isFinite((data as any).height_cm)
           ? ((data as any).height_cm as number)
           : undefined;
   const completedAtRaw = data.completedAt as unknown;
   const lastStepAtRaw = (data as any).lastStepAt as unknown;
-  const processingRequestedAtRaw = (data as any).processingRequestedAt as unknown;
+  const processingRequestedAtRaw = (data as any)
+    .processingRequestedAt as unknown;
   const processingStartedAtRaw = (data as any).processingStartedAt as unknown;
-  const processingHeartbeatAtRaw = (data as any).processingHeartbeatAt as unknown;
+  const processingHeartbeatAtRaw = (data as any)
+    .processingHeartbeatAt as unknown;
   const errorInfoRaw = (data as any).errorInfo as ScanErrorInfo | undefined;
   return {
     id,
@@ -267,30 +288,42 @@ function toScanDocument(
     errorMessage:
       typeof data.errorMessage === "string" ? data.errorMessage : null,
     errorReason:
-      typeof (data as any).errorReason === "string" ? (data as any).errorReason : null,
+      typeof (data as any).errorReason === "string"
+        ? (data as any).errorReason
+        : null,
     errorInfo:
       errorInfoRaw && typeof errorInfoRaw === "object"
         ? {
-            code: typeof errorInfoRaw.code === "string" ? errorInfoRaw.code : undefined,
+            code:
+              typeof errorInfoRaw.code === "string"
+                ? errorInfoRaw.code
+                : undefined,
             message:
               typeof errorInfoRaw.message === "string"
                 ? errorInfoRaw.message
                 : undefined,
             stage:
-              typeof errorInfoRaw.stage === "string" ? errorInfoRaw.stage : undefined,
+              typeof errorInfoRaw.stage === "string"
+                ? errorInfoRaw.stage
+                : undefined,
             debugId:
               typeof errorInfoRaw.debugId === "string"
                 ? errorInfoRaw.debugId
                 : undefined,
             stack:
-              typeof errorInfoRaw.stack === "string" ? errorInfoRaw.stack : undefined,
+              typeof errorInfoRaw.stack === "string"
+                ? errorInfoRaw.stack
+                : undefined,
           }
         : null,
     lastStep:
-      typeof (data as any).lastStep === "string" ? (data as any).lastStep : null,
+      typeof (data as any).lastStep === "string"
+        ? (data as any).lastStep
+        : null,
     lastStepAt: lastStepAtRaw ? parseTimestamp(lastStepAtRaw) : null,
     progress:
-      typeof (data as any).progress === "number" && Number.isFinite((data as any).progress)
+      typeof (data as any).progress === "number" &&
+      Number.isFinite((data as any).progress)
         ? (data as any).progress
         : null,
     correlationId:
@@ -327,7 +360,8 @@ function toScanDocument(
           .slice(0, 10) as string[])
       : null,
     disclaimer:
-      typeof (data as any).disclaimer === "string" && (data as any).disclaimer.trim()
+      typeof (data as any).disclaimer === "string" &&
+      (data as any).disclaimer.trim()
         ? ((data as any).disclaimer as string).trim().slice(0, 280)
         : null,
     planMarkdown:
@@ -341,6 +375,61 @@ function toScanDocument(
     usedFallback:
       typeof (data as any).usedFallback === "boolean"
         ? ((data as any).usedFallback as boolean)
+        : null,
+    resultSource:
+      typeof (data as any).resultSource === "string"
+        ? ((data as any).resultSource as string)
+        : null,
+    aiProcessing:
+      (data as any).aiProcessing &&
+      typeof (data as any).aiProcessing === "object"
+        ? {
+            status:
+              typeof (data as any).aiProcessing.status === "string"
+                ? (data as any).aiProcessing.status
+                : undefined,
+            provider:
+              typeof (data as any).aiProcessing.provider === "string"
+                ? (data as any).aiProcessing.provider
+                : null,
+            model:
+              typeof (data as any).aiProcessing.model === "string"
+                ? (data as any).aiProcessing.model
+                : null,
+            elapsedMs:
+              typeof (data as any).aiProcessing.elapsedMs === "number"
+                ? (data as any).aiProcessing.elapsedMs
+                : null,
+            errorCode:
+              typeof (data as any).aiProcessing.errorCode === "string"
+                ? (data as any).aiProcessing.errorCode
+                : null,
+            errorMessage:
+              typeof (data as any).aiProcessing.errorMessage === "string"
+                ? (data as any).aiProcessing.errorMessage
+                : null,
+            completedAt: (data as any).aiProcessing.completedAt
+              ? parseTimestamp((data as any).aiProcessing.completedAt)
+              : null,
+            failedAt: (data as any).aiProcessing.failedAt
+              ? parseTimestamp((data as any).aiProcessing.failedAt)
+              : null,
+          }
+        : null,
+    charged:
+      typeof (data as any).charged === "boolean"
+        ? ((data as any).charged as boolean)
+        : null,
+    refundedAt: (data as any).refundedAt
+      ? parseTimestamp((data as any).refundedAt)
+      : null,
+    refundReason:
+      typeof (data as any).refundReason === "string"
+        ? ((data as any).refundReason as string)
+        : null,
+    creditStatus:
+      typeof (data as any).creditStatus === "string"
+        ? ((data as any).creditStatus as string)
         : null,
     photoPaths:
       fallbackPaths ??
@@ -378,18 +467,21 @@ function toScanDocument(
         : null,
     input: {
       currentWeightKg:
-        typeof input?.currentWeightKg === "number" && Number.isFinite(input.currentWeightKg)
+        typeof input?.currentWeightKg === "number" &&
+        Number.isFinite(input.currentWeightKg)
           ? input.currentWeightKg
           : 0,
       goalWeightKg:
-        typeof input?.goalWeightKg === "number" && Number.isFinite(input.goalWeightKg)
+        typeof input?.goalWeightKg === "number" &&
+        Number.isFinite(input.goalWeightKg)
           ? input.goalWeightKg
           : 0,
       heightCm: normalizedHeight ?? null,
     },
     estimate: (data.estimate as ScanEstimate | null) ?? null,
     workoutPlan: (data.workoutPlan as WorkoutPlan | null) ?? null,
-    workoutProgram: ((data as any).workoutProgram as WorkoutPlan | null) ?? null,
+    workoutProgram:
+      ((data as any).workoutProgram as WorkoutPlan | null) ?? null,
     nutritionPlan: (data.nutritionPlan as NutritionPlan | null) ?? null,
     note: typeof data.note === "string" ? data.note : undefined,
   };
@@ -413,7 +505,9 @@ function buildScanError(
         : fallbackMessage;
     const effectiveReason = reason ?? data.reason;
     const normalizedMessage =
-      effectiveReason === "engine_not_configured" || effectiveReason === "scan_engine_not_configured" || effectiveReason === "provider_not_configured"
+      effectiveReason === "engine_not_configured" ||
+      effectiveReason === "scan_engine_not_configured" ||
+      effectiveReason === "provider_not_configured"
         ? "Scan provider not configured. Please contact support."
         : message;
     return {
@@ -460,7 +554,8 @@ export async function startScanSessionClient(
         currentWeightKg: params.currentWeightKg,
         goalWeightKg: params.goalWeightKg,
         heightCm:
-          typeof params.heightCm === "number" && Number.isFinite(params.heightCm)
+          typeof params.heightCm === "number" &&
+          Number.isFinite(params.heightCm)
             ? Math.round(params.heightCm)
             : undefined,
         correlationId: params.correlationId,
@@ -481,7 +576,6 @@ export async function startScanSessionClient(
     };
   }
 }
-
 
 export type ScanUploadProgress = {
   pose: keyof StartScanResponse["storagePaths"];
@@ -514,20 +608,32 @@ export function validateScanUploadInputs(params: {
 }> {
   const uid = String(params.uid || "").trim();
   if (!uid) {
-    return { ok: false, error: { message: "Missing scan session info.", reason: "upload_failed" } };
+    return {
+      ok: false,
+      error: { message: "Missing scan session info.", reason: "upload_failed" },
+    };
   }
   const poses = ["front", "back", "left", "right"] as const;
   const uploadTargets: UploadTarget[] = [];
   for (const pose of poses) {
     const file = params.photos[pose];
     if (!file) {
-      return { ok: false, error: { message: `Missing ${pose} photo.`, reason: "upload_failed" } };
+      return {
+        ok: false,
+        error: { message: `Missing ${pose} photo.`, reason: "upload_failed" },
+      };
     }
     const size = Number.isFinite(file.size) ? Number(file.size) : 0;
     uploadTargets.push({ pose, path: pose, file, size });
   }
   if (!uploadTargets.length) {
-    return { ok: false, error: { message: "No photos selected for this scan.", reason: "upload_failed" } };
+    return {
+      ok: false,
+      error: {
+        message: "No photos selected for this scan.",
+        reason: "upload_failed",
+      },
+    };
   }
   const zeroByteTargets = uploadTargets.filter((target) => target.size <= 0);
   if (zeroByteTargets.length) {
@@ -540,7 +646,10 @@ export function validateScanUploadInputs(params: {
       },
     };
   }
-  const totalBytes = uploadTargets.reduce((sum, target) => sum + target.size, 0);
+  const totalBytes = uploadTargets.reduce(
+    (sum, target) => sum + target.size,
+    0
+  );
   return { ok: true, data: { uploadTargets, totalBytes } };
 }
 
@@ -638,8 +747,14 @@ export async function submitScanClient(
       ok: false,
       error: { message: "Please sign in before submitting a scan." },
     };
-  const poses: Array<keyof StartScanResponse["storagePaths"]> = ["front", "back", "left", "right"];
-  const scanCorrelationId = params.scanCorrelationId ?? createScanCorrelationId(params.scanId);
+  const poses: Array<keyof StartScanResponse["storagePaths"]> = [
+    "front",
+    "back",
+    "left",
+    "right",
+  ];
+  const scanCorrelationId =
+    params.scanCorrelationId ?? createScanCorrelationId(params.scanId);
   if (params.heightCm == null) {
     console.warn("scan_submit_height_missing", {
       scanId: params.scanId,
@@ -675,22 +790,28 @@ export async function submitScanClient(
   }
 
   const perPhotoPrepTimeoutMs =
-    typeof options?.perPhotoTimeoutMs === "number" && Number.isFinite(options.perPhotoTimeoutMs)
+    typeof options?.perPhotoTimeoutMs === "number" &&
+    Number.isFinite(options.perPhotoTimeoutMs)
       ? Math.max(2500, Math.min(options.perPhotoTimeoutMs, 8000))
       : 3500;
   const uploadTimeoutMs =
-    typeof options?.perPhotoTimeoutMs === "number" && Number.isFinite(options.perPhotoTimeoutMs)
+    typeof options?.perPhotoTimeoutMs === "number" &&
+    Number.isFinite(options.perPhotoTimeoutMs)
       ? Math.max(30_000, options.perPhotoTimeoutMs)
       : 90_000;
   const overallTimeoutMs =
-    typeof options?.overallTimeoutMs === "number" && Number.isFinite(options.overallTimeoutMs)
+    typeof options?.overallTimeoutMs === "number" &&
+    Number.isFinite(options.overallTimeoutMs)
       ? Math.max(45_000, options.overallTimeoutMs)
       : 150_000;
   const controller = new AbortController();
   const overallTimer = setTimeout(() => controller.abort(), overallTimeoutMs);
   if (options?.signal) {
     if (options.signal.aborted) controller.abort();
-    else options.signal.addEventListener("abort", () => controller.abort(), { once: true });
+    else
+      options.signal.addEventListener("abort", () => controller.abort(), {
+        once: true,
+      });
   }
 
   type Prepared = {
@@ -701,7 +822,10 @@ export async function submitScanClient(
       debug?: UploadPreprocessResult["debug"];
     };
   };
-  const preparedFiles: Record<keyof StartScanResponse["storagePaths"], Prepared> = {
+  const preparedFiles: Record<
+    keyof StartScanResponse["storagePaths"],
+    Prepared
+  > = {
     front: null as any,
     back: null as any,
     left: null as any,
@@ -712,14 +836,19 @@ export async function submitScanClient(
     const original = params.photos[pose];
     if (!original) {
       clearTimeout(overallTimer);
-      return { ok: false, error: { message: `Missing ${pose} photo.`, reason: "upload_failed" } };
+      return {
+        ok: false,
+        error: { message: `Missing ${pose} photo.`, reason: "upload_failed" },
+      };
     }
     options?.onPhotoState?.({ pose, status: "preparing" });
     const startedAt = Date.now();
     try {
       const prepResult = await Promise.race([
         prepareScanPhoto(original, pose),
-        new Promise<null>((resolve) => setTimeout(() => resolve(null), perPhotoPrepTimeoutMs)),
+        new Promise<null>((resolve) =>
+          setTimeout(() => resolve(null), perPhotoPrepTimeoutMs)
+        ),
       ]);
       if (prepResult) {
         preparedFiles[pose] = {
@@ -748,7 +877,12 @@ export async function submitScanClient(
           file: fallbackFile,
           meta: { original: meta, prepared: meta },
         };
-        options?.onPhotoState?.({ pose, status: "preparing", original: meta, compressed: meta });
+        options?.onPhotoState?.({
+          pose,
+          status: "preparing",
+          original: meta,
+          compressed: meta,
+        });
       }
       console.info("scan.preprocess", {
         pose,
@@ -765,7 +899,10 @@ export async function submitScanClient(
       e.code = "preprocess_failed";
       e.pose = pose;
       clearTimeout(overallTimer);
-      return { ok: false, error: buildScanError(e, e.message, "upload_failed") };
+      return {
+        ok: false,
+        error: buildScanError(e, e.message, "upload_failed"),
+      };
     }
   }
 
@@ -783,8 +920,12 @@ export async function submitScanClient(
     };
   }
 
-  const emitOverallProgress = (bytesTransferred: number, status: ScanUploadProgress["status"]) => {
-    const percent = totalBytes > 0 ? clampProgressFraction(bytesTransferred / totalBytes) : 0;
+  const emitOverallProgress = (
+    bytesTransferred: number,
+    status: ScanUploadProgress["status"]
+  ) => {
+    const percent =
+      totalBytes > 0 ? clampProgressFraction(bytesTransferred / totalBytes) : 0;
     options?.onUploadProgress?.({
       pose: "front",
       fileIndex: 0,
@@ -854,7 +995,10 @@ export async function submitScanClient(
     });
 
     const uploadAbort = new AbortController();
-    const uploadTimeoutId = setTimeout(() => uploadAbort.abort(), uploadTimeoutMs);
+    const uploadTimeoutId = setTimeout(
+      () => uploadAbort.abort(),
+      uploadTimeoutMs
+    );
     const response = await fetch(scanUploadUrl(), {
       method: "POST",
       headers: {
@@ -876,7 +1020,10 @@ export async function submitScanClient(
       } catch {
         // ignore
       }
-      throw Object.assign(new Error(message), { code: "upload_failed", debugId });
+      throw Object.assign(new Error(message), {
+        code: "upload_failed",
+        debugId,
+      });
     }
 
     const payload = (await response.json()) as SubmitScanResponse | undefined;
@@ -946,7 +1093,10 @@ export async function retryScanProcessingClient(
     const refDoc = doc(db, "users", user.uid, "scans", trimmed);
     const snap = await getDoc(refDoc);
     if (!snap.exists()) {
-      return { ok: false, error: { message: "Scan not found.", reason: "submit_failed" } };
+      return {
+        ok: false,
+        error: { message: "Scan not found.", reason: "submit_failed" },
+      };
     }
     const data = snap.data() as any;
     const photoPaths = data?.photoPaths;
@@ -956,21 +1106,30 @@ export async function retryScanProcessingClient(
     const heightCm =
       typeof input?.heightCm === "number" && Number.isFinite(input.heightCm)
         ? input.heightCm
-        : typeof (data as any)?.heightCm === "number" && Number.isFinite((data as any).heightCm)
+        : typeof (data as any)?.heightCm === "number" &&
+            Number.isFinite((data as any).heightCm)
           ? ((data as any).heightCm as number)
           : null;
     const correlationId =
-      typeof data?.correlationId === "string" ? (data.correlationId as string) : undefined;
+      typeof data?.correlationId === "string"
+        ? (data.correlationId as string)
+        : undefined;
     if (!photoPaths || typeof photoPaths !== "object") {
       return {
         ok: false,
-        error: { message: "Missing photo paths for this scan.", reason: "submit_failed" },
+        error: {
+          message: "Missing photo paths for this scan.",
+          reason: "submit_failed",
+        },
       };
     }
     if (!Number.isFinite(currentWeightKg) || !Number.isFinite(goalWeightKg)) {
       return {
         ok: false,
-        error: { message: "Missing scan input (weights).", reason: "submit_failed" },
+        error: {
+          message: "Missing scan input (weights).",
+          reason: "submit_failed",
+        },
       };
     }
     await apiFetch(submitUrl(), {
@@ -995,7 +1154,11 @@ export async function retryScanProcessingClient(
   } catch (err) {
     return {
       ok: false,
-      error: buildScanError(err, "We couldn't restart processing right now.", "submit_failed"),
+      error: buildScanError(
+        err,
+        "We couldn't restart processing right now.",
+        "submit_failed"
+      ),
     };
   }
 }

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -30,6 +30,11 @@ export const STRIPE_PUBLISHABLE_KEY: string | undefined =
 /* Platform/service-worker */
 export const SW_ENABLED: boolean = bool(env.VITE_SW_ENABLED, false); // stays disabled by default
 
+export const TRANSFORMATION_PREVIEW_ENTRY_ENABLED: boolean = bool(
+  env.VITE_ENABLE_TRANSFORMATION_PREVIEW,
+  false
+);
+
 /* Marketing/public experience */
 export const MBS_FLAGS = {
   ...CONFIG_FLAGS,

--- a/src/lib/scanResultViewModel.ts
+++ b/src/lib/scanResultViewModel.ts
@@ -1,0 +1,206 @@
+import type { ScanDocument } from "@/lib/api/scan";
+import { canonicalizeScanStatus } from "@/lib/scanStatus";
+import { kgToLb } from "@/lib/units";
+import type { CoachPlan, CoachProfile } from "@/hooks/useUserProfile";
+import { normalizeProgramPreferences } from "@/lib/programs/preferences";
+
+type UnitSystem = "metric" | "us";
+
+export type CanonicalScanResultViewModel = {
+  isValidResult: boolean;
+  isFailedOrFallback: boolean;
+  sourceLabel:
+    | "AI analysis"
+    | "Demo only"
+    | "Failed"
+    | "Fallback/invalid"
+    | "Processing";
+  failureTitle: string;
+  failureMessage: string;
+  status: string;
+  primary: {
+    bodyFatPercent: number | null;
+    weightKg: number | null;
+    bmi: number | null;
+    leanMassKg: number | null;
+    goalProgressText: string;
+  };
+  nutrition: {
+    available: boolean;
+    calories: number | null;
+    proteinGrams: number | null;
+    carbsGrams: number | null;
+    fatsGrams: number | null;
+  };
+  plan: {
+    available: boolean;
+    daysPerWeek: number | null;
+    focus: string;
+    summary: string;
+    setupNeeded: boolean;
+    detailLines: string[];
+  };
+  diagnostics: {
+    provider: string | null;
+    processingStatus: string | null;
+    errorCode: string | null;
+    resultSource: string | null;
+    usedFallback: boolean;
+    charged: boolean | null;
+    refunded: boolean;
+  };
+};
+
+function finite(value: unknown): number | null {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+function round(value: number | null, digits = 0): number | null {
+  if (value == null) return null;
+  const f = 10 ** digits;
+  return Math.round(value * f) / f;
+}
+
+export function formatKgForUnits(
+  valueKg: number | null,
+  units: UnitSystem
+): string {
+  if (valueKg == null) return "—";
+  if (units === "us") return `${kgToLb(valueKg).toFixed(1)} lb`;
+  return `${valueKg.toFixed(1)} kg`;
+}
+
+export function buildScanResultViewModel(args: {
+  scan: ScanDocument;
+  profile?: CoachProfile | null;
+  plan?: CoachPlan | null;
+}): CanonicalScanResultViewModel {
+  const { scan, profile, plan } = args;
+  const canonical = canonicalizeScanStatus(scan.status);
+  const usedFallback =
+    scan.usedFallback === true || scan.resultSource === "fallback";
+  const processingStatus = scan.aiProcessing?.status ?? null;
+  const resultSource = scan.resultSource ?? (usedFallback ? "fallback" : null);
+  const bf = finite(scan.estimate?.bodyFatPercent);
+  const weightKg =
+    finite(scan.input?.currentWeightKg) ??
+    finite(profile?.weight_kg) ??
+    finite(profile?.weightKg);
+  const heightCm =
+    finite(scan.input?.heightCm) ??
+    finite(profile?.height_cm) ??
+    finite(profile?.heightCm);
+  const bmi =
+    finite(scan.estimate?.bmi) ??
+    (weightKg && heightCm ? weightKg / Math.pow(heightCm / 100, 2) : null);
+  const leanMassKg =
+    finite(scan.estimate?.leanMassKg) ??
+    finite(scan.metrics?.leanMassKg) ??
+    (weightKg != null && bf != null ? weightKg * (1 - bf / 100) : null);
+  const hasNutrition =
+    Boolean(scan.nutritionPlan) &&
+    finite(scan.nutritionPlan?.caloriesPerDay) != null;
+  const isComplete = canonical === "complete";
+  const isValidResult =
+    isComplete &&
+    !usedFallback &&
+    bf != null &&
+    Boolean(scan.estimate) &&
+    hasNutrition;
+  const isFailedOrFallback =
+    canonical === "error" || usedFallback || (isComplete && !isValidResult);
+
+  const goalWeightKg =
+    finite(scan.input?.goalWeightKg) ??
+    finite((profile as any)?.goal_weight_kg);
+  const goalProgressText = (() => {
+    if (weightKg == null || goalWeightKg == null)
+      return "Add a goal to track progress";
+    const delta = Math.abs(weightKg - goalWeightKg);
+    return `${delta.toFixed(1)} kg from goal weight`;
+  })();
+
+  const prefsRaw = profile?.programPreferences as any;
+  const hasPrefs = Boolean(prefsRaw && typeof prefsRaw === "object");
+  const prefs = hasPrefs ? normalizeProgramPreferences(prefsRaw) : null;
+  const planDays = finite(plan?.days) ?? prefs?.daysPerWeek ?? null;
+  const planFocus =
+    plan?.split ||
+    (prefs ? prefs.focus.replaceAll("_", " ") : "Plan setup needed");
+  const planAvailable = Boolean(
+    plan && planDays && Array.isArray(plan.sessions) && plan.sessions.length > 0
+  );
+  const detailLines =
+    plan?.sessions?.slice(0, 3).map((session) => {
+      const focuses = session.blocks
+        ?.map((block) => block.focus || block.title)
+        .filter(Boolean)
+        .slice(0, 2)
+        .join(" + ");
+      return `${session.day}: ${focuses || "training"}`;
+    }) ?? [];
+
+  return {
+    isValidResult,
+    isFailedOrFallback,
+    sourceLabel: usedFallback
+      ? "Fallback/invalid"
+      : resultSource === "demo"
+        ? "Demo only"
+        : canonical === "error"
+          ? "Failed"
+          : isValidResult
+            ? "AI analysis"
+            : canonical === "complete"
+              ? "Fallback/invalid"
+              : "Processing",
+    failureTitle: "We could not complete this scan",
+    failureMessage:
+      scan.errorMessage ||
+      scan.aiProcessing?.errorMessage ||
+      "The scan engine did not return a trustworthy analysis. Please retry processing or re-upload the scan photos.",
+    status: canonical,
+    primary: {
+      bodyFatPercent: isValidResult ? round(bf, 1) : null,
+      weightKg: isValidResult ? round(weightKg, 1) : weightKg,
+      bmi: isValidResult ? round(bmi, 1) : null,
+      leanMassKg: isValidResult ? round(leanMassKg, 1) : null,
+      goalProgressText,
+    },
+    nutrition: {
+      available: isValidResult && hasNutrition,
+      calories: isValidResult
+        ? round(finite(scan.nutritionPlan?.caloriesPerDay))
+        : null,
+      proteinGrams: isValidResult
+        ? round(finite(scan.nutritionPlan?.proteinGrams))
+        : null,
+      carbsGrams: isValidResult
+        ? round(finite(scan.nutritionPlan?.carbsGrams))
+        : null,
+      fatsGrams: isValidResult
+        ? round(finite(scan.nutritionPlan?.fatsGrams))
+        : null,
+    },
+    plan: {
+      available: isValidResult && planAvailable,
+      daysPerWeek: planAvailable ? planDays : null,
+      focus: planFocus,
+      summary: planAvailable
+        ? `${planDays} days/week · ${planFocus}`
+        : "Complete plan setup to receive a personalized training plan.",
+      setupNeeded: !planAvailable,
+      detailLines,
+    },
+    diagnostics: {
+      provider: scan.aiProcessing?.provider ?? null,
+      processingStatus,
+      errorCode: scan.errorReason ?? scan.aiProcessing?.errorCode ?? null,
+      resultSource,
+      usedFallback,
+      charged: scan.charged ?? null,
+      refunded: Boolean(scan.refundedAt || scan.creditStatus === "refunded"),
+    },
+  };
+}

--- a/src/lib/transformationPreview.ts
+++ b/src/lib/transformationPreview.ts
@@ -1,10 +1,4 @@
-import {
-  doc,
-  onSnapshot,
-  serverTimestamp,
-  setDoc,
-  type Unsubscribe,
-} from "firebase/firestore";
+import { doc, onSnapshot, type Unsubscribe } from "firebase/firestore";
 import { db } from "@/lib/firebase";
 
 export type TransformationPreviewStatus =
@@ -39,9 +33,9 @@ export type TransformationPreviewDocument = {
 function toDateOrNull(value: unknown): Date | null {
   if (!value) return null;
   if (value instanceof Date) return value;
-  if (typeof (value as any)?.toDate === "function") {
+  if (typeof (value as { toDate?: unknown })?.toDate === "function") {
     try {
-      return (value as any).toDate();
+      return (value as { toDate: () => Date }).toDate();
     } catch {
       return null;
     }
@@ -53,8 +47,13 @@ function toDateOrNull(value: unknown): Date | null {
   return null;
 }
 
-function normalize(raw: any, scanId: string): TransformationPreviewDocument {
-  const statusRaw = String(raw?.status || "not_started").toLowerCase();
+function normalize(
+  raw: unknown,
+  scanId: string
+): TransformationPreviewDocument {
+  const data =
+    raw && typeof raw === "object" ? (raw as Record<string, unknown>) : {};
+  const statusRaw = String(data.status || "not_started").toLowerCase();
   const status: TransformationPreviewStatus =
     statusRaw === "queued" ||
     statusRaw === "processing" ||
@@ -63,7 +62,7 @@ function normalize(raw: any, scanId: string): TransformationPreviewDocument {
       ? (statusRaw as TransformationPreviewStatus)
       : "not_started";
 
-  const goalRaw = String(raw?.goal || "recomp").toLowerCase();
+  const goalRaw = String(data.goal || "recomp").toLowerCase();
   const goal: TransformationPreviewGoal =
     goalRaw === "lose_fat" ||
     goalRaw === "gain_muscle" ||
@@ -73,26 +72,31 @@ function normalize(raw: any, scanId: string): TransformationPreviewDocument {
       ? (goalRaw as TransformationPreviewGoal)
       : "recomp";
 
+  const timelineWeeks =
+    typeof data.timelineWeeks === "number" &&
+    Number.isFinite(data.timelineWeeks)
+      ? Math.min(52, Math.max(2, Math.round(data.timelineWeeks)))
+      : 12;
+
   return {
     scanId,
     status,
     goal,
-    timelineWeeks:
-      typeof raw?.timelineWeeks === "number" && Number.isFinite(raw.timelineWeeks)
-        ? Math.min(52, Math.max(2, Math.round(raw.timelineWeeks)))
-        : 12,
+    timelineWeeks,
     disclaimer:
-      typeof raw?.disclaimer === "string" && raw.disclaimer.trim().length
-        ? raw.disclaimer.trim()
-        : "Transformation Preview is a motivational projection based on your scan and plan. Results vary by adherence, recovery, and consistency.",
-    requestedAt: toDateOrNull(raw?.requestedAt),
-    updatedAt: toDateOrNull(raw?.updatedAt),
-    readyAt: toDateOrNull(raw?.readyAt),
-    imageUrl: typeof raw?.imageUrl === "string" ? raw.imageUrl : null,
+      typeof data.disclaimer === "string" && data.disclaimer.trim().length
+        ? data.disclaimer.trim()
+        : "Transformation Preview is a motivational wellness visualization. Results vary by adherence, recovery, and consistency.",
+    requestedAt: toDateOrNull(data.requestedAt),
+    updatedAt: toDateOrNull(data.updatedAt),
+    readyAt: toDateOrNull(data.readyAt),
+    imageUrl: typeof data.imageUrl === "string" ? data.imageUrl : null,
     compareImageUrl:
-      typeof raw?.compareImageUrl === "string" ? raw.compareImageUrl : null,
-    promptSummary: typeof raw?.promptSummary === "string" ? raw.promptSummary : null,
-    failureReason: typeof raw?.failureReason === "string" ? raw.failureReason : null,
+      typeof data.compareImageUrl === "string" ? data.compareImageUrl : null,
+    promptSummary:
+      typeof data.promptSummary === "string" ? data.promptSummary : null,
+    failureReason:
+      typeof data.failureReason === "string" ? data.failureReason : null,
   };
 }
 
@@ -119,34 +123,5 @@ export function subscribeTransformationPreview(
     (error) => {
       onError?.(error as Error);
     }
-  );
-}
-
-export async function requestTransformationPreview(params: {
-  uid: string;
-  scanId: string;
-  goal: TransformationPreviewGoal;
-  timelineWeeks: number;
-  planSummary?: string | null;
-}) {
-  const ref = transformationPreviewDoc(params.uid, params.scanId);
-  const timelineWeeks = Math.min(52, Math.max(2, Math.round(params.timelineWeeks || 12)));
-  await setDoc(
-    ref,
-    {
-      scanId: params.scanId,
-      status: "queued",
-      goal: params.goal,
-      timelineWeeks,
-      promptSummary:
-        typeof params.planSummary === "string" && params.planSummary.trim().length
-          ? params.planSummary.trim().slice(0, 240)
-          : null,
-      disclaimer:
-        "Transformation Preview is a motivational projection based on your scan and plan. Results vary by adherence, recovery, and consistency.",
-      requestedAt: serverTimestamp(),
-      updatedAt: serverTimestamp(),
-    },
-    { merge: true }
   );
 }

--- a/src/pages/LiveFlowsQA.tsx
+++ b/src/pages/LiveFlowsQA.tsx
@@ -11,14 +11,10 @@ import {
   query,
 } from "firebase/firestore";
 import { db } from "@/lib/firebase";
-import { coachChatApi } from "@/lib/api/coach";
 import { nutritionSearch } from "@/lib/api/nutrition";
-import { addMeal, deleteMeal, getDailyLog } from "@/lib/nutritionBackend";
-import { getPlan, getWorkouts, applyCatalogPlan } from "@/lib/workouts";
-import {
-  startScanSessionClient,
-  validateScanUploadInputs,
-} from "@/lib/api/scan";
+import { getDailyLog } from "@/lib/nutritionBackend";
+import { getPlan, getWorkouts } from "@/lib/workouts";
+import { validateScanUploadInputs } from "@/lib/api/scan";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
@@ -95,113 +91,96 @@ export default function LiveFlowsQA() {
     if (!user) return;
     setRunning(true);
     setResults([]);
-    let testMealId: string | null = null;
-    let scanId: string | null = null;
 
-    await run("1. auth state", async () => {
-      const token = await getIdToken({ forceRefresh: false });
-      if (!token) throw new Error("missing_auth_token");
-      return `uid=${user.uid}`;
-    });
-    await run("2. profile/onboarding", async () => {
-      const snap = await getDoc(doc(db, "users", user.uid));
-      if (!snap.exists()) throw new Error("user_doc_missing");
-      const d = snap.data() as any;
-      return `onboarding=${String(Boolean(d?.onboardingCompleted || d?.onboarding?.completed))}`;
-    });
-    await run("3. entitlement/subscription/credits", async () => {
-      const [creditsSnap, entSnap] = await Promise.all([
-        getDoc(doc(db, "users", user.uid, "private", "credits")),
-        getDoc(doc(db, "users", user.uid, "entitlements", "pro")),
-      ]);
-      return `credits=${creditsSnap.data()?.creditsSummary?.totalAvailable ?? "na"}, pro=${Boolean(entSnap.data()?.pro)}`;
-    });
-    await run("4. coachChat callable", async () => {
-      const res = await coachChatApi({
-        message: "QA ping: respond with one short line.",
-      });
-      if (!res.replyText) throw new Error("empty_coach_reply");
-      return res.replyText.slice(0, 60);
-    });
-    await run("5. nutritionSearch callable", async () => {
-      const res = await nutritionSearch("banana");
-      return `items=${res.results.length}, source=${res.source || "unknown"}`;
-    });
-    await run("6. getDailyLog callable/http", async () => {
-      const res = await getDailyLog(todayISO);
-      return `meals=${Array.isArray((res as any)?.meals) ? (res as any).meals.length : 0}`;
-    });
-    await run("7. addMeal callable", async () => {
-      const meal = {
-        name: "QA Test Item (safe)",
-        mealType: "snacks",
-        calories: 10,
-        protein: 0,
-        carbs: 1,
-        fat: 0,
-        notes: "qa-live-flows",
-      };
-      const res = await addMeal(todayISO, meal);
-      testMealId = (res as any)?.meal?.id || null;
-      if (!testMealId) throw new Error("add_meal_missing_id");
-      return `mealId=${testMealId}`;
-    });
-    await run("8. deleteMeal callable", async () => {
-      if (!testMealId) throw new Error("skipped_no_test_meal");
-      await deleteMeal(todayISO, testMealId);
-    });
-    await run("9. getPlan callable", async () => {
-      const res = await getPlan();
-      return `planId=${String((res as any)?.planId || (res as any)?.id || "none")}`;
-    });
-    await run("10. getWorkouts callable", async () => {
-      const res = await getWorkouts();
-      return `days=${res?.days?.length ?? 0}`;
-    });
-    await run("11. applyCatalogPlan safe path", async () => {
-      const payload = {
-        programId: "qa-live-flow",
-        title: "QA Safe Plan",
-        goal: "recomp",
-        level: "beginner",
-        days: [
-          {
-            day: "Mon",
-            exercises: [{ name: "Bodyweight Squat", sets: 2, reps: "8" }],
-          },
-        ],
-      };
-      const res = await applyCatalogPlan(payload as any);
-      return `ok=${String(Boolean((res as any)?.ok ?? true))}`;
-    });
-    await run("12. startScanSession callable/http", async () => {
-      const res = await startScanSessionClient({
-        currentWeightKg: 70,
-        goalWeightKg: 69,
-        heightCm: 175,
-        correlationId: `qa-${Date.now()}`,
-      });
-      if (!res.ok) throw new Error(res.error.message || "start_scan_failed");
-      scanId = res.data.scanId;
-      return `scanId=${scanId}`;
-    });
-    await run("13. scan upload readiness (no credit consume)", async () => {
-      if (!scanId) throw new Error("skipped_no_scan_session");
-      const f = new File(["qa"], "qa.txt", { type: "text/plain" });
-      const probe = validateScanUploadInputs({
-        uid: user.uid,
-        photos: { front: f, back: f, left: f, right: f } as any,
-      });
-      if (!probe.ok) throw new Error(probe.error.message);
-      return `targets=${probe.data.uploadTargets.length}`;
-    });
-    await run("14. Transformation Preview readiness", async () => {
-      if (!scanId) throw new Error("missing_scanId");
-      const ref = doc(db, "users", user.uid, "transformationPreviews", scanId);
-      return `doc=${ref.path}`;
-    });
+    let latestScanId: string | null = latestScan?.id ?? null;
 
-    setRunning(false);
+    try {
+      await run("1. auth state", async () => {
+        const token = await getIdToken({ forceRefresh: false });
+        if (!token) throw new Error("missing_auth_token");
+        return `uid=${user.uid}`;
+      });
+      await run("2. profile/onboarding read", async () => {
+        const snap = await getDoc(doc(db, "users", user.uid));
+        if (!snap.exists()) throw new Error("user_doc_missing");
+        const d = snap.data() as any;
+        return `onboarding=${String(Boolean(d?.onboardingCompleted || d?.onboarding?.completed))}`;
+      });
+      await run("3. entitlement/subscription/credits read", async () => {
+        const [creditsSnap, entSnap] = await Promise.all([
+          getDoc(doc(db, "users", user.uid, "private", "credits")),
+          getDoc(doc(db, "users", user.uid, "entitlements", "pro")),
+        ]);
+        return `credits=${creditsSnap.data()?.creditsSummary?.totalAvailable ?? "na"}, pro=${Boolean(entSnap.data()?.pro)}`;
+      });
+      await run("4. coachChat manual verification", async () => {
+        return "manual only: skipped to avoid paid AI request or message writes";
+      });
+      await run("5. nutritionSearch read", async () => {
+        const res = await nutritionSearch("banana");
+        return `items=${res.results.length}, source=${res.source || "unknown"}`;
+      });
+      await run("6. getDailyLog read", async () => {
+        const res = await getDailyLog(todayISO);
+        return `meals=${Array.isArray((res as any)?.meals) ? (res as any).meals.length : 0}`;
+      });
+      await run("7. getPlan read", async () => {
+        const res = await getPlan();
+        return `planId=${String((res as any)?.planId || (res as any)?.id || "none")}`;
+      });
+      await run("8. getWorkouts read", async () => {
+        const res = await getWorkouts();
+        return `days=${res?.days?.length ?? 0}`;
+      });
+      await run("9. latest scan/result diagnostics read", async () => {
+        const snap = await getDocs(
+          query(
+            collection(db, "users", user.uid, "scans"),
+            orderBy("createdAt", "desc"),
+            limit(1)
+          )
+        );
+        if (snap.empty) {
+          setLatestScan(null);
+          return "no scan documents found";
+        }
+        const docSnap = snap.docs[0];
+        const next = { id: docSnap.id, ...docSnap.data() };
+        latestScanId = docSnap.id;
+        setLatestScan(next);
+        return `scanId=${docSnap.id}, status=${String((next as any).status ?? "unknown")}`;
+      });
+      await run("10. scan upload validation only", async () => {
+        const pixel = new File([new Uint8Array([137, 80, 78, 71])], "qa.png", {
+          type: "image/png",
+        });
+        const probe = validateScanUploadInputs({
+          uid: user.uid,
+          photos: {
+            front: pixel,
+            back: pixel,
+            left: pixel,
+            right: pixel,
+          } as any,
+        });
+        if (!probe.ok) throw new Error(probe.error.message);
+        return `client-only targets=${probe.data.uploadTargets.length}, bytes=${probe.data.totalBytes}`;
+      });
+      await run("11. Transformation Preview read access", async () => {
+        if (!latestScanId) return "skipped: no latest scan";
+        const ref = doc(
+          db,
+          "users",
+          user.uid,
+          "transformationPreviews",
+          latestScanId
+        );
+        const snap = await getDoc(ref);
+        return `doc=${ref.path}, exists=${String(snap.exists())}`;
+      });
+    } finally {
+      setRunning(false);
+    }
   }
 
   if (!user) return <div className="p-6">Sign in required.</div>;
@@ -220,8 +199,12 @@ export default function LiveFlowsQA() {
         </CardHeader>
         <CardContent>
           <Button onClick={runAll} disabled={running}>
-            {running ? "Running…" : "Run all live-flow checks"}
+            {running ? "Running…" : "Run read-only live-flow checks"}
           </Button>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Read-only by default: no meals, workout plans, scan sessions,
+            credits, or paid AI calls are created by this check.
+          </p>
         </CardContent>
       </Card>
       <Card>

--- a/src/pages/LiveFlowsQA.tsx
+++ b/src/pages/LiveFlowsQA.tsx
@@ -1,17 +1,34 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useAuthUser, getIdToken } from "@/auth/mbs-auth";
 import { useClaims } from "@/lib/claims";
-import { doc, getDoc } from "firebase/firestore";
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  limit,
+  orderBy,
+  query,
+} from "firebase/firestore";
 import { db } from "@/lib/firebase";
 import { coachChatApi } from "@/lib/api/coach";
 import { nutritionSearch } from "@/lib/api/nutrition";
 import { addMeal, deleteMeal, getDailyLog } from "@/lib/nutritionBackend";
 import { getPlan, getWorkouts, applyCatalogPlan } from "@/lib/workouts";
-import { startScanSessionClient, validateScanUploadInputs } from "@/lib/api/scan";
+import {
+  startScanSessionClient,
+  validateScanUploadInputs,
+} from "@/lib/api/scan";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
-type Result = { name: string; ok: boolean; latencyMs: number; error: string; detail?: string };
+type Result = {
+  name: string;
+  ok: boolean;
+  latencyMs: number;
+  error: string;
+  detail?: string;
+};
 
 const todayISO = new Date().toISOString().slice(0, 10);
 
@@ -26,21 +43,51 @@ export default function LiveFlowsQA() {
   const { claims } = useClaims();
   const [results, setResults] = useState<Result[]>([]);
   const [running, setRunning] = useState(false);
+  const [latestScan, setLatestScan] = useState<any>(null);
 
   const allowed = useMemo(() => {
     const c = (claims || {}) as any;
-    return Boolean(c.admin || c.dev || c.staff || c.unlimited || c.unlimitedCredits);
+    return Boolean(
+      c.admin || c.dev || c.staff || c.unlimited || c.unlimitedCredits
+    );
   }, [claims]);
+
+  useEffect(() => {
+    if (!user || !allowed) return;
+    let cancelled = false;
+    async function loadLatestScan() {
+      const snap = await getDocs(
+        query(
+          collection(db, "users", user!.uid, "scans"),
+          orderBy("createdAt", "desc"),
+          limit(1)
+        )
+      ).catch(() => null);
+      if (cancelled || !snap || snap.empty) return;
+      const docSnap = snap.docs[0];
+      setLatestScan({ id: docSnap.id, ...docSnap.data() });
+    }
+    void loadLatestScan();
+    return () => {
+      cancelled = true;
+    };
+  }, [allowed, user]);
 
   async function run(name: string, fn: () => Promise<string | void>) {
     const started = performance.now();
     try {
       const detail = await fn();
       const latencyMs = Math.round(performance.now() - started);
-      setResults((prev) => [...prev, { name, ok: true, latencyMs, error: "", detail }]);
+      setResults((prev) => [
+        ...prev,
+        { name, ok: true, latencyMs, error: "", detail },
+      ]);
     } catch (error) {
       const latencyMs = Math.round(performance.now() - started);
-      setResults((prev) => [...prev, { name, ok: false, latencyMs, error: normalizeError(error) }]);
+      setResults((prev) => [
+        ...prev,
+        { name, ok: false, latencyMs, error: normalizeError(error) },
+      ]);
     }
   }
 
@@ -70,7 +117,9 @@ export default function LiveFlowsQA() {
       return `credits=${creditsSnap.data()?.creditsSummary?.totalAvailable ?? "na"}, pro=${Boolean(entSnap.data()?.pro)}`;
     });
     await run("4. coachChat callable", async () => {
-      const res = await coachChatApi({ message: "QA ping: respond with one short line." });
+      const res = await coachChatApi({
+        message: "QA ping: respond with one short line.",
+      });
       if (!res.replyText) throw new Error("empty_coach_reply");
       return res.replyText.slice(0, 60);
     });
@@ -84,7 +133,13 @@ export default function LiveFlowsQA() {
     });
     await run("7. addMeal callable", async () => {
       const meal = {
-        name: "QA Test Item (safe)", mealType: "snacks", calories: 10, protein: 0, carbs: 1, fat: 0, notes: "qa-live-flows",
+        name: "QA Test Item (safe)",
+        mealType: "snacks",
+        calories: 10,
+        protein: 0,
+        carbs: 1,
+        fat: 0,
+        notes: "qa-live-flows",
       };
       const res = await addMeal(todayISO, meal);
       testMealId = (res as any)?.meal?.id || null;
@@ -109,13 +164,23 @@ export default function LiveFlowsQA() {
         title: "QA Safe Plan",
         goal: "recomp",
         level: "beginner",
-        days: [{ day: "Mon", exercises: [{ name: "Bodyweight Squat", sets: 2, reps: "8" }] }],
+        days: [
+          {
+            day: "Mon",
+            exercises: [{ name: "Bodyweight Squat", sets: 2, reps: "8" }],
+          },
+        ],
       };
       const res = await applyCatalogPlan(payload as any);
       return `ok=${String(Boolean((res as any)?.ok ?? true))}`;
     });
     await run("12. startScanSession callable/http", async () => {
-      const res = await startScanSessionClient({ currentWeightKg: 70, goalWeightKg: 69, heightCm: 175, correlationId: `qa-${Date.now()}` });
+      const res = await startScanSessionClient({
+        currentWeightKg: 70,
+        goalWeightKg: 69,
+        heightCm: 175,
+        correlationId: `qa-${Date.now()}`,
+      });
       if (!res.ok) throw new Error(res.error.message || "start_scan_failed");
       scanId = res.data.scanId;
       return `scanId=${scanId}`;
@@ -123,7 +188,10 @@ export default function LiveFlowsQA() {
     await run("13. scan upload readiness (no credit consume)", async () => {
       if (!scanId) throw new Error("skipped_no_scan_session");
       const f = new File(["qa"], "qa.txt", { type: "text/plain" });
-      const probe = validateScanUploadInputs({ uid: user.uid, photos: { front: f, back: f, left: f, right: f } as any });
+      const probe = validateScanUploadInputs({
+        uid: user.uid,
+        photos: { front: f, back: f, left: f, right: f } as any,
+      });
       if (!probe.ok) throw new Error(probe.error.message);
       return `targets=${probe.data.uploadTargets.length}`;
     });
@@ -137,16 +205,106 @@ export default function LiveFlowsQA() {
   }
 
   if (!user) return <div className="p-6">Sign in required.</div>;
-  if (!allowed) return <div className="p-6">Internal QA access only (admin/dev/unlimited/staff).</div>;
+  if (!allowed)
+    return (
+      <div className="p-6">
+        Internal QA access only (admin/dev/unlimited/staff).
+      </div>
+    );
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
       <Card>
-        <CardHeader><CardTitle>Live Flow Diagnostics QA</CardTitle></CardHeader>
+        <CardHeader>
+          <CardTitle>Live Flow Diagnostics QA</CardTitle>
+        </CardHeader>
         <CardContent>
-          <Button onClick={runAll} disabled={running}>{running ? "Running…" : "Run all live-flow checks"}</Button>
+          <Button onClick={runAll} disabled={running}>
+            {running ? "Running…" : "Run all live-flow checks"}
+          </Button>
         </CardContent>
       </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Latest scan/result diagnostics</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 text-sm">
+          {latestScan ? (
+            <>
+              <div className="grid gap-2 md:grid-cols-2">
+                <div>scanId: {latestScan.id}</div>
+                <div>scan status: {String(latestScan.status ?? "unknown")}</div>
+                <div>
+                  AI processing status:{" "}
+                  {String(
+                    latestScan.aiProcessing?.status ??
+                      latestScan.lastStep ??
+                      "unknown"
+                  )}
+                </div>
+                <div>
+                  provider:{" "}
+                  {String(latestScan.aiProcessing?.provider ?? "unknown")}
+                </div>
+                <div>
+                  output source:{" "}
+                  {latestScan.usedFallback
+                    ? "fallback"
+                    : String(
+                        latestScan.resultSource ??
+                          (latestScan.status === "complete"
+                            ? "real/legacy"
+                            : "none")
+                      )}
+                </div>
+                <div>
+                  timeout/error code:{" "}
+                  {String(
+                    latestScan.errorReason ??
+                      latestScan.aiProcessing?.errorCode ??
+                      "none"
+                  )}
+                </div>
+                <div>
+                  credit status:{" "}
+                  {latestScan.refundedAt
+                    ? "refunded"
+                    : latestScan.charged
+                      ? "consumed/charged"
+                      : String(latestScan.creditStatus ?? "not charged")}
+                </div>
+                <div>
+                  completedAt:{" "}
+                  {String(
+                    latestScan.completedAt?.toDate?.()?.toISOString?.() ??
+                      latestScan.completedAt ??
+                      "none"
+                  )}
+                </div>
+              </div>
+              <details className="rounded-lg border p-3">
+                <summary className="cursor-pointer font-medium">
+                  Result document fields returned
+                </summary>
+                <pre className="mt-2 max-h-96 overflow-auto whitespace-pre-wrap text-xs">
+                  {JSON.stringify(
+                    latestScan,
+                    (_key, value) => {
+                      if (value && typeof value.toDate === "function")
+                        return value.toDate().toISOString();
+                      return value;
+                    },
+                    2
+                  )}
+                </pre>
+              </details>
+            </>
+          ) : (
+            <div>No scan document found yet.</div>
+          )}
+        </CardContent>
+      </Card>
+
       {results.map((r) => (
         <Card key={r.name}>
           <CardContent className="pt-4">

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -1,6 +1,14 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Sparkles, ArrowRight, Lock, Dumbbell, Apple, Flame } from "lucide-react";
+import {
+  Sparkles,
+  ArrowRight,
+  Lock,
+  Dumbbell,
+  Apple,
+  Flame,
+  RotateCcw,
+} from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Textarea } from "@/components/ui/textarea";
@@ -13,17 +21,18 @@ import { useLatestScanForUser } from "@/hooks/useLatestScanForUser";
 import { updateDoc } from "@/lib/dbWrite";
 import { doc, serverTimestamp } from "firebase/firestore";
 import { db } from "@/lib/firebase";
-import { extractScanMetrics } from "@/lib/scans";
-import { summarizeScanMetrics } from "@/lib/scanDisplay";
 import { DemoWriteButton } from "@/components/DemoWriteGuard";
 import { DemoBanner } from "@/components/DemoBanner";
 import { isDemo } from "@/lib/demoFlag";
 import { demoLatestScan } from "@/lib/demoDataset";
 import { scanStatusLabel } from "@/lib/scanStatus";
+import {
+  buildScanResultViewModel,
+  formatKgForUnits,
+} from "@/lib/scanResultViewModel";
+import { retryScanProcessingClient } from "@/lib/api/scan";
 import { useUnits } from "@/hooks/useUnits";
-import { kgToLb } from "@/lib/units";
 import { demoToast } from "@/lib/demoToast";
-import { deriveNutritionGoals } from "@/lib/nutritionGoals";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { hasPro } from "@/lib/entitlements/pro";
 import { useEntitlements } from "@/lib/entitlements/store";
@@ -62,7 +71,10 @@ const Results = () => {
     setSaving(true);
     try {
       const scanRef = doc(db, "users", user.uid, "scans", scan.id);
-      await updateDoc(scanRef, { note: note.trim(), noteUpdatedAt: serverTimestamp() });
+      await updateDoc(scanRef, {
+        note: note.trim(),
+        noteUpdatedAt: serverTimestamp(),
+      });
       toast({ title: "Note saved" });
     } catch {
       toast({ title: "Failed to save note", variant: "destructive" });
@@ -71,43 +83,44 @@ const Results = () => {
     }
   };
 
-  const metrics = extractScanMetrics(activeScan || {});
-  const summary = summarizeScanMetrics(metrics, units);
   const statusMeta = activeScan
-    ? scanStatusLabel(activeScan.status, activeScan.completedAt ?? activeScan.updatedAt ?? activeScan.createdAt)
+    ? scanStatusLabel(
+        activeScan.status,
+        activeScan.completedAt ?? activeScan.updatedAt ?? activeScan.createdAt
+      )
+    : null;
+  const vm = activeScan
+    ? buildScanResultViewModel({ scan: activeScan as any, profile, plan })
     : null;
 
-  const nutritionGoals = useMemo(
-    () =>
-      deriveNutritionGoals({
-        weightKg: profile?.weight_kg ?? null,
-        heightCm: profile?.height_cm ?? null,
-        age: profile?.age ?? null,
-        sex: profile?.sex ?? null,
-        goalWeightKg: profile?.goal_weight_kg ?? null,
-        goal:
-          profile?.goal === "lose_fat"
-            ? "lose_fat"
-            : profile?.goal === "gain_muscle"
-              ? "gain_muscle"
-              : null,
-        activityLevel: profile?.activity_level ?? null,
-        overrides: {
-          calories: plan?.calorieTarget,
-          proteinGrams: plan?.proteinFloor,
-        },
-      }),
-    [plan?.calorieTarget, plan?.proteinFloor, profile]
-  );
+  const onRetryProcessing = async () => {
+    if (!activeScan?.id || readOnlyDemo) return;
+    const result = await retryScanProcessingClient(activeScan.id);
+    if (result.ok) toast({ title: "Scan retry queued" });
+    else
+      toast({
+        title: "Unable to retry scan",
+        description: result.error.message,
+        variant: "destructive",
+      });
+  };
 
   if (!user && !demo && !loading) {
-    return <main className="min-h-screen p-6 max-w-md mx-auto"><Button onClick={() => navigate("/auth")}>Sign In</Button></main>;
+    return (
+      <main className="min-h-screen p-6 max-w-md mx-auto">
+        <Button onClick={() => navigate("/auth")}>Sign In</Button>
+      </main>
+    );
   }
 
   if (loading && !demo) {
     return (
       <main className="min-h-screen p-6 max-w-md mx-auto">
-        <Seo title="Results – MyBodyScan" description="Review scan results." canonical={window.location.href} />
+        <Seo
+          title="Results – MyBodyScan"
+          description="Review scan results."
+          canonical={window.location.href}
+        />
         <Skeleton className="h-40 w-full" />
       </main>
     );
@@ -116,108 +129,306 @@ const Results = () => {
   if (error || !activeScan) {
     return (
       <main className="min-h-screen p-6 max-w-md mx-auto space-y-4">
-        <Seo title="Results – MyBodyScan" description="Review scan results." canonical={window.location.href} />
+        <Seo
+          title="Results – MyBodyScan"
+          description="Review scan results."
+          canonical={window.location.href}
+        />
         <DemoBanner />
-        <Card><CardContent className="pt-6">Unable to load results.</CardContent></Card>
-        <Button onClick={() => navigate(readOnlyDemo ? "/auth" : "/scan/new")} className="w-full">
+        <Card>
+          <CardContent className="pt-6">Unable to load results.</CardContent>
+        </Card>
+        <Button
+          onClick={() => navigate(readOnlyDemo ? "/auth" : "/scan/new")}
+          className="w-full"
+        >
           {readOnlyDemo ? "Sign in to start" : "Start a Scan"}
         </Button>
       </main>
     );
   }
 
-  const leanMassKg = Number((activeScan as any)?.estimate?.leanMassKg ?? (activeScan as any)?.metrics?.leanMassKg);
-  const fatMassKg = Number((activeScan as any)?.estimate?.fatMassKg ?? (activeScan as any)?.metrics?.fatMassKg);
+  if (!vm) return null;
+
+  if (vm.isFailedOrFallback) {
+    return (
+      <main className="min-h-screen p-4 md:p-6 max-w-3xl mx-auto space-y-4">
+        <Seo
+          title="Scan recovery – MyBodyScan"
+          description="Recover a failed scan."
+          canonical={window.location.href}
+        />
+        <DemoBanner />
+        <Card className="border-destructive/30 bg-destructive/5">
+          <CardHeader>
+            <div className="flex items-center justify-between gap-2">
+              <CardTitle>{vm.failureTitle}</CardTitle>
+              <Badge variant="destructive">{vm.sourceLabel}</Badge>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-4 text-sm">
+            <p>{vm.failureMessage}</p>
+            <div className="rounded-lg border bg-background/80 p-3 text-xs text-muted-foreground">
+              status={activeScan.status || "unknown"} · provider=
+              {vm.diagnostics.provider || "unknown"} · error=
+              {vm.diagnostics.errorCode || "none"} · credit=
+              {vm.diagnostics.refunded
+                ? "refunded"
+                : vm.diagnostics.charged
+                  ? "charged"
+                  : "not charged"}
+            </div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <Button onClick={onRetryProcessing} disabled={readOnlyDemo}>
+                <RotateCcw className="mr-2 h-4 w-4" />
+                Retry processing
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => navigate(readOnlyDemo ? "/auth" : "/scan/new")}
+              >
+                Re-upload scan
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
 
   return (
     <main className="min-h-screen p-4 md:p-6 max-w-3xl mx-auto space-y-4">
-      <Seo title="Results – MyBodyScan" description="Premium body composition results." canonical={window.location.href} />
+      <Seo
+        title="Your Body Scan – MyBodyScan"
+        description="Premium body composition results."
+        canonical={window.location.href}
+      />
       <DemoBanner />
 
       <Card className="bg-gradient-to-b from-zinc-900 via-zinc-950 to-black border-zinc-800 text-zinc-100">
         <CardHeader>
           <div className="flex items-center justify-between gap-2">
-            <CardTitle className="text-xl">Scan Results</CardTitle>
-            <Badge variant={statusMeta?.badgeVariant}>{statusMeta?.label}</Badge>
+            <div>
+              <CardTitle className="text-xl">Your Body Scan</CardTitle>
+              <p className="text-xs text-zinc-400 mt-1">
+                {formatDate(activeScan.completedAt || activeScan.createdAt)} ·{" "}
+                {vm.sourceLabel}
+              </p>
+            </div>
+            <Badge variant={statusMeta?.badgeVariant}>
+              {statusMeta?.label}
+            </Badge>
           </div>
-          <p className="text-xs text-zinc-400">{formatDate(activeScan.completedAt || activeScan.createdAt)}</p>
         </CardHeader>
         <CardContent className="space-y-4">
-          {statusMeta?.showMetrics ? (
+          {vm.isValidResult ? (
             <>
-              <div className="grid grid-cols-3 gap-2">
-                <Card className="bg-zinc-900/70 border-zinc-800"><CardContent className="py-4 text-center"><div className="text-2xl font-semibold">{summary.bodyFatPercent != null ? `${summary.bodyFatPercent.toFixed(1)}%` : "—"}</div><div className="text-xs text-zinc-400">Body Fat</div></CardContent></Card>
-                <Card className="bg-zinc-900/70 border-zinc-800"><CardContent className="py-4 text-center"><div className="text-2xl font-semibold">{summary.weightText}</div><div className="text-xs text-zinc-400">Weight</div></CardContent></Card>
-                <Card className="bg-zinc-900/70 border-zinc-800"><CardContent className="py-4 text-center"><div className="text-2xl font-semibold">{summary.bmiText}</div><div className="text-xs text-zinc-400">BMI</div></CardContent></Card>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                <Card className="bg-zinc-900/70 border-zinc-800">
+                  <CardContent className="py-4 text-center">
+                    <div className="text-2xl font-semibold">
+                      {vm.primary.bodyFatPercent != null
+                        ? `${vm.primary.bodyFatPercent.toFixed(1)}%`
+                        : "—"}
+                    </div>
+                    <div className="text-xs text-zinc-400">Est. body fat</div>
+                  </CardContent>
+                </Card>
+                <Card className="bg-zinc-900/70 border-zinc-800">
+                  <CardContent className="py-4 text-center">
+                    <div className="text-2xl font-semibold">
+                      {formatKgForUnits(vm.primary.weightKg, units)}
+                    </div>
+                    <div className="text-xs text-zinc-400">Weight</div>
+                  </CardContent>
+                </Card>
+                <Card className="bg-zinc-900/70 border-zinc-800">
+                  <CardContent className="py-4 text-center">
+                    <div className="text-2xl font-semibold">
+                      {vm.primary.bmi ?? "—"}
+                    </div>
+                    <div className="text-xs text-zinc-400">BMI</div>
+                  </CardContent>
+                </Card>
+                <Card className="bg-zinc-900/70 border-zinc-800">
+                  <CardContent className="py-4 text-center">
+                    <div className="text-2xl font-semibold">
+                      {formatKgForUnits(vm.primary.leanMassKg, units)}
+                    </div>
+                    <div className="text-xs text-zinc-400">Lean mass</div>
+                  </CardContent>
+                </Card>
               </div>
-
-              <div className="grid sm:grid-cols-2 gap-2 text-sm">
-                <Card className="bg-zinc-900/60 border-zinc-800"><CardContent className="py-3">Lean mass: {Number.isFinite(leanMassKg) ? (units === "us" ? `${kgToLb(leanMassKg).toFixed(1)} lb` : `${leanMassKg.toFixed(1)} kg`) : "—"}</CardContent></Card>
-                <Card className="bg-zinc-900/60 border-zinc-800"><CardContent className="py-3">Fat mass: {Number.isFinite(fatMassKg) ? (units === "us" ? `${kgToLb(fatMassKg).toFixed(1)} lb` : `${fatMassKg.toFixed(1)} kg`) : "—"}</CardContent></Card>
-              </div>
+              <p className="text-xs text-zinc-400">
+                {vm.primary.goalProgressText}
+              </p>
             </>
           ) : (
-            <p className="text-sm text-zinc-400">{statusMeta?.helperText || "Your scan is processing."}</p>
+            <p className="text-sm text-zinc-400">
+              {statusMeta?.helperText || "Your scan is processing."}
+            </p>
           )}
         </CardContent>
       </Card>
 
-      {statusMeta?.showMetrics && (
+      {vm.isValidResult && (
         <Card className="border-zinc-800 bg-zinc-950/70">
           <CardHeader>
-            <CardTitle className="text-base text-zinc-100">Transformation Preview</CardTitle>
+            <CardTitle className="text-base text-zinc-100">
+              Transformation Preview
+            </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm text-zinc-300">
             <div className="flex items-start gap-3">
               <Sparkles className="h-4 w-4 mt-0.5 text-primary" />
               <p>
-                Realistic premium projection based on your scan metrics, goal timeline, and current program. Same person, same look, same context.
+                See a realistic motivational visualization of your goal physique
+                once your scan and plan are ready.
               </p>
             </div>
             <Button
               className="w-full"
-              onClick={() => navigate(`/results/${activeScan.id}/transformation-preview`)}
+              onClick={() =>
+                navigate(`/results/${activeScan.id}/transformation-preview`)
+              }
               variant={pro ? "default" : "secondary"}
             >
-              {pro ? "Open Transformation Preview" : "Unlock Transformation Preview"}
-              {pro ? <ArrowRight className="ml-2 h-4 w-4" /> : <Lock className="ml-2 h-4 w-4" />}
+              {pro ? "Open not-ready preview" : "Unlock Transformation Preview"}
+              {pro ? (
+                <ArrowRight className="ml-2 h-4 w-4" />
+              ) : (
+                <Lock className="ml-2 h-4 w-4" />
+              )}
             </Button>
-            <p className="text-xs text-zinc-500">Motivational projection. Not a medical prediction.</p>
+            <p className="text-xs text-zinc-500">
+              Premium scaffold only — no generated image until scan reliability
+              is proven.
+            </p>
           </CardContent>
         </Card>
       )}
 
-      {statusMeta?.showMetrics && (
+      {vm.isValidResult && (
         <Card>
-          <CardHeader><CardTitle className="text-base">Plan summary</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle className="text-base">Nutrition targets</CardTitle>
+          </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
-              <div className="rounded-md border p-3"><div className="flex items-center gap-2"><Flame className="h-4 w-4" />Calories</div><div className="text-lg font-semibold">{nutritionGoals.calories ?? "—"}</div></div>
-              <div className="rounded-md border p-3"><div className="flex items-center gap-2"><Dumbbell className="h-4 w-4" />Protein</div><div className="text-lg font-semibold">{nutritionGoals.proteinGrams ?? "—"}g</div></div>
-              <div className="rounded-md border p-3"><div className="flex items-center gap-2"><Apple className="h-4 w-4" />Carb/Fat</div><div className="text-lg font-semibold">{nutritionGoals.carbsGrams ?? 0}g / {nutritionGoals.fatGrams ?? 0}g</div></div>
+              <div className="rounded-md border p-3">
+                <div className="flex items-center gap-2">
+                  <Flame className="h-4 w-4" />
+                  Calories
+                </div>
+                <div className="text-lg font-semibold">
+                  {vm.nutrition.calories ?? "—"} kcal
+                </div>
+              </div>
+              <div className="rounded-md border p-3">
+                <div className="flex items-center gap-2">
+                  <Dumbbell className="h-4 w-4" />
+                  Protein
+                </div>
+                <div className="text-lg font-semibold">
+                  {vm.nutrition.proteinGrams ?? "—"}g
+                </div>
+              </div>
+              <div className="rounded-md border p-3">
+                <div className="flex items-center gap-2">
+                  <Apple className="h-4 w-4" />
+                  Carbs / fats
+                </div>
+                <div className="text-lg font-semibold">
+                  {vm.nutrition.carbsGrams ?? "—"}g /{" "}
+                  {vm.nutrition.fatsGrams ?? "—"}g
+                </div>
+              </div>
             </div>
-            {activeScan.planMarkdown ? <pre className="whitespace-pre-wrap text-xs text-muted-foreground">{activeScan.planMarkdown}</pre> : null}
           </CardContent>
         </Card>
       )}
 
-      {statusMeta?.showMetrics && (
+      {vm.isValidResult && (
         <Card>
-          <CardHeader><CardTitle className="text-base">Notes</CardTitle></CardHeader>
+          <CardHeader>
+            <CardTitle className="text-base">Recommended plan</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <p className="font-medium">{vm.plan.summary}</p>
+            {vm.plan.setupNeeded ? (
+              <Button
+                variant="outline"
+                onClick={() => navigate("/coach/onboarding")}
+              >
+                Complete plan setup
+              </Button>
+            ) : (
+              <Button variant="outline" onClick={() => navigate("/programs")}>
+                View full plan
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {vm.isValidResult && (
+        <Card>
+          <CardContent className="pt-6 text-sm">
+            Next scan: rescan in 10 days under similar lighting and time of day.
+          </CardContent>
+        </Card>
+      )}
+
+      {vm.isValidResult && (
+        <details className="rounded-lg border bg-card p-4 text-sm">
+          <summary className="cursor-pointer font-medium">
+            View full report
+          </summary>
+          <pre className="mt-3 whitespace-pre-wrap text-xs text-muted-foreground">
+            {activeScan.planMarkdown || "Detailed report unavailable."}
+          </pre>
+        </details>
+      )}
+
+      {vm.isValidResult && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Notes</CardTitle>
+          </CardHeader>
           <CardContent className="space-y-2">
-            <Textarea value={note} onChange={(e) => setNote(e.target.value)} placeholder="Add context for your next check-in..." />
-            <DemoWriteButton onClick={onSaveNote} disabled={!note.trim() || saving || readOnlyDemo} className="w-full">
+            <Textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Add context for your next check-in..."
+            />
+            <DemoWriteButton
+              onClick={onSaveNote}
+              disabled={!note.trim() || saving || readOnlyDemo}
+              className="w-full"
+            >
               {saving ? "Saving..." : "Save Note"}
             </DemoWriteButton>
           </CardContent>
         </Card>
       )}
 
+      <p className="text-xs text-muted-foreground">
+        Fitness estimates only. Not medical advice.
+      </p>
       <Separator />
       <div className="grid gap-2 sm:grid-cols-3">
-        <Button variant="secondary" onClick={() => navigate("/")}>Home</Button>
-        <Button variant="secondary" onClick={() => navigate("/history")}>History</Button>
-        <Button variant="outline" onClick={() => (readOnlyDemo ? demoToast() : navigate("/scan/new"))}>New Scan</Button>
+        <Button variant="secondary" onClick={() => navigate("/")}>
+          Home
+        </Button>
+        <Button variant="secondary" onClick={() => navigate("/history")}>
+          History
+        </Button>
+        <Button
+          variant="outline"
+          onClick={() => (readOnlyDemo ? demoToast() : navigate("/scan/new"))}
+        >
+          New Scan
+        </Button>
       </div>
     </main>
   );

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -36,6 +36,7 @@ import { demoToast } from "@/lib/demoToast";
 import { useUserProfile } from "@/hooks/useUserProfile";
 import { hasPro } from "@/lib/entitlements/pro";
 import { useEntitlements } from "@/lib/entitlements/store";
+import { TRANSFORMATION_PREVIEW_ENTRY_ENABLED } from "@/lib/flags";
 
 const formatDate = (timestamp: any) => {
   if (!timestamp) return "—";
@@ -92,6 +93,10 @@ const Results = () => {
   const vm = activeScan
     ? buildScanResultViewModel({ scan: activeScan as any, profile, plan })
     : null;
+  const paidScanPreviewEligible = Boolean((activeScan as any)?.charged);
+  const previewEligible = pro || paidScanPreviewEligible;
+  const showTransformationPreviewEntry =
+    TRANSFORMATION_PREVIEW_ENTRY_ENABLED && vm?.isValidResult;
 
   const onRetryProcessing = async () => {
     if (!activeScan?.id || readOnlyDemo) return;
@@ -168,16 +173,11 @@ const Results = () => {
           </CardHeader>
           <CardContent className="space-y-4 text-sm">
             <p>{vm.failureMessage}</p>
-            <div className="rounded-lg border bg-background/80 p-3 text-xs text-muted-foreground">
-              status={activeScan.status || "unknown"} · provider=
-              {vm.diagnostics.provider || "unknown"} · error=
-              {vm.diagnostics.errorCode || "none"} · credit=
-              {vm.diagnostics.refunded
-                ? "refunded"
-                : vm.diagnostics.charged
-                  ? "charged"
-                  : "not charged"}
-            </div>
+            {vm.diagnostics.refunded ? (
+              <div className="rounded-lg border bg-background/80 p-3 text-sm text-muted-foreground">
+                Your scan credit has been returned.
+              </div>
+            ) : null}
             <div className="grid gap-2 sm:grid-cols-2">
               <Button onClick={onRetryProcessing} disabled={readOnlyDemo}>
                 <RotateCcw className="mr-2 h-4 w-4" />
@@ -271,7 +271,7 @@ const Results = () => {
         </CardContent>
       </Card>
 
-      {vm.isValidResult && (
+      {showTransformationPreviewEntry && (
         <Card className="border-zinc-800 bg-zinc-950/70">
           <CardHeader>
             <CardTitle className="text-base text-zinc-100">
@@ -291,18 +291,20 @@ const Results = () => {
               onClick={() =>
                 navigate(`/results/${activeScan.id}/transformation-preview`)
               }
-              variant={pro ? "default" : "secondary"}
+              variant={previewEligible ? "default" : "secondary"}
             >
-              {pro ? "Open not-ready preview" : "Unlock Transformation Preview"}
-              {pro ? (
+              {previewEligible
+                ? "Open Transformation Preview"
+                : "Unlock Transformation Preview"}
+              {previewEligible ? (
                 <ArrowRight className="ml-2 h-4 w-4" />
               ) : (
                 <Lock className="ml-2 h-4 w-4" />
               )}
             </Button>
             <p className="text-xs text-zinc-500">
-              Premium scaffold only — no generated image until scan reliability
-              is proven.
+              Motivational visualization availability depends on scan
+              eligibility.
             </p>
           </CardContent>
         </Card>

--- a/src/pages/ScanResult.tsx
+++ b/src/pages/ScanResult.tsx
@@ -18,16 +18,24 @@ import { Seo } from "@/components/Seo";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { Separator } from "@/components/ui/separator";
 import { useUnits } from "@/hooks/useUnits";
-import { formatHeightFromCm, formatWeight, formatWeightFromKg, kgToLb } from "@/lib/units";
 import { useAuthUser } from "@/auth/mbs-auth";
 import { useUserProfile } from "@/hooks/useUserProfile";
-import { deriveNutritionGoals } from "@/lib/nutritionGoals";
-import { collection, doc, getDocs, limit, onSnapshot, orderBy, query } from "firebase/firestore";
+import {
+  buildScanResultViewModel,
+  formatKgForUnits,
+} from "@/lib/scanResultViewModel";
+import {
+  collection,
+  doc,
+  getDocs,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+} from "firebase/firestore";
 import { db, storage } from "@/lib/firebase";
 import { getCachedScanPhotoUrlMaybe } from "@/lib/storage/photoUrlCache";
-import silhouetteFront from "@/assets/silhouette-front.png";
 import {
   describeScanPipelineStage,
   readScanPipelineState,
@@ -35,7 +43,10 @@ import {
   type ScanPipelineState,
 } from "@/lib/scanPipeline";
 import { useAppCheckStatus } from "@/hooks/useAppCheckStatus";
-import { computeProcessingTimeouts, latestHeartbeatMillis } from "@/lib/scanHeartbeat";
+import {
+  computeProcessingTimeouts,
+  latestHeartbeatMillis,
+} from "@/lib/scanHeartbeat";
 import { mark, measure, flush as flushPerf } from "@/lib/scan/perf";
 
 const LONG_PROCESSING_WARNING_MS = 3 * 60 * 1000;
@@ -62,7 +73,9 @@ export default function ScanResultPage() {
     Partial<Record<keyof ScanDocument["photoPaths"], string>>
   >({});
   const [photoUrlRetryTick, setPhotoUrlRetryTick] = useState(0);
-  const photoUrlRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const photoUrlRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
   const loggedPhotoUrlErrorRef = useRef<Record<string, true>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -205,7 +218,9 @@ export default function ScanResultPage() {
         if (cancelled) return;
         setDocStatus({
           exists: snap.exists(),
-          fields: snap.exists() ? Object.keys(snap.data() as Record<string, unknown>) : [],
+          fields: snap.exists()
+            ? Object.keys(snap.data() as Record<string, unknown>)
+            : [],
         });
         if (!snap.exists()) return;
         const next = deserializeScanDocument(snap.id, uid, snap.data() as any);
@@ -262,11 +277,15 @@ export default function ScanResultPage() {
     }
     if (normalized === "processing" || normalized === "in_progress") {
       mark("processing_seen", { scanId });
-      measure("queued_to_processing", "queued_seen", "processing_seen", { scanId });
+      measure("queued_to_processing", "queued_seen", "processing_seen", {
+        scanId,
+      });
     }
     if (normalized === "complete" || normalized === "completed") {
       mark("complete_seen", { scanId });
-      measure("processing_to_complete", "processing_seen", "complete_seen", { scanId });
+      measure("processing_to_complete", "processing_seen", "complete_seen", {
+        scanId,
+      });
       void flushPerf();
     }
   }, [scan, scanId]);
@@ -351,7 +370,11 @@ export default function ScanResultPage() {
     if (!showLongProcessing) return;
     if (autoRetry.attempted) return;
     if (typeof navigator !== "undefined" && navigator.onLine === false) return;
-    if (typeof document !== "undefined" && document.visibilityState === "hidden") return;
+    if (
+      typeof document !== "undefined" &&
+      document.visibilityState === "hidden"
+    )
+      return;
     setAutoRetry({ attempted: true, status: "running" });
     retryScanProcessingClient(scanId)
       .then((result) => {
@@ -373,7 +396,10 @@ export default function ScanResultPage() {
         setAutoRetry({
           attempted: true,
           status: "fail",
-          message: typeof (err as any)?.message === "string" ? (err as any).message : "Retry failed.",
+          message:
+            typeof (err as any)?.message === "string"
+              ? (err as any).message
+              : "Retry failed.",
         });
       });
   }, [autoRetry.attempted, needsRefresh, scanId, showLongProcessing]);
@@ -396,9 +422,13 @@ export default function ScanResultPage() {
         next.status === "failed";
       if (!canResolve) return;
       const paths = next.photoPaths;
-      const entries = (Object.entries(paths) as Array<
-        [keyof ScanDocument["photoPaths"], string]
-      >).filter(([, path]) => typeof path === "string" && path.trim().length > 0);
+      const entries = (
+        Object.entries(paths) as Array<
+          [keyof ScanDocument["photoPaths"], string]
+        >
+      ).filter(
+        ([, path]) => typeof path === "string" && path.trim().length > 0
+      );
       if (!entries.length) {
         setPhotoUrls({});
         return;
@@ -411,13 +441,24 @@ export default function ScanResultPage() {
       const resolved = await Promise.all(
         toFetch.map(async ([pose, path]) => {
           const cacheKey = `${scanKey}:${pose}`;
-          const outcome = await getCachedScanPhotoUrlMaybe(storage, path, cacheKey);
+          const outcome = await getCachedScanPhotoUrlMaybe(
+            storage,
+            path,
+            cacheKey
+          );
           if (outcome.url) {
-            return { pose, url: outcome.url, nextRetryAt: null as number | null };
+            return {
+              pose,
+              url: outcome.url,
+              nextRetryAt: null as number | null,
+            };
           }
           const storageErrorCode = outcome.errorCode;
           const httpStatus = outcome.httpStatus;
-          const retryAt = typeof outcome.nextRetryAt === "number" ? outcome.nextRetryAt : null;
+          const retryAt =
+            typeof outcome.nextRetryAt === "number"
+              ? outcome.nextRetryAt
+              : null;
 
           // One-line diagnostics (no spam): log only once per scan+pose when it's not a simple "not found yet".
           const logKey = `${scanKey}:${pose}`;
@@ -445,14 +486,18 @@ export default function ScanResultPage() {
       if (cancelled) return;
       let earliestRetryAt: number | null = null;
       setPhotoUrls((prev) => {
-        const nextUrls: Partial<Record<keyof ScanDocument["photoPaths"], string>> = {
+        const nextUrls: Partial<
+          Record<keyof ScanDocument["photoPaths"], string>
+        > = {
           ...prev,
         };
         for (const item of resolved) {
           if (item.url) nextUrls[item.pose] = item.url;
           if (typeof item.nextRetryAt === "number") {
             earliestRetryAt =
-              earliestRetryAt == null ? item.nextRetryAt : Math.min(earliestRetryAt, item.nextRetryAt);
+              earliestRetryAt == null
+                ? item.nextRetryAt
+                : Math.min(earliestRetryAt, item.nextRetryAt);
           }
         }
         return nextUrls;
@@ -554,10 +599,17 @@ export default function ScanResultPage() {
     scan.completedAt ?? scan.updatedAt ?? scan.createdAt
   );
   const lastUpdateAt =
-    scan.lastStepAt ?? scan.processingHeartbeatAt ?? scan.updatedAt ?? scan.createdAt;
+    scan.lastStepAt ??
+    scan.processingHeartbeatAt ??
+    scan.updatedAt ??
+    scan.createdAt;
   const lastUpdateLabel = lastUpdateAt ? formatDateTime(lastUpdateAt) : null;
 
-  if (statusMeta.canonical === "error" || statusMeta.recommendRescan) {
+  if (
+    statusMeta.recommendRescan &&
+    scan.status !== "error" &&
+    scan.status !== "failed"
+  ) {
     const canResume =
       scan.status === "uploaded" ||
       scan.status === "pending" ||
@@ -644,7 +696,8 @@ export default function ScanResultPage() {
                   : PROCESSING_STEPS[processingStepIdx]}
               </p>
               <p className="text-xs text-muted-foreground">
-                We’ll keep updating automatically. If your connection changed, we’ll recover when you’re back online.
+                We’ll keep updating automatically. If your connection changed,
+                we’ll recover when you’re back online.
               </p>
             </div>
             {autoRetry.status !== "idle" ? (
@@ -667,13 +720,20 @@ export default function ScanResultPage() {
 
             {hardProcessingTimeout ? (
               <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3">
-                <p className="text-sm font-medium">This scan is taking too long</p>
+                <p className="text-sm font-medium">
+                  This scan is taking too long
+                </p>
                 <p className="mt-1 text-xs text-muted-foreground">
-                  We won’t keep you stuck here. You can retry processing without re-uploading.
+                  We won’t keep you stuck here. You can retry processing without
+                  re-uploading.
                 </p>
                 <div className="mt-2 space-y-1 text-xs text-muted-foreground">
-                  {scan.lastStep ? <div>Last stage: {scan.lastStep}</div> : null}
-                  {lastUpdateLabel ? <div>Last update: {lastUpdateLabel}</div> : null}
+                  {scan.lastStep ? (
+                    <div>Last stage: {scan.lastStep}</div>
+                  ) : null}
+                  {lastUpdateLabel ? (
+                    <div>Last update: {lastUpdateLabel}</div>
+                  ) : null}
                   {scan.errorInfo?.message ? (
                     <div>Last error: {scan.errorInfo.message}</div>
                   ) : null}
@@ -720,8 +780,12 @@ export default function ScanResultPage() {
                   If needed, we can restart processing without re-uploading.
                 </p>
                 <div className="mt-2 space-y-1 text-xs text-muted-foreground">
-                  {scan.lastStep ? <div>Current stage: {scan.lastStep}</div> : null}
-                  {lastUpdateLabel ? <div>Last update: {lastUpdateLabel}</div> : null}
+                  {scan.lastStep ? (
+                    <div>Current stage: {scan.lastStep}</div>
+                  ) : null}
+                  {lastUpdateLabel ? (
+                    <div>Last update: {lastUpdateLabel}</div>
+                  ) : null}
                 </div>
                 <div className="mt-3 flex flex-wrap gap-2">
                   <Button
@@ -746,7 +810,11 @@ export default function ScanResultPage() {
                   >
                     Retry processing
                   </Button>
-                  <Button type="button" variant="outline" onClick={() => nav("/scan")}>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => nav("/scan")}
+                  >
                     Back to Scan
                   </Button>
                   <Button
@@ -802,7 +870,9 @@ export default function ScanResultPage() {
                 {scanId}
               </div>
               <div>
-                <span className="font-medium text-foreground">correlationId:</span>{" "}
+                <span className="font-medium text-foreground">
+                  correlationId:
+                </span>{" "}
                 {scan.correlationId ?? pipelineState?.correlationId ?? "—"}
               </div>
               <div>
@@ -814,7 +884,9 @@ export default function ScanResultPage() {
                   : "—"}
               </div>
               <div>
-                <span className="font-medium text-foreground">scan status:</span>{" "}
+                <span className="font-medium text-foreground">
+                  scan status:
+                </span>{" "}
                 {scan.status}
               </div>
               <div>
@@ -822,15 +894,21 @@ export default function ScanResultPage() {
                 {scan.lastStep ?? "—"}
               </div>
               <div>
-                <span className="font-medium text-foreground">last step at:</span>{" "}
+                <span className="font-medium text-foreground">
+                  last step at:
+                </span>{" "}
                 {scan.lastStepAt ? formatDateTime(scan.lastStepAt) : "—"}
               </div>
               <div>
-                <span className="font-medium text-foreground">scan progress:</span>{" "}
+                <span className="font-medium text-foreground">
+                  scan progress:
+                </span>{" "}
                 {typeof scan.progress === "number" ? `${scan.progress}%` : "—"}
               </div>
               <div>
-                <span className="font-medium text-foreground">last update:</span>{" "}
+                <span className="font-medium text-foreground">
+                  last update:
+                </span>{" "}
                 {lastUpdateLabel ?? "—"}
               </div>
               {scan.errorInfo ? (
@@ -839,7 +917,9 @@ export default function ScanResultPage() {
                 </pre>
               ) : null}
               <div>
-                <span className="font-medium text-foreground">pipeline timestamps:</span>{" "}
+                <span className="font-medium text-foreground">
+                  pipeline timestamps:
+                </span>{" "}
                 {pipelineState
                   ? `created=${new Date(
                       pipelineState.createdAt
@@ -859,7 +939,9 @@ export default function ScanResultPage() {
                 {appCheckStatus.message ? ` · ${appCheckStatus.message}` : ""}
               </div>
               <div>
-                <span className="font-medium text-foreground">firestore doc:</span>{" "}
+                <span className="font-medium text-foreground">
+                  firestore doc:
+                </span>{" "}
                 {docStatus.exists == null
                   ? "unknown"
                   : docStatus.exists
@@ -867,7 +949,9 @@ export default function ScanResultPage() {
                     : "missing"}
               </div>
               <div>
-                <span className="font-medium text-foreground">storage bucket:</span>{" "}
+                <span className="font-medium text-foreground">
+                  storage bucket:
+                </span>{" "}
                 {String(storage.app?.options?.storageBucket || "—")}
               </div>
               {docStatus.fields.length ? (
@@ -900,648 +984,261 @@ export default function ScanResultPage() {
     );
   }
 
-  const displayName =
-    (typeof user?.displayName === "string" && user.displayName.trim()) ||
-    (typeof user?.email === "string" && user.email.includes("@")
-      ? user.email.split("@")[0]
-      : null) ||
-    "You";
+  const resultVm = buildScanResultViewModel({ scan, profile, plan });
+  const retryProcessing = () => {
+    setLoading(true);
+    retryScanProcessingClient(scanId)
+      .then((result) => {
+        setLoading(false);
+        if (result.ok) return;
+        setError(result.error.message);
+      })
+      .catch((err) => {
+        setLoading(false);
+        setError(
+          typeof (err as any)?.message === "string"
+            ? (err as any).message
+            : "Retry failed."
+        );
+      });
+  };
 
-  const sex =
-    profile?.sex === "male" || profile?.sex === "female"
-      ? profile.sex
-      : profile?.sex === "unspecified" || profile?.sex === "other"
-        ? profile.sex
-        : null;
-  const age =
-    typeof profile?.age === "number" && Number.isFinite(profile.age)
-      ? profile.age
-      : null;
-
-  const weightKg =
-    typeof scan.input?.currentWeightKg === "number" &&
-    Number.isFinite(scan.input.currentWeightKg)
-      ? scan.input.currentWeightKg
-      : typeof profile?.weight_kg === "number" && Number.isFinite(profile.weight_kg)
-        ? profile.weight_kg
-        : null;
-  const heightCm =
-    typeof profile?.height_cm === "number" && Number.isFinite(profile.height_cm)
-      ? profile.height_cm
-      : null;
-
-  const bfPct =
-    typeof scan.estimate?.bodyFatPercent === "number" &&
-    Number.isFinite(scan.estimate.bodyFatPercent)
-      ? scan.estimate.bodyFatPercent
-      : null;
-
-  const fatMassKg =
-    weightKg != null && bfPct != null ? (weightKg * bfPct) / 100 : null;
-  const leanMassKg =
-    weightKg != null && fatMassKg != null ? weightKg - fatMassKg : null;
-
-  const skeletalMuscleKg =
-    leanMassKg != null ? Math.max(0, leanMassKg * 0.52) : null;
-  const totalBodyWaterKg =
-    leanMassKg != null ? Math.max(0, leanMassKg * 0.73) : null;
-  const totalBodyWaterPct =
-    totalBodyWaterKg != null && weightKg != null && weightKg > 0
-      ? (totalBodyWaterKg / weightKg) * 100
-      : null;
-
-  const goalLabel = (() => {
-    const goal = profile?.goal;
-    if (goal === "lose_fat") return "Fat loss";
-    if (goal === "gain_muscle") return "Muscle gain";
-    if (goal === "improve_heart") return "Improve health";
-    return "Maintain";
-  })();
-
-  const computedGoals = deriveNutritionGoals({
-    weightKg: weightKg ?? null,
-    bodyFatPercent: bfPct ?? null,
-    goalWeightKg: scan.input?.goalWeightKg ?? null,
-    goal:
-      profile?.goal === "lose_fat"
-        ? "lose_fat"
-        : profile?.goal === "gain_muscle"
-          ? "gain_muscle"
-          : null,
-    activityLevel: profile?.activity_level ?? null,
-    sex,
-    age,
-    heightCm,
-    overrides: {
-      calories:
-        typeof plan?.calorieTarget === "number" && Number.isFinite(plan.calorieTarget)
-          ? plan.calorieTarget
-          : undefined,
-      proteinGrams:
-        typeof plan?.proteinFloor === "number" && Number.isFinite(plan.proteinFloor)
-          ? plan.proteinFloor
-          : undefined,
-    },
-  });
-
-  const bmiValue =
-    heightCm != null && weightKg != null
-      ? Number((weightKg / Math.pow(heightCm / 100, 2)).toFixed(1))
-      : null;
-
-  const workoutPlan = scan.workoutPlan?.weeks?.length
-    ? scan.workoutPlan
-    : buildFallbackWorkoutPlan();
-  const weeksToShow = workoutPlan.weeks.slice(0, 1);
-  const hasMoreWeeks = workoutPlan.weeks.length > 1;
-  const progressionRules =
-    Array.isArray(workoutPlan.progressionRules) &&
-    workoutPlan.progressionRules.length
-      ? workoutPlan.progressionRules
-      : [
-          "Add 1–2 reps per set each week until you hit the top of the rep range.",
-          "When all sets hit the top range, increase load 2–5% next week.",
-          "Keep 1–2 reps in reserve on compounds; push accessories closer to failure.",
-          "Deload every 4–6 weeks by cutting volume in half.",
-        ];
-
-  const nutritionPlan = scan.nutritionPlan
-    ? {
-        ...scan.nutritionPlan,
-        adjustmentRules: Array.isArray(scan.nutritionPlan.adjustmentRules)
-          ? scan.nutritionPlan.adjustmentRules
-          : [],
-        sampleDay: Array.isArray(scan.nutritionPlan.sampleDay)
-          ? scan.nutritionPlan.sampleDay
-          : [],
-      }
-    : {
-        caloriesPerDay: Math.round(computedGoals.calories),
-        proteinGrams: Math.round(computedGoals.proteinGrams),
-        carbsGrams: Math.round(computedGoals.carbsGrams),
-        fatsGrams: Math.round(computedGoals.fatGrams),
-        adjustmentRules: [
-          "If weight change is <0.25 kg/week, drop 150–200 kcal.",
-          "If losing >1% body weight/week, add 150–200 kcal.",
-          "Keep protein constant; adjust carbs/fats first.",
-        ],
-        sampleDay: [],
-      };
-
-  const bodyAge = (() => {
-    if (age == null || bfPct == null) return null;
-    const ideal =
-      sex === "female" ? 26 : sex === "male" ? 18 : 22;
-    const delta = clampNumber((bfPct - ideal) * 0.4, -6, 12);
-    return Math.round(age + delta);
-  })();
-
-  const bodyScore = (() => {
-    // A simple 0–10 score: rewards lower BF% and higher lean mass vs weight.
-    if (weightKg == null || bfPct == null || leanMassKg == null) return null;
-    const bfScore =
-      sex === "female"
-        ? mapToScore(18, 34, bfPct, true)
-        : mapToScore(10, 26, bfPct, true);
-    const leanRatio = leanMassKg / weightKg;
-    const leanScore = mapToScore(0.62, 0.82, leanRatio, false);
-    return clampNumber(Math.round(((bfScore + leanScore) / 2) * 10) / 10, 0, 10);
-  })();
-
-  const recommendations =
-    Array.isArray(scan.recommendations) && scan.recommendations.length
-      ? scan.recommendations
-      : defaultRecommendations(computedGoals);
-
-  const improvementAreas =
-    Array.isArray(scan.improvementAreas) && scan.improvementAreas.length
-      ? scan.improvementAreas
-      : Array.isArray(scan.estimate?.keyObservations) && scan.estimate.keyObservations.length
-        ? scan.estimate.keyObservations
-        : Array.isArray(scan.estimate?.goalRecommendations) && scan.estimate.goalRecommendations.length
-          ? scan.estimate.goalRecommendations
-          : [];
-
-  const disclaimer =
-    typeof scan.disclaimer === "string" && scan.disclaimer.trim()
-      ? scan.disclaimer.trim()
-      : "Estimates only. Not medical advice.";
-
-  const delta = (() => {
-    if (!previousScan) return null;
-    const prevWeight = previousScan.input?.currentWeightKg;
-    const prevBf = previousScan.estimate?.bodyFatPercent;
-    const prevWeightOk =
-      typeof prevWeight === "number" && Number.isFinite(prevWeight) ? prevWeight : null;
-    const prevBfOk =
-      typeof prevBf === "number" && Number.isFinite(prevBf) ? prevBf : null;
-    if (weightKg == null || bfPct == null || prevWeightOk == null || prevBfOk == null) {
-      return null;
-    }
-    const prevFatKg = (prevWeightOk * prevBfOk) / 100;
-    const prevLeanKg = prevWeightOk - prevFatKg;
-    return {
-      weightKg: weightKg - prevWeightOk,
-      bfPct: bfPct - prevBfOk,
-      leanKg: (leanMassKg ?? 0) - prevLeanKg,
-    };
-  })();
-
-  return (
-    <div className="mx-auto w-full max-w-6xl space-y-6 p-4 md:p-6">
-      <Seo title="Your Body Scan – MyBodyScan" description="Your scan report." />
-
-      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-        <div className="space-y-1">
-          <h1 className="text-3xl font-semibold tracking-tight">Your Body Scan</h1>
-          <p className="text-sm text-muted-foreground">
-            {formatDateTime(scan.completedAt ?? scan.updatedAt)} · {displayName}
-          </p>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Button variant="outline" onClick={() => nav("/scan/history")}>
-            History
-          </Button>
-          <Button onClick={() => nav("/scan")}>New scan</Button>
-        </div>
-      </header>
-
-      <Card className="border bg-card/60">
-        <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <CardTitle className="text-lg">Overview</CardTitle>
-          <div className="flex flex-wrap gap-2">
-            <Badge variant="secondary">{goalLabel}</Badge>
-            {delta ? (
-              <Badge variant="outline">
-                {(() => {
-                  const preferredUnit = units === "metric" ? "kg" : "lb";
-                  const absKg = delta.weightKg;
-                  const formatted = formatWeight({ kg: absKg, preferredUnit, digits: 1 });
-                  const text =
-                    formatted.value != null
-                      ? `${formatted.value >= 0 ? "+" : ""}${formatted.value.toFixed(1)} ${formatted.unitLabel}`
-                      : "—";
-                  return (
-                    <>
-                      vs last scan: {text} · {delta.bfPct >= 0 ? "+" : ""}
-                    </>
-                  );
-                })()}
-                {delta.bfPct.toFixed(1)}%
-              </Badge>
-            ) : null}
-          </div>
-        </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-2">
-          <div className="grid grid-cols-2 gap-3">
-            <InfoRow label="Sex" value={sex ? capitalize(sex) : "—"} />
-            <InfoRow label="Age" value={age != null ? String(age) : "—"} />
-            <InfoRow
-              label="Height"
-              value={
-                heightCm != null
-                  ? units === "metric"
-                    ? `${Math.round(heightCm)} cm`
-                    : formatHeightFromCm(heightCm)
-                  : "—"
-              }
-            />
-            <InfoRow
-              label="Weight"
-              value={weightKg != null ? formatWeightFromKg(weightKg, 1, units === "metric" ? "metric" : "us") : "—"}
-            />
-          </div>
-          <div className="grid grid-cols-2 gap-3">
-            <InfoRow
-              label="Body fat %"
-              value={bfPct != null ? `${bfPct.toFixed(1)}%` : "—"}
-            />
-            <InfoRow
-              label="BMI"
-              value={
-                bmiValue != null ? bmiValue.toFixed(1) : "—"
-              }
-            />
-            <InfoRow
-              label="BMR"
-              value={computedGoals.bmr != null ? `${Math.round(computedGoals.bmr)} kcal` : "—"}
-            />
-            <InfoRow
-              label="TDEE"
-              value={computedGoals.tdee != null ? `${Math.round(computedGoals.tdee)} kcal` : "—"}
-            />
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card className="border bg-card/60">
-        <CardHeader>
-          <CardTitle className="text-lg">Coach report</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Structured like a coaching chat — use this as your 8-week playbook.
-          </p>
-        </CardHeader>
-        <CardContent className="space-y-6 text-sm">
-          <section className="space-y-2">
-            <h3 className="text-base font-semibold">1) Body metrics snapshot</h3>
-            <ul className="space-y-1 text-muted-foreground">
-              <li>
-                <span className="font-medium text-foreground">Body fat:</span>{" "}
-                {bfPct != null ? `${bfPct.toFixed(1)}%` : "—"}
-              </li>
-              <li>
-                <span className="font-medium text-foreground">Fat mass:</span>{" "}
-                {formatKgLb(fatMassKg, units)}
-              </li>
-              <li>
-                <span className="font-medium text-foreground">Lean mass:</span>{" "}
-                {formatKgLb(leanMassKg, units)}
-              </li>
-              <li>
-                <span className="font-medium text-foreground">BMI:</span>{" "}
-                {bmiValue != null ? bmiValue.toFixed(1) : "Add your height to calculate BMI."}
-              </li>
-            </ul>
-            {typeof scan.estimate?.notes === "string" && scan.estimate.notes.trim() ? (
-              <p className="text-xs text-muted-foreground">{scan.estimate.notes}</p>
-            ) : null}
-            {improvementAreas.length ? (
-              <div className="pt-2">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Improvement areas
-                </p>
-                <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
-                  {improvementAreas.slice(0, 6).map((item, idx) => (
-                    <li key={idx}>• {item}</li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-          </section>
-
-          <Separator />
-
-          <section className="space-y-3">
-            <div className="space-y-1">
-              <h3 className="text-base font-semibold">
-                2) Training plan (6-day PPL split)
-              </h3>
-              <p className="text-muted-foreground">{workoutPlan.summary}</p>
+  if (resultVm.isFailedOrFallback) {
+    return (
+      <div className="mx-auto max-w-3xl space-y-4 p-4 md:p-6">
+        <Seo
+          title="Scan recovery – MyBodyScan"
+          description="Recover a failed scan."
+        />
+        <Card className="border-destructive/30 bg-destructive/5">
+          <CardHeader className="space-y-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <CardTitle>{resultVm.failureTitle}</CardTitle>
+              <Badge variant="destructive">{resultVm.sourceLabel}</Badge>
             </div>
-            {weeksToShow.map((week) => (
-              <div key={week.weekNumber} className="space-y-2">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Week {week.weekNumber} split
-                </p>
-                <div className="grid gap-2 md:grid-cols-2">
-                  {week.days.map((day, idx) => (
-                    <div key={`${day.day}-${idx}`} className="rounded-lg border p-3">
-                      <div className="flex items-center justify-between">
-                        <span className="font-medium">{day.day}</span>
-                        <span className="text-xs text-muted-foreground">{day.focus}</span>
-                      </div>
-                      <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
-                        {day.exercises.map((exercise, exIdx) => (
-                          <li key={`${exercise.name}-${exIdx}`}>
-                            {exercise.name} · {exercise.sets}x{exercise.reps}
-                            {exercise.notes ? ` · ${exercise.notes}` : ""}
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            ))}
-            {hasMoreWeeks ? (
-              <p className="text-xs text-muted-foreground">
-                Weeks {weeksToShow.length + 1}+ follow the same split with progressive
-                overload.
-              </p>
-            ) : null}
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Progression rules
-              </p>
-              <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
-                {progressionRules.map((rule, idx) => (
-                  <li key={idx}>• {rule}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-
-          <Separator />
-
-          <section className="space-y-3">
-            <div className="space-y-1">
-              <h3 className="text-base font-semibold">3) Nutrition plan</h3>
-              <p className="text-muted-foreground">
-                Calories and macros tailored for your goal.
-              </p>
-            </div>
-            <div className="grid gap-2 sm:grid-cols-2">
-              <div className="rounded-lg border p-3">
-                <p className="text-xs text-muted-foreground">Daily calories</p>
-                <p className="text-lg font-semibold">
-                  {Math.round(nutritionPlan.caloriesPerDay)} kcal
-                </p>
-              </div>
-              <div className="rounded-lg border p-3">
-                <p className="text-xs text-muted-foreground">Macros</p>
-                <p className="text-sm font-medium">
-                  P {Math.round(nutritionPlan.proteinGrams)}g · C{" "}
-                  {Math.round(nutritionPlan.carbsGrams)}g · F{" "}
-                  {Math.round(nutritionPlan.fatsGrams)}g
-                </p>
-              </div>
-            </div>
-            {(nutritionPlan.trainingDay || nutritionPlan.restDay) && (
-              <div className="grid gap-2 sm:grid-cols-2">
-                {nutritionPlan.trainingDay ? (
-                  <div className="rounded-lg border p-3">
-                    <p className="text-xs text-muted-foreground">Training day</p>
-                    <p className="text-sm font-medium">
-                      {Math.round(nutritionPlan.trainingDay.calories)} kcal ·{" "}
-                      {Math.round(nutritionPlan.trainingDay.proteinGrams)}P /{" "}
-                      {Math.round(nutritionPlan.trainingDay.carbsGrams)}C /{" "}
-                      {Math.round(nutritionPlan.trainingDay.fatsGrams)}F
-                    </p>
-                  </div>
-                ) : null}
-                {nutritionPlan.restDay ? (
-                  <div className="rounded-lg border p-3">
-                    <p className="text-xs text-muted-foreground">Rest day</p>
-                    <p className="text-sm font-medium">
-                      {Math.round(nutritionPlan.restDay.calories)} kcal ·{" "}
-                      {Math.round(nutritionPlan.restDay.proteinGrams)}P /{" "}
-                      {Math.round(nutritionPlan.restDay.carbsGrams)}C /{" "}
-                      {Math.round(nutritionPlan.restDay.fatsGrams)}F
-                    </p>
-                  </div>
-                ) : null}
-              </div>
-            )}
-            {nutritionPlan.sampleDay?.length ? (
-              <div className="space-y-2">
-                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                  Sample day
-                </p>
-                <ul className="space-y-2 text-xs text-muted-foreground">
-                  {nutritionPlan.sampleDay.map((meal, idx) => (
-                    <li key={`${meal.mealName}-${idx}`}>
-                      <span className="font-medium text-foreground">{meal.mealName}:</span>{" "}
-                      {meal.description} · {meal.calories} kcal (P {meal.proteinGrams}g · C{" "}
-                      {meal.carbsGrams}g · F {meal.fatsGrams}g)
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            ) : null}
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Adjustment rules
-              </p>
-              <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
-                {nutritionPlan.adjustmentRules.map((rule, idx) => (
-                  <li key={idx}>• {rule}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-
-          <Separator />
-
-          <section className="space-y-2">
-            <h3 className="text-base font-semibold">4) Next steps</h3>
-            <ul className="space-y-2 text-muted-foreground">
-              {recommendations.map((item, idx) => (
-                <li key={idx} className="flex gap-2">
-                  <span className="mt-1 h-2 w-2 shrink-0 rounded-full bg-primary" />
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-            {disclaimer ? (
-              <p className="pt-2 text-[11px] text-muted-foreground">{disclaimer}</p>
-            ) : null}
-          </section>
-        </CardContent>
-      </Card>
-
-      <ScanPhotos photoUrls={photoUrls} />
-
-      <div className="grid gap-4 lg:grid-cols-[1.6fr,1fr]">
-        <Card className="border bg-card/60">
-          <CardHeader>
-            <CardTitle className="text-lg">Body composition</CardTitle>
-          </CardHeader>
-          <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            <MetricCard
-              label="Lean Body Mass"
-              value={formatKgLb(leanMassKg, units)}
-              hint={leanMassKg != null && weightKg != null ? `${Math.round((leanMassKg / weightKg) * 100)}% of weight` : undefined}
-            />
-            <MetricCard
-              label="Skeletal Muscle Mass"
-              value={formatKgLb(skeletalMuscleKg, units)}
-              hint="Estimate"
-            />
-            <MetricCard
-              label="Body Fat %"
-              value={bfPct != null ? `${bfPct.toFixed(1)}%` : "—"}
-            />
-            <MetricCard
-              label="Body Fat Mass"
-              value={formatKgLb(fatMassKg, units)}
-            />
-            <MetricCard
-              label="Total Body Water"
-              value={
-                totalBodyWaterKg != null
-                  ? `${formatKgLbNumber(totalBodyWaterKg, units)}${totalBodyWaterPct != null ? ` · ${Math.round(totalBodyWaterPct)}%` : ""}`
-                  : "—"
-              }
-              hint="Estimate"
-            />
-            <MetricCard
-              label="Visceral fat"
-              value={bfPct != null ? visceralLabel(bfPct, sex) : "—"}
-              hint="Estimate"
-            />
-          </CardContent>
-        </Card>
-
-        <Card className="border bg-card/60">
-          <CardHeader>
-            <CardTitle className="text-lg">Score</CardTitle>
+            <p className="text-sm text-muted-foreground">
+              {resultVm.failureMessage}
+            </p>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="grid grid-cols-2 gap-3">
-              <CircleGauge
-                label="Body age"
-                value={bodyAge != null ? String(bodyAge) : "—"}
-                sublabel={age != null ? `Actual: ${age}` : undefined}
-                progress={bodyAge != null && age != null ? clampNumber(age / Math.max(bodyAge, 1), 0, 1) : null}
-              />
-              <CircleGauge
-                label="Body score"
-                value={bodyScore != null ? `${bodyScore.toFixed(1)}` : "—"}
-                sublabel="out of 10"
-                progress={bodyScore != null ? clampNumber(bodyScore / 10, 0, 1) : null}
-              />
+            <div className="rounded-lg border bg-background/80 p-3 text-xs text-muted-foreground">
+              status={scan.status || "unknown"} · provider=
+              {resultVm.diagnostics.provider || "unknown"} · aiStatus=
+              {resultVm.diagnostics.processingStatus || "unknown"} · error=
+              {resultVm.diagnostics.errorCode || "none"} · credit=
+              {resultVm.diagnostics.refunded
+                ? "refunded"
+                : resultVm.diagnostics.charged
+                  ? "charged"
+                  : "not charged"}
             </div>
-
-            <div className="rounded-lg border bg-background/60 p-4">
-              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Segmental analysis
-              </div>
-              <div className="mt-3 grid grid-cols-[1fr,auto,1fr] items-center gap-3">
-                <div className="space-y-1 text-sm">
-                  <div className="flex items-center justify-between">
-                    <span className="text-muted-foreground">Upper lean</span>
-                    <span className="font-medium">
-                      {leanMassKg != null ? formatKgLbNumber(leanMassKg * 0.55, units) : "—"}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-muted-foreground">Lower lean</span>
-                    <span className="font-medium">
-                      {leanMassKg != null ? formatKgLbNumber(leanMassKg * 0.45, units) : "—"}
-                    </span>
-                  </div>
-                </div>
-                <div className="flex justify-center">
-                  <img
-                    src={silhouetteFront}
-                    alt="Body silhouette"
-                    className="h-40 w-auto opacity-90"
-                    loading="lazy"
-                  />
-                </div>
-                <div className="space-y-1 text-sm">
-                  <div className="flex items-center justify-between">
-                    <span className="text-muted-foreground">BMR</span>
-                    <span className="font-medium">
-                      {computedGoals.bmr != null ? `${Math.round(computedGoals.bmr)} kcal` : "—"}
-                    </span>
-                  </div>
-                  <div className="flex items-center justify-between">
-                    <span className="text-muted-foreground">TDEE</span>
-                    <span className="font-medium">
-                      {computedGoals.tdee != null ? `${Math.round(computedGoals.tdee)} kcal` : "—"}
-                    </span>
-                  </div>
-                </div>
-              </div>
+            <div className="grid gap-2 sm:grid-cols-3">
+              <Button onClick={retryProcessing}>Retry processing</Button>
+              <Button variant="outline" onClick={() => nav("/scan")}>
+                Re-upload scan
+              </Button>
+              <Button variant="outline" onClick={() => nav("/scan/history")}>
+                History
+              </Button>
             </div>
+            <p className="text-xs text-muted-foreground">
+              We do not display body fat, macros, body age, scores, or workout
+              prescriptions unless the AI analysis succeeds.
+            </p>
           </CardContent>
         </Card>
       </div>
+    );
+  }
 
-      <div className="grid gap-4 lg:grid-cols-2">
+  if (resultVm.isValidResult) {
+    return (
+      <div className="mx-auto w-full max-w-3xl space-y-4 p-4 md:p-6">
+        <Seo
+          title="Your Body Scan – MyBodyScan"
+          description="Your scan report."
+        />
+        <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-1">
+            <h1 className="text-3xl font-semibold tracking-tight">
+              Your Body Scan
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              {formatDateTime(scan.completedAt ?? scan.updatedAt)} ·{" "}
+              {resultVm.sourceLabel}
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button variant="outline" onClick={() => nav("/scan/history")}>
+              History
+            </Button>
+            <Button onClick={() => nav("/scan")}>New scan</Button>
+          </div>
+        </header>
+
         <Card className="border bg-card/60">
           <CardHeader>
-            <CardTitle className="text-lg">Your nutrition</CardTitle>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <CardTitle className="text-lg">Primary results</CardTitle>
+              <Badge variant="secondary">Fitness estimates only</Badge>
+            </div>
           </CardHeader>
-          <CardContent className="grid gap-3 sm:grid-cols-2">
+          <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <MetricCard
+              label="Est. body fat"
+              value={
+                resultVm.primary.bodyFatPercent != null
+                  ? `${resultVm.primary.bodyFatPercent.toFixed(1)}%`
+                  : "—"
+              }
+            />
+            <MetricCard
+              label="Weight"
+              value={formatKgForUnits(resultVm.primary.weightKg, units)}
+            />
+            <MetricCard
+              label="BMI"
+              value={
+                resultVm.primary.bmi != null
+                  ? resultVm.primary.bmi.toFixed(1)
+                  : "—"
+              }
+            />
+            <MetricCard
+              label="Lean mass"
+              value={formatKgForUnits(resultVm.primary.leanMassKg, units)}
+              hint="Derived from weight and body-fat estimate"
+            />
+          </CardContent>
+        </Card>
+
+        <Card className="border bg-card/60">
+          <CardHeader>
+            <CardTitle className="text-lg">Transformation Preview</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm">
+            <p>
+              See a realistic motivational visualization of your goal physique
+              once your scan and plan are ready.
+            </p>
+            <Button
+              className="w-full sm:w-auto"
+              onClick={() => nav(`/results/${scan.id}/transformation-preview`)}
+            >
+              Open preview status
+            </Button>
+            <p className="text-xs text-muted-foreground">
+              Premium scaffold only. No generated image is shown yet.
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card className="border bg-card/60">
+          <CardHeader>
+            <CardTitle className="text-lg">Nutrition targets</CardTitle>
+          </CardHeader>
+          <CardContent className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             <MetricCard
               label="Calories"
-              value={`${rangeText(computedGoals.calories)} kcal`}
-              hint={computedGoals.tdee != null ? `TDEE ~${Math.round(computedGoals.tdee)} kcal` : undefined}
+              value={
+                resultVm.nutrition.calories != null
+                  ? `${resultVm.nutrition.calories} kcal`
+                  : "—"
+              }
             />
             <MetricCard
               label="Protein"
-              value={`${Math.round(computedGoals.proteinGrams)} g`}
-              hint={`${Math.round(computedGoals.proteinPct)}%`}
+              value={
+                resultVm.nutrition.proteinGrams != null
+                  ? `${resultVm.nutrition.proteinGrams} g`
+                  : "—"
+              }
             />
             <MetricCard
               label="Carbs"
-              value={`${Math.round(computedGoals.carbsGrams)} g`}
-              hint={`${Math.round(computedGoals.carbsPct)}%`}
+              value={
+                resultVm.nutrition.carbsGrams != null
+                  ? `${resultVm.nutrition.carbsGrams} g`
+                  : "—"
+              }
             />
             <MetricCard
-              label="Fat"
-              value={`${Math.round(computedGoals.fatGrams)} g`}
-              hint={`${Math.round(computedGoals.fatPct)}%`}
+              label="Fats"
+              value={
+                resultVm.nutrition.fatsGrams != null
+                  ? `${resultVm.nutrition.fatsGrams} g`
+                  : "—"
+              }
             />
           </CardContent>
         </Card>
 
         <Card className="border bg-card/60">
           <CardHeader>
-            <CardTitle className="text-lg">Coach recommendations</CardTitle>
+            <CardTitle className="text-lg">Recommended plan</CardTitle>
           </CardHeader>
-          <CardContent className="space-y-3">
-            <ul className="space-y-2 text-sm text-foreground">
-              {recommendations.map((item, idx) => (
-                <li key={idx} className="flex gap-2">
-                  <span className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-primary" />
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-            {typeof scan.estimate?.notes === "string" && scan.estimate.notes.trim() ? (
-              <>
-                <Separator />
-                <p className="text-xs text-muted-foreground">{scan.estimate.notes}</p>
-              </>
+          <CardContent className="space-y-3 text-sm">
+            <p className="font-medium">{resultVm.plan.summary}</p>
+            {resultVm.plan.detailLines.length ? (
+              <ul className="space-y-1 text-muted-foreground">
+                {resultVm.plan.detailLines.map((line) => (
+                  <li key={line}>• {line}</li>
+                ))}
+              </ul>
             ) : null}
+            {resultVm.plan.setupNeeded ? (
+              <Button
+                variant="outline"
+                onClick={() => nav("/coach/onboarding")}
+              >
+                Complete plan setup
+              </Button>
+            ) : (
+              <Button variant="outline" onClick={() => nav("/programs")}>
+                View full plan
+              </Button>
+            )}
           </CardContent>
         </Card>
-      </div>
-    </div>
-  );
-}
 
+        <Card className="border bg-card/60">
+          <CardContent className="pt-6 text-sm">
+            Next scan: rescan in 10 days with the same four angles and current
+            weight.
+          </CardContent>
+        </Card>
+
+        <details className="rounded-lg border bg-card/60 p-4 text-sm">
+          <summary className="cursor-pointer font-medium">
+            View full report
+          </summary>
+          <div className="mt-4 space-y-4">
+            <ScanPhotos photoUrls={photoUrls} />
+            <pre className="whitespace-pre-wrap text-xs text-muted-foreground">
+              {scan.planMarkdown || "Detailed report unavailable."}
+            </pre>
+          </div>
+        </details>
+
+        <p className="text-xs text-muted-foreground">
+          Fitness estimates only. Not medical advice.
+        </p>
+      </div>
+    );
+  }
+
+  return null;
+}
 function ScanPhotos({
   photoUrls,
 }: {
   photoUrls: Partial<Record<"front" | "back" | "left" | "right", string>>;
 }) {
-  const entries = (Object.entries(photoUrls) as Array<
-    ["front" | "back" | "left" | "right", string]
-  >).filter(([, url]) => typeof url === "string" && url.length > 0);
+  const entries = (
+    Object.entries(photoUrls) as Array<
+      ["front" | "back" | "left" | "right", string]
+    >
+  ).filter(([, url]) => typeof url === "string" && url.length > 0);
   if (!entries.length) return null;
   const label: Record<string, string> = {
     front: "Front",
@@ -1611,190 +1308,4 @@ function InfoRow({ label, value }: { label: string; value: string }) {
       <div className="mt-1 text-sm font-medium text-foreground">{value}</div>
     </div>
   );
-}
-
-function CircleGauge({
-  label,
-  value,
-  sublabel,
-  progress,
-}: {
-  label: string;
-  value: string;
-  sublabel?: string;
-  progress: number | null;
-}) {
-  const pct = progress != null ? clampNumber(progress, 0, 1) : 0;
-  const r = 34;
-  const c = 2 * Math.PI * r;
-  const dash = c - c * pct;
-  return (
-    <div className="rounded-lg border bg-background/60 p-4">
-      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
-        {label}
-      </div>
-      <div className="mt-3 flex items-center gap-3">
-        <svg width="84" height="84" viewBox="0 0 84 84" aria-hidden>
-          <circle
-            cx="42"
-            cy="42"
-            r={r}
-            strokeWidth="8"
-            className="fill-none stroke-muted"
-          />
-          <circle
-            cx="42"
-            cy="42"
-            r={r}
-            strokeWidth="8"
-            className="fill-none stroke-primary"
-            strokeDasharray={`${c} ${c}`}
-            strokeDashoffset={dash}
-            strokeLinecap="round"
-            transform="rotate(-90 42 42)"
-          />
-        </svg>
-        <div>
-          <div className="text-2xl font-semibold tracking-tight">{value}</div>
-          {sublabel ? (
-            <div className="text-xs text-muted-foreground">{sublabel}</div>
-          ) : null}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function formatKgLb(valueKg: number | null, units: "metric" | "us") {
-  if (valueKg == null || !Number.isFinite(valueKg)) return "—";
-  const kg = valueKg;
-  const lb = kgToLb(kg);
-  return units === "metric"
-    ? `${kg.toFixed(1)} kg · ${lb.toFixed(1)} lb`
-    : `${lb.toFixed(1)} lb · ${kg.toFixed(1)} kg`;
-}
-
-function formatKgLbNumber(valueKg: number, units: "metric" | "us") {
-  const kg = valueKg;
-  const lb = kgToLb(kg);
-  return units === "metric" ? `${kg.toFixed(1)} kg` : `${lb.toFixed(1)} lb`;
-}
-
-function clampNumber(n: number, min: number, max: number) {
-  if (!Number.isFinite(n)) return min;
-  return Math.min(max, Math.max(min, n));
-}
-
-function capitalize(s: string) {
-  return s ? s.charAt(0).toUpperCase() + s.slice(1) : s;
-}
-
-function mapToScore(min: number, max: number, value: number, lowerIsBetter: boolean) {
-  const v = clampNumber((value - min) / (max - min), 0, 1);
-  return lowerIsBetter ? 1 - v : v;
-}
-
-function rangeText(calories: number) {
-  const base = Math.round(calories);
-  const lo = Math.max(0, base - 50);
-  const hi = base + 50;
-  return `${lo.toLocaleString()}–${hi.toLocaleString()}`;
-}
-
-function visceralLabel(bfPct: number, sex: "male" | "female" | null) {
-  // Lightweight heuristic label for display only.
-  const thresholds = sex === "female" ? [30, 38] : [20, 28];
-  if (bfPct < thresholds[0]!) return "Low";
-  if (bfPct < thresholds[1]!) return "Moderate";
-  return "High";
-}
-
-function defaultRecommendations(goals: ReturnType<typeof deriveNutritionGoals>): string[] {
-  const protein = Math.round(goals.proteinGrams);
-  const calories = Math.round(goals.calories);
-  return [
-    `Aim for ~${protein}g protein per day to support recovery.`,
-    `Keep calories around ~${calories} kcal/day and adjust based on weekly progress.`,
-    "Train 3–5x/week with progressive overload and prioritize sleep (7–9h).",
-    "Hit a daily step baseline (e.g. 7–10k) to support energy balance.",
-  ].slice(0, 5);
-}
-
-function buildFallbackWorkoutPlan() {
-  return {
-    summary:
-      "6-day push/pull/legs split focused on progressive overload and balanced volume.",
-    progressionRules: [
-      "Add reps weekly until you reach the top of the rep range, then increase load.",
-      "Keep 1–2 reps in reserve on compounds to stay consistent.",
-      "Deload every 4–6 weeks if performance stalls.",
-    ],
-    weeks: [
-      {
-        weekNumber: 1,
-        days: [
-          {
-            day: "Day 1",
-            focus: "Push (chest/shoulders/triceps)",
-            exercises: [
-              { name: "Bench press", sets: 4, reps: "6-10" },
-              { name: "Incline dumbbell press", sets: 3, reps: "8-12" },
-              { name: "Overhead press", sets: 3, reps: "6-10" },
-              { name: "Triceps pressdown", sets: 3, reps: "10-15" },
-            ],
-          },
-          {
-            day: "Day 2",
-            focus: "Pull (back/biceps)",
-            exercises: [
-              { name: "Pull-ups or pulldown", sets: 4, reps: "6-10" },
-              { name: "Barbell row", sets: 3, reps: "6-10" },
-              { name: "Face pulls", sets: 3, reps: "12-15" },
-              { name: "Biceps curl", sets: 3, reps: "10-12" },
-            ],
-          },
-          {
-            day: "Day 3",
-            focus: "Legs (quads/hamstrings/glutes)",
-            exercises: [
-              { name: "Squat", sets: 4, reps: "5-8" },
-              { name: "Romanian deadlift", sets: 3, reps: "8-10" },
-              { name: "Leg press", sets: 3, reps: "10-12" },
-              { name: "Calf raise", sets: 3, reps: "12-15" },
-            ],
-          },
-          {
-            day: "Day 4",
-            focus: "Push (volume)",
-            exercises: [
-              { name: "Dumbbell bench press", sets: 3, reps: "8-12" },
-              { name: "Lateral raise", sets: 3, reps: "12-15" },
-              { name: "Dip or push-up", sets: 3, reps: "8-12" },
-              { name: "Triceps extension", sets: 3, reps: "12-15" },
-            ],
-          },
-          {
-            day: "Day 5",
-            focus: "Pull (volume)",
-            exercises: [
-              { name: "Chest-supported row", sets: 3, reps: "8-12" },
-              { name: "Lat pulldown", sets: 3, reps: "10-12" },
-              { name: "Rear delt fly", sets: 3, reps: "12-15" },
-              { name: "Hammer curl", sets: 3, reps: "10-12" },
-            ],
-          },
-          {
-            day: "Day 6",
-            focus: "Legs (volume)",
-            exercises: [
-              { name: "Front squat or goblet squat", sets: 3, reps: "8-10" },
-              { name: "Hip hinge (RDL/hip thrust)", sets: 3, reps: "8-12" },
-              { name: "Leg curl", sets: 3, reps: "10-12" },
-              { name: "Walking lunge", sets: 2, reps: "12-16 steps" },
-            ],
-          },
-        ],
-      },
-    ],
-  };
 }

--- a/src/pages/ScanResult.tsx
+++ b/src/pages/ScanResult.tsx
@@ -48,6 +48,7 @@ import {
   latestHeartbeatMillis,
 } from "@/lib/scanHeartbeat";
 import { mark, measure, flush as flushPerf } from "@/lib/scan/perf";
+import { TRANSFORMATION_PREVIEW_ENTRY_ENABLED } from "@/lib/flags";
 
 const LONG_PROCESSING_WARNING_MS = 3 * 60 * 1000;
 const HARD_PROCESSING_TIMEOUT_MS = 4 * 60 * 1000;
@@ -1021,17 +1022,11 @@ export default function ScanResultPage() {
             </p>
           </CardHeader>
           <CardContent className="space-y-4">
-            <div className="rounded-lg border bg-background/80 p-3 text-xs text-muted-foreground">
-              status={scan.status || "unknown"} · provider=
-              {resultVm.diagnostics.provider || "unknown"} · aiStatus=
-              {resultVm.diagnostics.processingStatus || "unknown"} · error=
-              {resultVm.diagnostics.errorCode || "none"} · credit=
-              {resultVm.diagnostics.refunded
-                ? "refunded"
-                : resultVm.diagnostics.charged
-                  ? "charged"
-                  : "not charged"}
-            </div>
+            {resultVm.diagnostics.refunded ? (
+              <div className="rounded-lg border bg-background/80 p-3 text-sm text-muted-foreground">
+                Your scan credit has been returned.
+              </div>
+            ) : null}
             <div className="grid gap-2 sm:grid-cols-3">
               <Button onClick={retryProcessing}>Retry processing</Button>
               <Button variant="outline" onClick={() => nav("/scan")}>
@@ -1112,26 +1107,27 @@ export default function ScanResultPage() {
           </CardContent>
         </Card>
 
-        <Card className="border bg-card/60">
-          <CardHeader>
-            <CardTitle className="text-lg">Transformation Preview</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm">
-            <p>
-              See a realistic motivational visualization of your goal physique
-              once your scan and plan are ready.
-            </p>
-            <Button
-              className="w-full sm:w-auto"
-              onClick={() => nav(`/results/${scan.id}/transformation-preview`)}
-            >
-              Open preview status
-            </Button>
-            <p className="text-xs text-muted-foreground">
-              Premium scaffold only. No generated image is shown yet.
-            </p>
-          </CardContent>
-        </Card>
+        {TRANSFORMATION_PREVIEW_ENTRY_ENABLED ? (
+          <Card className="border bg-card/60">
+            <CardHeader>
+              <CardTitle className="text-lg">Transformation Preview</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <p>
+                See a realistic motivational visualization of your goal physique
+                once your scan and plan are ready.
+              </p>
+              <Button
+                className="w-full sm:w-auto"
+                onClick={() =>
+                  nav(`/results/${scan.id}/transformation-preview`)
+                }
+              >
+                Open Transformation Preview
+              </Button>
+            </CardContent>
+          </Card>
+        ) : null}
 
         <Card className="border bg-card/60">
           <CardHeader>

--- a/src/pages/TransformationPreview.tsx
+++ b/src/pages/TransformationPreview.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Download, Lock, Share2, Sparkles } from "lucide-react";
+import { Lock, Sparkles, AlertCircle, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -9,35 +9,24 @@ import { useAuthUser } from "@/auth/mbs-auth";
 import { useEntitlements } from "@/lib/entitlements/store";
 import { hasPro } from "@/lib/entitlements/pro";
 import { useLatestScanForUser } from "@/hooks/useLatestScanForUser";
-import {
-  requestTransformationPreview,
-  subscribeTransformationPreview,
-  type TransformationPreviewGoal,
-} from "@/lib/transformationPreview";
-import { toast } from "@/hooks/use-toast";
-
-const GOAL_TO_COPY: Record<TransformationPreviewGoal, string> = {
-  lose_fat: "Reduce fat while preserving muscle.",
-  gain_muscle: "Build lean mass while keeping waist controlled.",
-  recomp: "Trade fat mass for lean tissue gradually.",
-  maintain: "Maintain composition and improve definition.",
-  performance: "Build a stronger athletic shape for performance.",
-};
+import { subscribeTransformationPreview } from "@/lib/transformationPreview";
+import { buildScanResultViewModel } from "@/lib/scanResultViewModel";
+import { useUserProfile } from "@/hooks/useUserProfile";
 
 export default function TransformationPreviewPage() {
   const { scanId = "" } = useParams();
   const navigate = useNavigate();
   const { user } = useAuthUser();
   const { entitlements } = useEntitlements();
-  const { scan } = useLatestScanForUser(scanId);
+  const { scan, loading: scanLoading } = useLatestScanForUser(scanId);
+  const { profile, plan } = useUserProfile();
   const pro = hasPro(entitlements);
   const [state, setState] = useState<any>(null);
-  const [loading, setLoading] = useState(true);
-  const [requesting, setRequesting] = useState(false);
+  const [loadingState, setLoadingState] = useState(true);
 
   useEffect(() => {
     if (!user?.uid || !scanId) {
-      setLoading(false);
+      setLoadingState(false);
       return;
     }
     const unsub = subscribeTransformationPreview(
@@ -45,71 +34,118 @@ export default function TransformationPreviewPage() {
       scanId,
       (next) => {
         setState(next);
-        setLoading(false);
+        setLoadingState(false);
       },
-      () => setLoading(false)
+      () => setLoadingState(false)
     );
     return () => unsub();
   }, [user?.uid, scanId]);
 
-  const goal = useMemo<TransformationPreviewGoal>(() => {
-    const raw = String((scan as any)?.goalType || (scan as any)?.goal || "recomp").toLowerCase();
-    if (raw.includes("lose")) return "lose_fat";
-    if (raw.includes("gain")) return "gain_muscle";
-    if (raw.includes("maintain")) return "maintain";
-    if (raw.includes("perform")) return "performance";
-    return "recomp";
-  }, [scan]);
+  const vm = useMemo(
+    () =>
+      scan
+        ? buildScanResultViewModel({ scan: scan as any, profile, plan })
+        : null,
+    [scan, profile, plan]
+  );
 
-  const onRequest = async () => {
-    if (!user?.uid || !scanId) return;
-    setRequesting(true);
-    try {
-      await requestTransformationPreview({
-        uid: user.uid,
-        scanId,
-        goal,
-        timelineWeeks: Number((scan as any)?.timelineWeeks) || 12,
-        planSummary: (scan as any)?.planMarkdown || null,
-      });
-      toast({ title: "Transformation Preview queued" });
-    } catch (error: any) {
-      toast({ title: "Unable to queue preview", description: error?.message, variant: "destructive" });
-    } finally {
-      setRequesting(false);
-    }
-  };
+  const eligibility = (() => {
+    if (!pro)
+      return {
+        label: "Locked",
+        copy: "One paid scan credit will include one Transformation Preview when generation is enabled.",
+      };
+    if (scanLoading || loadingState)
+      return {
+        label: "Checking",
+        copy: "Checking scan and preview eligibility…",
+      };
+    if (!vm?.isValidResult)
+      return {
+        label: "Scan not ready",
+        copy: "A trustworthy completed scan is required before Transformation Preview can be generated.",
+      };
+    if (vm.plan.setupNeeded)
+      return {
+        label: "Plan setup needed",
+        copy: "Complete your plan setup so the preview can reflect your actual training target.",
+      };
+    if (state?.status === "failed")
+      return {
+        label: "Not ready",
+        copy: "Preview generation is currently disabled while scan reliability is being verified.",
+      };
+    return {
+      label: "Not ready",
+      copy: "Transformation Preview is scaffolded, but image generation is intentionally disabled until scan results are trustworthy.",
+    };
+  })();
 
   return (
     <main className="min-h-screen p-4 md:p-6 max-w-3xl mx-auto space-y-4">
-      <Seo title="Transformation Preview – MyBodyScan" description="Premium transformation projection" canonical={window.location.href} />
+      <Seo
+        title="Transformation Preview – MyBodyScan"
+        description="Premium transformation projection status"
+        canonical={window.location.href}
+      />
       <Card className="bg-gradient-to-b from-zinc-900 to-black border-zinc-800 text-zinc-100">
         <CardHeader>
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-xl flex items-center gap-2"><Sparkles className="h-5 w-5 text-primary" /> Transformation Preview</CardTitle>
-            <Badge variant={pro ? "default" : "secondary"}>{pro ? "Premium" : "Locked"}</Badge>
+          <div className="flex items-center justify-between gap-3">
+            <CardTitle className="text-xl flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-primary" /> Transformation
+              Preview
+            </CardTitle>
+            <Badge variant={pro ? "default" : "secondary"}>
+              {eligibility.label}
+            </Badge>
           </div>
-          <p className="text-xs text-zinc-400">Realistic visual projection tied to your current plan and timeline.</p>
+          <p className="text-xs text-zinc-400">
+            See a realistic motivational visualization of your goal physique
+            once your scan and plan are ready.
+          </p>
         </CardHeader>
         <CardContent className="space-y-4">
-          {!pro ? (
-            <Card className="border-zinc-700 bg-zinc-900/60"><CardContent className="pt-6 space-y-3 text-sm text-zinc-300"><div className="flex gap-2 items-start"><Lock className="h-4 w-4 mt-0.5" />Premium members unlock Transformation Preview immediately after each scan.</div><Button className="w-full" onClick={() => navigate("/plans")}>Upgrade to Premium</Button></CardContent></Card>
-          ) : state?.status === "ready" && state?.imageUrl ? (
-            <div className="space-y-3">
-              <img src={state.imageUrl} alt="Transformation preview" className="w-full rounded-xl border border-zinc-700 object-cover" />
-              <div className="grid grid-cols-2 gap-2">
-                <Button variant="secondary"><Download className="h-4 w-4 mr-1" />Download</Button>
-                <Button variant="secondary"><Share2 className="h-4 w-4 mr-1" />Share</Button>
+          <Card className="border-zinc-700 bg-zinc-900/50">
+            <CardContent className="pt-6 space-y-3 text-sm text-zinc-300">
+              <div className="flex gap-3 items-start">
+                {pro ? (
+                  <Clock className="h-4 w-4 mt-0.5" />
+                ) : (
+                  <Lock className="h-4 w-4 mt-0.5" />
+                )}
+                <div className="space-y-1">
+                  <p className="font-medium text-zinc-100">
+                    Preview image generation is not enabled yet.
+                  </p>
+                  <p>{eligibility.copy}</p>
+                </div>
               </div>
-            </div>
-          ) : (
-            <Card className="border-zinc-700 bg-zinc-900/40"><CardContent className="pt-6 space-y-3 text-sm text-zinc-300">
-              <p>{GOAL_TO_COPY[goal]}</p>
-              <p className="text-zinc-400">{loading ? "Loading preview status..." : state?.status === "queued" || state?.status === "processing" ? "Your preview is being generated. Keep this plan for the most realistic progression." : "No preview generated yet for this scan."}</p>
-              <Button onClick={onRequest} disabled={requesting || state?.status === "queued" || state?.status === "processing"} className="w-full">{requesting ? "Queuing..." : "Generate Transformation Preview"}</Button>
-            </CardContent></Card>
-          )}
-          <p className="text-xs text-zinc-500">Transformation Preview is a motivational projection based on your scan and plan. Results vary by adherence, recovery, and consistency.</p>
+              {state?.status ? (
+                <div className="rounded-lg border border-zinc-700 p-3 text-xs text-zinc-400">
+                  Stored preview status: {String(state.status)}. No image is
+                  displayed from this scaffold.
+                </div>
+              ) : null}
+              {vm?.isFailedOrFallback ? (
+                <div className="flex gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
+                  <AlertCircle className="h-4 w-4 shrink-0" /> Resolve the
+                  failed scan first; fallback metrics are never eligible.
+                </div>
+              ) : null}
+              <div className="grid gap-2 sm:grid-cols-2">
+                <Button onClick={() => navigate(`/results/${scanId}`)}>
+                  Back to results
+                </Button>
+                <Button variant="outline" onClick={() => navigate("/programs")}>
+                  Review plan
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+          <p className="text-xs text-zinc-500">
+            Motivational feature only. No fake before/after image is generated
+            or displayed in this pass.
+          </p>
         </CardContent>
       </Card>
     </main>

--- a/src/pages/TransformationPreview.tsx
+++ b/src/pages/TransformationPreview.tsx
@@ -1,26 +1,39 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { Lock, Sparkles, AlertCircle, Clock } from "lucide-react";
+import { Clock, Lock, Sparkles } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Seo } from "@/components/Seo";
 import { useAuthUser } from "@/auth/mbs-auth";
+import { useClaims } from "@/lib/claims";
 import { useEntitlements } from "@/lib/entitlements/store";
 import { hasPro } from "@/lib/entitlements/pro";
 import { useLatestScanForUser } from "@/hooks/useLatestScanForUser";
 import { subscribeTransformationPreview } from "@/lib/transformationPreview";
 import { buildScanResultViewModel } from "@/lib/scanResultViewModel";
 import { useUserProfile } from "@/hooks/useUserProfile";
+import { TRANSFORMATION_PREVIEW_ENTRY_ENABLED } from "@/lib/flags";
 
 export default function TransformationPreviewPage() {
   const { scanId = "" } = useParams();
   const navigate = useNavigate();
   const { user } = useAuthUser();
+  const { claims } = useClaims();
   const { entitlements } = useEntitlements();
   const { scan, loading: scanLoading } = useLatestScanForUser(scanId);
   const { profile, plan } = useUserProfile();
   const pro = hasPro(entitlements);
+  const internalAccess = Boolean(
+    import.meta.env.DEV ||
+      (claims as any)?.admin ||
+      (claims as any)?.dev ||
+      (claims as any)?.staff ||
+      (claims as any)?.unlimited ||
+      (claims as any)?.unlimitedCredits
+  );
+  const paidScanPreviewEligible = Boolean((scan as any)?.charged);
+  const previewEligible = pro || paidScanPreviewEligible;
   const [state, setState] = useState<any>(null);
   const [loadingState, setLoadingState] = useState(true);
 
@@ -49,35 +62,63 @@ export default function TransformationPreviewPage() {
     [scan, profile, plan]
   );
 
+  if (!TRANSFORMATION_PREVIEW_ENTRY_ENABLED && !internalAccess) {
+    return (
+      <main className="min-h-screen p-4 md:p-6 max-w-2xl mx-auto space-y-4">
+        <Seo
+          title="Transformation Preview – MyBodyScan"
+          description="Transformation Preview status"
+          canonical={window.location.href}
+        />
+        <Card>
+          <CardHeader>
+            <CardTitle>Transformation Preview</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3 text-sm text-muted-foreground">
+            <p>Transformation Preview is not available for this scan yet.</p>
+            <Button onClick={() => navigate(`/results/${scanId}`)}>
+              Back to results
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
   const eligibility = (() => {
-    if (!pro)
-      return {
-        label: "Locked",
-        copy: "One paid scan credit will include one Transformation Preview when generation is enabled.",
-      };
-    if (scanLoading || loadingState)
+    if (scanLoading || loadingState) {
       return {
         label: "Checking",
         copy: "Checking scan and preview eligibility…",
       };
-    if (!vm?.isValidResult)
+    }
+    if (!previewEligible) {
+      return {
+        label: "Locked",
+        copy: "Transformation Preview is included with eligible paid scans and premium memberships.",
+      };
+    }
+    if (!vm?.isValidResult) {
       return {
         label: "Scan not ready",
-        copy: "A trustworthy completed scan is required before Transformation Preview can be generated.",
+        copy: "A completed scan is required before Transformation Preview can be prepared.",
       };
-    if (vm.plan.setupNeeded)
+    }
+    if (vm.plan.setupNeeded) {
       return {
         label: "Plan setup needed",
-        copy: "Complete your plan setup so the preview can reflect your actual training target.",
+        copy: "Complete your plan setup so the preview can reflect your training target.",
       };
-    if (state?.status === "failed")
+    }
+    if (state?.status === "ready" && state?.imageUrl) {
       return {
-        label: "Not ready",
-        copy: "Preview generation is currently disabled while scan reliability is being verified.",
+        label: "Ready",
+        copy: "Your Transformation Preview is ready.",
       };
+    }
     return {
       label: "Not ready",
-      copy: "Transformation Preview is scaffolded, but image generation is intentionally disabled until scan results are trustworthy.",
+      copy: "Your scan is eligible. We’ll show your preview here when it is ready.",
     };
   })();
 
@@ -95,7 +136,7 @@ export default function TransformationPreviewPage() {
               <Sparkles className="h-5 w-5 text-primary" /> Transformation
               Preview
             </CardTitle>
-            <Badge variant={pro ? "default" : "secondary"}>
+            <Badge variant={previewEligible ? "default" : "secondary"}>
               {eligibility.label}
             </Badge>
           </div>
@@ -105,46 +146,51 @@ export default function TransformationPreviewPage() {
           </p>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Card className="border-zinc-700 bg-zinc-900/50">
-            <CardContent className="pt-6 space-y-3 text-sm text-zinc-300">
-              <div className="flex gap-3 items-start">
-                {pro ? (
-                  <Clock className="h-4 w-4 mt-0.5" />
-                ) : (
-                  <Lock className="h-4 w-4 mt-0.5" />
-                )}
-                <div className="space-y-1">
-                  <p className="font-medium text-zinc-100">
-                    Preview image generation is not enabled yet.
-                  </p>
-                  <p>{eligibility.copy}</p>
+          {state?.status === "ready" &&
+          state?.imageUrl &&
+          TRANSFORMATION_PREVIEW_ENTRY_ENABLED ? (
+            <img
+              src={state.imageUrl}
+              alt="Transformation preview"
+              className="w-full rounded-xl border border-zinc-700 object-cover"
+            />
+          ) : (
+            <Card className="border-zinc-700 bg-zinc-900/50">
+              <CardContent className="pt-6 space-y-3 text-sm text-zinc-300">
+                <div className="flex gap-3 items-start">
+                  {previewEligible ? (
+                    <Clock className="h-4 w-4 mt-0.5" />
+                  ) : (
+                    <Lock className="h-4 w-4 mt-0.5" />
+                  )}
+                  <div className="space-y-1">
+                    <p className="font-medium text-zinc-100">
+                      {eligibility.label}
+                    </p>
+                    <p>{eligibility.copy}</p>
+                  </div>
                 </div>
-              </div>
-              {state?.status ? (
-                <div className="rounded-lg border border-zinc-700 p-3 text-xs text-zinc-400">
-                  Stored preview status: {String(state.status)}. No image is
-                  displayed from this scaffold.
+                {internalAccess && state?.status ? (
+                  <div className="rounded-lg border border-zinc-700 p-3 text-xs text-zinc-400">
+                    Preview document status: {String(state.status)}.
+                  </div>
+                ) : null}
+                <div className="grid gap-2 sm:grid-cols-2">
+                  <Button onClick={() => navigate(`/results/${scanId}`)}>
+                    Back to results
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => navigate("/programs")}
+                  >
+                    Review plan
+                  </Button>
                 </div>
-              ) : null}
-              {vm?.isFailedOrFallback ? (
-                <div className="flex gap-2 rounded-lg border border-amber-500/40 bg-amber-500/10 p-3 text-xs text-amber-100">
-                  <AlertCircle className="h-4 w-4 shrink-0" /> Resolve the
-                  failed scan first; fallback metrics are never eligible.
-                </div>
-              ) : null}
-              <div className="grid gap-2 sm:grid-cols-2">
-                <Button onClick={() => navigate(`/results/${scanId}`)}>
-                  Back to results
-                </Button>
-                <Button variant="outline" onClick={() => navigate("/programs")}>
-                  Review plan
-                </Button>
-              </div>
-            </CardContent>
-          </Card>
+              </CardContent>
+            </Card>
+          )}
           <p className="text-xs text-zinc-500">
-            Motivational feature only. No fake before/after image is generated
-            or displayed in this pass.
+            Motivational wellness visualization only. Not a medical prediction.
           </p>
         </CardContent>
       </Card>

--- a/tests/rules/src/rules.test.ts
+++ b/tests/rules/src/rules.test.ts
@@ -112,6 +112,27 @@ d("Firestore security rules", () => {
     );
   });
 
+  it("allows owner to read transformation previews but blocks all client writes", async () => {
+    const uid = "alice";
+    await testEnv.withSecurityRulesDisabled(async (ctx: any) => {
+      await ctx
+        .firestore()
+        .doc(`users/${uid}/transformationPreviews/scan1`)
+        .set({ status: "not_started", scanId: "scan1" });
+    });
+    const authed = testEnv.authenticatedContext(uid).firestore();
+    const previewRef = authed.doc(`users/${uid}/transformationPreviews/scan1`);
+    await assertSucceeds(previewRef.get());
+    await assertFails(
+      authed.doc(`users/${uid}/transformationPreviews/scan2`).set({
+        status: "ready",
+        imageUrl: "https://example.com/fake.png",
+      })
+    );
+    await assertFails(previewRef.update({ status: "ready" }));
+    await assertFails(previewRef.delete());
+  });
+
   it("blocks cross-user access", async () => {
     const uid1 = "alice";
     const uid2 = "bob";


### PR DESCRIPTION
### Motivation
- Prevent timeout fallbacks from appearing as authoritative paid results and stop fabricated metrics from reaching the UI or billing ledger. 
- Provide one canonical result/view model so nutrition, metrics and plan summaries are consistent across the app. 
- Surface a clear failed-state + retry/refund flow and scaffold the Transformation Preview as a gated premium next step. 

### Description
- Backend: stop treating OpenAI timeouts as successful analyses and prevent writing fabricated data; on processing errors the worker now marks scans as failed, clears analysis fields, annotates `aiProcessing`/`resultSource`, and attempts an automatic credit refund when the scan was charged. (files changed: `functions/src/scan/worker.ts`, `functions/src/scan/refundIfNoResult.ts`, `functions/src/types.ts`) 
- Canonical result model: add `resultSource` and `aiProcessing` bookkeeping fields in functions types and surface them to the client; introduce `src/lib/scanResultViewModel.ts` that normalizes a single canonical view model used by all results UI. 
- Frontend: stop rendering fallback metrics, body-age/score and the large 6-day fallback training report for failed/fallback scans; Results and ScanResult pages now use the canonical view model to decide what to show and present a concise premium-first layout (primary cards, transformation scaffold, nutrition targets, short plan summary, CTAs). (files changed: `src/pages/Results.tsx`, `src/pages/ScanResult.tsx`, `src/pages/TransformationPreview.tsx`) 
- Diagnostics & QA: add a Live Flows QA enhancements panel showing latest scan doc fields, AI processing status, provider, timeout/error codes, and credit/refund state so non-technical QA can screenshot real diagnostics. (file changed: `src/pages/LiveFlowsQA.tsx`) 
- Client API mapping: parse new fields from Firestore into the typed client model (`src/lib/api/scan.ts`) so the view model has authoritative inputs. 
- UX behavior: retry processing (no re-upload) and re-upload flows exposed clearly when processing fails; Transformation Preview is scaffolded and gated (no image generation yet). 

### Testing
- Typecheck: ran `npm run typecheck` (TS compile) with no blocking errors. (succeeded) 
- Functions build: ran `npm --prefix functions run build` to compile Cloud Functions TypeScript and confirm changed functions compile. (succeeded) 
- Frontend build: ran `npm run build` and verified the SPA builds without runtime-type errors; verified the app bundles include the updated pages. (succeeded) 

Files changed (high level):
- functions/src/scan/worker.ts (stop writing fallback result, mark error on timeout, refund charged credits)
- functions/src/scan/refundIfNoResult.ts (improve detection of missing/invalid result and mark/refund)
- functions/src/types.ts (added resultSource / aiProcessing / credit/refund fields)
- src/lib/api/scan.ts (deserialize new fields)
- src/lib/scanResultViewModel.ts (new canonical view model)
- src/pages/Results.tsx (use view model; concise layout; Transformation Preview scaffold button)
- src/pages/ScanResult.tsx (use view model; clear failed state and retry UI)
- src/pages/TransformationPreview.tsx (scaffolded premium preview page; no image generation)
- src/pages/LiveFlowsQA.tsx (added hidden diagnostics block showing latest scan doc + fields)

Deployment command
- Build locally and deploy functions + hosting: `npm run build && npm --prefix functions run build && firebase deploy --only functions,hosting` 

Manual QA steps
- Successful real scan result
  1. Start a paid scan via app and complete 4 photos and required weight input. 
  2. Wait for a processing `complete` result (watch /qa/live-flows for aiProcessing.status `succeeded` and resultSource `ai`). 
  3. On Results, confirm primary cards show: estimated body fat %, weight, BMI, lean mass; Transformation Preview hero is shown as scaffold (no fake image), nutrition targets match `scan.nutritionPlan`, and plan summary matches the plan provided by the scan document. 
- Failed/timed-out scan recovery
  1. Simulate AI timeout (or temporarily unset OPENAI key in functions env). 
  2. Submit a paid scan and watch `/qa/live-flows` or the ScanResult page; the scan should be marked `error` with a helpful message and not show body-fat/macros/workout as authoritative. 
  3. Confirm the UI shows "We could not complete this scan" recovery card with clear Retry processing and Re-upload actions. 
  4. If the scan was charged, confirm the functions log shows a refund attempt and the scan doc indicates `refundedAt` or `creditStatus: refunded` and the UI diagnostic shows credit status refunded. 
- Nutrition numbers consistency
  1. For a valid scan, open Results and ScanResult and verify nutrition numbers (calories/protein/carbs/fats) are identical between the primary nutrition card and the coach/plan summary. 
  2. Confirm numbers come from the canonical `scan.nutritionPlan` document fields and the UI does not compute a separate conflicting macro set. 
- Workout recommendation match
  1. For valid scans that include a `workoutPlan`, confirm the summary shown is taken from `scan.workoutPlan.summary` and that the displayed plan days/focus match the user profile/preferences when available; no fallback 6-day PPL is shown unless the user's plan legitimately prescribes it. 
- Transformation Preview scaffold route/card
  1. Open `Results` and click the Transformation Preview CTA; it must navigate to `/results/:scanId/transformation-preview`. 
  2. For non-Pro users, the page shows Locked/Upgrade messaging. For Pro users without a valid scan, the page explains "scan not ready"; for valid scans, the page shows a not-ready scaffold and no generated image. 
- History & diagnostics
  1. Open `/qa/live-flows` (internal QA access) and run the checks; inspect the added diagnostics card showing the latest scan doc, `aiProcessing` status, provider, `usedFallback`/`resultSource`, `errorReason`, and credit/refund status. 

Notes / Deliverables
- Root cause: the cloud `processQueuedScan` worker previously caught OpenAI timeouts and returned a fabricated fallback analysis which was written to the scan doc as `complete`, allowing paid scans to appear successful despite the engine timing out. 
- Credits: paid scans could be consumed while fallback outputs were provided; the worker now marks failed processing as `error`, clears analysis fields, annotates the scan doc (`aiProcessing` & `resultSource`), and automatically attempts a refund when `charged` was true (via `refundCredit`). `refundIfNoResult` logic was tightened to treat fallback/usedFallback as invalid and allow support/client refunds. 
- Conflicting metric sources: previously nutrition/metrics could originate from the worker fallback generation or client-side derived goals; the UI now uses one canonical source (`scan.nutritionPlan` and `scan.estimate`) normalized by `scanResultViewModel`, eliminating duplicate calculation paths. 
- Exact files changed: listed above. 

If you want, I can open a follow-up to: (A) add unit tests for the view model and functions refund path, (B) add telemetry alerts when auto-refunds occur, and (C) prepare a short admin dashboard view for refunded scans.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f02ebe26c832591c3380a2003d88e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scan recovery options with retry and re-upload capabilities for failed scans.
  * Enhanced scan result diagnostics with AI processing details and refund information.
  
* **Bug Fixes**
  * Improved error handling and recovery paths for failed scan processing.
  * Automatic credit refunds now applied when scans fail to complete.

* **Refactor**
  * Restructured scan result display to use unified view model for consistent data handling.
  * Simplified transformation preview eligibility messaging and status tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->