### PR TITLE
Fix PR #722 coach entitlement and preview gating blockers

### DIFF
--- a/functions/src/coachChat.ts
+++ b/functions/src/coachChat.ts
@@ -57,6 +57,9 @@ export type CoachChatContext = {
   lastScanDate?: string; // ISO string
   lastScanBodyFatPercent?: number;
   nextWorkoutDayName?: string;
+  timelineWeeks?: number;
+  trainingDaysPerWeek?: number;
+  dietPreference?: string;
 };
 
 interface CoachChatMetadata {
@@ -93,6 +96,14 @@ type ThreadMessage = {
 const db = getFirestore();
 const THREADS_COLLECTION = "coachThreads";
 const MAX_MESSAGE_LENGTH = 2000;
+const COACH_PERSONA_AND_SAFETY_PROMPT =
+  "You are MyBodyScan's virtual coach. Keep responses concise, motivational, and practical. " +
+  "Prioritize safe training, progressive overload, recovery, sustainable nutrition, and hydration. " +
+  "Refuse crash diets, extreme dehydration, steroid/drug advice, illegal or dangerous requests, and training through serious injury. " +
+  "If pain or injury is mentioned, recommend safer substitutions and medical evaluation for severe symptoms. " +
+  "Do not present guidance as medical advice.";
+const COACH_METADATA_INSTRUCTION =
+  'After your reply, add a line exactly once: METADATA: {"recommendedSplit":"...", "caloriesPerDay":1234, "macros":{"protein":150,"carbs":200,"fat":60}}. Omit fields instead of guessing wildly.';
 
 function sanitizeMessage(value: unknown): string {
   if (typeof value !== "string") return "";
@@ -135,6 +146,10 @@ function normalizeContext(data: unknown): CoachChatContext | undefined {
     typeof raw.nextWorkoutDayName === "string"
       ? raw.nextWorkoutDayName.trim().slice(0, 20)
       : undefined;
+  const dietPreference =
+    typeof raw.dietPreference === "string"
+      ? raw.dietPreference.trim().slice(0, 80)
+      : undefined;
   return scrubUndefined({
     todayCalories: toNumber(raw.todayCalories),
     todayCaloriesGoal: toNumber(raw.todayCaloriesGoal),
@@ -147,6 +162,9 @@ function normalizeContext(data: unknown): CoachChatContext | undefined {
     lastScanDate: sanitizeIsoString(raw.lastScanDate),
     lastScanBodyFatPercent: toNumber(raw.lastScanBodyFatPercent),
     nextWorkoutDayName: nextWorkoutDayName || undefined,
+    timelineWeeks: toNumber(raw.timelineWeeks),
+    trainingDaysPerWeek: toNumber(raw.trainingDaysPerWeek),
+    dietPreference: dietPreference || undefined,
   }) as CoachChatContext;
 }
 
@@ -193,6 +211,9 @@ function mergeContext(
     "lastScanDate",
     "lastScanBodyFatPercent",
     "nextWorkoutDayName",
+    "timelineWeeks",
+    "trainingDaysPerWeek",
+    "dietPreference",
   ];
   for (const key of keys) {
     const value = clientContext[key];
@@ -206,7 +227,8 @@ function mergeContext(
 
 function toDateOrNull(value: any): Date | null {
   if (!value) return null;
-  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value : null;
+  if (value instanceof Date)
+    return Number.isFinite(value.getTime()) ? value : null;
   if (typeof value.toDate === "function") {
     try {
       const d = value.toDate();
@@ -252,8 +274,10 @@ async function buildServerContext(params: {
     const data = snap.exists ? (snap.data() as any) : null;
     const totals = (data?.totals as any) || null;
     const calories = Number(totals?.calories ?? data?.calories) || 0;
-    const protein = Number(totals?.protein ?? totals?.protein_g ?? data?.protein_g) || 0;
-    const carbs = Number(totals?.carbs ?? totals?.carbs_g ?? data?.carbs_g) || 0;
+    const protein =
+      Number(totals?.protein ?? totals?.protein_g ?? data?.protein_g) || 0;
+    const carbs =
+      Number(totals?.carbs ?? totals?.carbs_g ?? data?.carbs_g) || 0;
     const fat = Number(totals?.fat ?? totals?.fat_g ?? data?.fat_g) || 0;
     serverComputed.todayCalories = calories;
     serverComputed.todayProteinGrams = protein;
@@ -273,16 +297,22 @@ async function buildServerContext(params: {
     const planSnap = await db.doc(`users/${uid}/coachPlans/current`).get();
     if (planSnap.exists) {
       const plan = planSnap.data() as any;
-      const calorieTarget = toNumber(plan?.calorieTarget ?? plan?.targetCalories);
+      const calorieTarget = toNumber(
+        plan?.calorieTarget ?? plan?.targetCalories
+      );
       const proteinFloor = toNumber(plan?.proteinFloor ?? plan?.proteinTarget);
-      if (calorieTarget !== undefined) serverComputed.todayCaloriesGoal = calorieTarget;
+      if (calorieTarget !== undefined)
+        serverComputed.todayCaloriesGoal = calorieTarget;
       if (proteinFloor !== undefined)
         serverComputed.todayProteinGoalGrams = proteinFloor;
       const macros = plan?.macros;
       if (macros && typeof macros === "object") {
-        const carbsGoal = toNumber((macros as any).carbs ?? (macros as any).carb);
+        const carbsGoal = toNumber(
+          (macros as any).carbs ?? (macros as any).carb
+        );
         const fatGoal = toNumber((macros as any).fat);
-        if (carbsGoal !== undefined) serverComputed.todayCarbGoalGrams = carbsGoal;
+        if (carbsGoal !== undefined)
+          serverComputed.todayCarbGoalGrams = carbsGoal;
         if (fatGoal !== undefined) serverComputed.todayFatGoalGrams = fatGoal;
       }
     }
@@ -304,7 +334,8 @@ async function buildServerContext(params: {
     if (!scansSnap.empty) {
       const doc = scansSnap.docs[0];
       const scan = doc.data() as any;
-      const createdAt = toDateOrNull(scan?.createdAt) ?? toDateOrNull(scan?.completedAt);
+      const createdAt =
+        toDateOrNull(scan?.createdAt) ?? toDateOrNull(scan?.completedAt);
       if (createdAt) {
         serverComputed.lastScanDate = createdAt.toISOString();
       }
@@ -333,14 +364,18 @@ async function buildServerContext(params: {
 
 function buildCoachContextBlock(context?: CoachChatContext): string | null {
   if (!context) return null;
-  const hasAny =
-    Object.values(context).some((v) => v !== undefined) &&
-    (Number(context.todayCalories) > 0 ||
-      Number(context.todayProteinGrams) > 0 ||
-      Number(context.todayCarbGrams) > 0 ||
-      Number(context.todayFatGrams) > 0 ||
-      typeof context.lastScanDate === "string" ||
-      typeof context.todayCaloriesGoal === "number");
+  const hasAny = Object.entries(context).some(([key, value]) => {
+    if (value === undefined || value === null || value === "") return false;
+    if (
+      key === "todayCalories" ||
+      key === "todayProteinGrams" ||
+      key === "todayCarbGrams" ||
+      key === "todayFatGrams"
+    ) {
+      return Number(value) > 0;
+    }
+    return true;
+  });
   if (!hasAny) return null;
 
   const safe = scrubUndefined({
@@ -355,6 +390,9 @@ function buildCoachContextBlock(context?: CoachChatContext): string | null {
     lastScanDate: context.lastScanDate,
     lastScanBodyFatPercent: context.lastScanBodyFatPercent,
     nextWorkoutDayName: context.nextWorkoutDayName,
+    timelineWeeks: context.timelineWeeks,
+    trainingDaysPerWeek: context.trainingDaysPerWeek,
+    dietPreference: context.dietPreference,
   });
 
   return `TODAY_AT_A_GLANCE: ${JSON.stringify(safe)}`;
@@ -373,6 +411,7 @@ function buildPrompt(input: CoachChatRequest): string {
     context.push(`Activity level: ${input.activityLevel}`);
 
   const lines: string[] = [];
+  lines.push(COACH_PERSONA_AND_SAFETY_PROMPT);
   lines.push(
     "Provide a concise, motivational yet practical answer for the user below."
   );
@@ -387,24 +426,22 @@ function buildPrompt(input: CoachChatRequest): string {
   }
   lines.push("Question:");
   lines.push(input.message);
-  lines.push(
-    "Respond in 2-3 short paragraphs max. Prioritize safety, progressive overload, recovery, and nutrition."
-  );
-  lines.push(
-    'After your reply, add a line exactly once: METADATA: {"recommendedSplit":"...", "caloriesPerDay":1234, "macros":{"protein":150,"carbs":200,"fat":60}}. Omit fields instead of guessing wildly.'
-  );
+  lines.push("Respond in 2-3 short paragraphs max.");
+  lines.push(COACH_METADATA_INSTRUCTION);
   return lines.join("\n");
 }
 
 function buildContextLines(input: CoachChatRequest): string[] {
   const context: string[] = [];
   if (input.goalType) context.push(`Goal focus: ${input.goalType}`);
-  if (input.currentWeight) context.push(`Current weight: ${input.currentWeight} kg`);
+  if (input.currentWeight)
+    context.push(`Current weight: ${input.currentWeight} kg`);
   if (input.goalWeight) context.push(`Goal weight: ${input.goalWeight} kg`);
   if (input.heightCm) context.push(`Height: ${input.heightCm} cm`);
   if (input.sex) context.push(`Sex: ${input.sex}`);
   if (input.age) context.push(`Age: ${input.age}`);
-  if (input.activityLevel) context.push(`Activity level: ${input.activityLevel}`);
+  if (input.activityLevel)
+    context.push(`Activity level: ${input.activityLevel}`);
   return context;
 }
 
@@ -466,8 +503,10 @@ function parseMetadataLine(source: string): {
   return { replyText: replyText || source.trim(), metadata };
 }
 
-
-function deterministicCoachFallback(payload: CoachChatRequest, requestId: string): CoachChatResponsePayload {
+function deterministicCoachFallback(
+  payload: CoachChatRequest,
+  requestId: string
+): CoachChatResponsePayload {
   const goal = (payload.goalType || "general").toLowerCase();
   const experience = (payload.activityLevel || "beginner").toLowerCase();
   const cardioDays = goal.includes("fat") ? 4 : goal.includes("muscle") ? 2 : 3;
@@ -553,8 +592,8 @@ function threadMessagesToOpenAI(
     {
       role: "system",
       content:
-        "You are MyBodyScan's virtual coach. Respond with concise, motivational guidance in under 150 words. Avoid medical advice.\n" +
-        'After your reply, add a line exactly once: METADATA: {"recommendedSplit":"...", "caloriesPerDay":1234, "macros":{"protein":150,"carbs":200,"fat":60}}. Omit fields instead of guessing wildly.',
+        `${COACH_PERSONA_AND_SAFETY_PROMPT} Respond in under 150 words.\n` +
+        COACH_METADATA_INSTRUCTION,
     },
   ];
 
@@ -686,7 +725,8 @@ async function generateCoachResponseForThread(
       requestId: context.requestId,
       model,
       tokens:
-        (usage?.promptTokens ?? 0) + (usage?.completionTokens ?? 0) || undefined,
+        (usage?.promptTokens ?? 0) + (usage?.completionTokens ?? 0) ||
+        undefined,
       metadata,
     },
   });
@@ -711,9 +751,49 @@ async function generateCoachResponseForThread(
       metadata,
       model,
       tokens:
-        (usage?.promptTokens ?? 0) + (usage?.completionTokens ?? 0) || undefined,
+        (usage?.promptTokens ?? 0) + (usage?.completionTokens ?? 0) ||
+        undefined,
     },
   };
+}
+
+async function ensureCoachEntitled(
+  uid: string,
+  tokenOrClaims?: Record<string, unknown> | null,
+  email?: string | null
+): Promise<void> {
+  const tokenEmail =
+    typeof email === "string" && email.trim()
+      ? email.trim()
+      : typeof tokenOrClaims?.email === "string"
+        ? tokenOrClaims.email
+        : null;
+  const role =
+    typeof tokenOrClaims?.role === "string"
+      ? tokenOrClaims.role.toLowerCase()
+      : "";
+  const claimEntitled =
+    hasUnlimitedAccessFromClaims(tokenOrClaims as any) ||
+    tokenOrClaims?.dev === true ||
+    tokenOrClaims?.pro === true ||
+    role === "dev" ||
+    role === "staff" ||
+    role === "pro";
+  const staffOrPro =
+    claimEntitled || (await hasProEntitlement(uid, tokenEmail));
+
+  if (staffOrPro) {
+    return;
+  }
+
+  const userSnap = await db.doc(`users/${uid}`).get();
+  const active = hasActiveSubscriptionFromUserDoc(userSnap.data());
+  if (!active) {
+    throw new HttpsError(
+      "permission-denied",
+      "Coach is available on an active plan or Unlimited. Visit Plans to activate your account."
+    );
+  }
 }
 
 function getHttpsErrorDetails(error: HttpsError): any {
@@ -787,14 +867,16 @@ function httpStatusFromHttpsError(error: HttpsError): number {
   }
 }
 
-async function resolveUidFromRequest(req: Request): Promise<string | null> {
+async function resolveAuthFromRequest(
+  req: Request
+): Promise<{ uid: string; token: Record<string, unknown> } | null> {
   const header = req.get("Authorization") || req.get("authorization") || "";
   if (!header.startsWith("Bearer ")) return null;
   const idToken = header.slice("Bearer ".length).trim();
   if (!idToken) return null;
   try {
     const decoded = await getAuth().verifyIdToken(idToken);
-    return decoded.uid ?? null;
+    return decoded.uid ? { uid: decoded.uid, token: decoded as any } : null;
   } catch (error) {
     logger.warn("coachChat.http.auth_failed", {
       message: (error as Error)?.message,
@@ -824,23 +906,11 @@ export const coachChat = onCall<CoachChatRequest>(
       throw new HttpsError("unauthenticated", "Authentication required");
     }
 
-    // Entitlement gate: Unlimited credits OR active subscription.
+    // Entitlement gate: Unlimited/dev/staff/pro claims OR active subscription.
     // Keep this server-side so a misconfigured client can't bypass it.
     try {
       const token = request.auth?.token as any;
-      const tokenEmail = typeof token?.email === "string" ? token.email : null;
-      const unlimited = hasUnlimitedAccessFromClaims(token);
-      const staffOrPro = unlimited || (await hasProEntitlement(uid, tokenEmail));
-      if (!staffOrPro) {
-        const userSnap = await db.doc(`users/${uid}`).get();
-        const active = hasActiveSubscriptionFromUserDoc(userSnap.data());
-        if (!active) {
-          throw new HttpsError(
-            "permission-denied",
-            "Coach is available on an active plan or Unlimited. Visit Plans to activate your account."
-          );
-        }
-      }
+      await ensureCoachEntitled(uid, token);
     } catch (error) {
       if (error instanceof HttpsError) throw error;
       throw new HttpsError(
@@ -883,7 +953,11 @@ export const coachChat = onCall<CoachChatRequest>(
         requestId,
       };
       if (payload.threadId) {
-        return await generateCoachResponseForThread(payload, ctx, payload.threadId);
+        return await generateCoachResponseForThread(
+          payload,
+          ctx,
+          payload.threadId
+        );
       }
       return await generateCoachResponse(payload, ctx);
     } catch (error) {
@@ -893,7 +967,10 @@ export const coachChat = onCall<CoachChatRequest>(
         message: (error as Error)?.message,
       });
       const mapped = toHttpsError(error, requestId);
-      if (mapped.code === "failed-precondition" || mapped.code === "unavailable") {
+      if (
+        mapped.code === "failed-precondition" ||
+        mapped.code === "unavailable"
+      ) {
         return deterministicCoachFallback(payload, requestId);
       }
       throw mapped;
@@ -940,13 +1017,15 @@ export async function coachChatHandler(
 
   const requestId = req.get("x-request-id")?.trim() || randomUUID();
   const identifier = identifierFromRequest(req);
-  const uid = await resolveUidFromRequest(req);
+  const auth = await resolveAuthFromRequest(req);
+  const uid = auth?.uid ?? null;
   await ensureSoftAppCheckFromRequest(req, { fn: "coachChat", uid, requestId });
 
   try {
-    if (!uid) {
+    if (!uid || !auth) {
       throw new HttpsError("unauthenticated", "Authentication required");
     }
+    await ensureCoachEntitled(uid, auth.token);
     await enforceRateLimit({
       uid,
       key: "coachChat",
@@ -965,7 +1044,10 @@ export async function coachChatHandler(
     res.status(200).json(response);
   } catch (error) {
     const mapped = toHttpsError(error, requestId);
-    if (mapped.code === "failed-precondition" || mapped.code === "unavailable") {
+    if (
+      mapped.code === "failed-precondition" ||
+      mapped.code === "unavailable"
+    ) {
       res.status(200).json(deterministicCoachFallback(payload, requestId));
       return;
     }

--- a/src/pages/Coach/Chat.tsx
+++ b/src/pages/Coach/Chat.tsx
@@ -189,15 +189,16 @@ export default function CoachChatPage() {
   const coachPrereqMessage =
     systemHealth?.openaiConfigured === false ||
     systemHealth?.openaiKeyPresent === false
-        ? "Coach chat requires the OpenAI key (OPENAI_API_KEY). Ask an admin to add it."
-        : coachConfigured === false
-          ? "Coach chat is offline until the backend configuration is completed."
-          : null;
+      ? "Coach chat requires the OpenAI key (OPENAI_API_KEY). Ask an admin to add it."
+      : coachConfigured === false
+        ? "Coach chat is offline until the backend configuration is completed."
+        : null;
   const coachAvailable = coachConfigured && !coachPrereqMessage;
   const coachEntitled = canUseCoach({
     demo,
     entitlements,
   });
+  const coachInteractive = coachAvailable && coachEntitled;
   const { totals, latestScan } = useCoachTodayAtAGlance();
 
   const startListening = () => {
@@ -341,8 +342,10 @@ export default function CoachChatPage() {
             })
             .filter((t): t is ThreadMeta => Boolean(t))
             .sort((a, b) => {
-              const am = a.updatedAt?.getTime?.() ?? a.createdAt?.getTime?.() ?? 0;
-              const bm = b.updatedAt?.getTime?.() ?? b.createdAt?.getTime?.() ?? 0;
+              const am =
+                a.updatedAt?.getTime?.() ?? a.createdAt?.getTime?.() ?? 0;
+              const bm =
+                b.updatedAt?.getTime?.() ?? b.createdAt?.getTime?.() ?? 0;
               if (am !== bm) return bm - am;
               const ac = a.createdAt?.getTime?.() ?? 0;
               const bc = b.createdAt?.getTime?.() ?? 0;
@@ -373,7 +376,8 @@ export default function CoachChatPage() {
             threadStorageKey && typeof window !== "undefined"
               ? window.localStorage.getItem(threadStorageKey)
               : null;
-          const storedValid = stored && nextThreads.some((t) => t.id === stored);
+          const storedValid =
+            stored && nextThreads.some((t) => t.id === stored);
           setActiveThreadId((prev) => {
             if (prev && nextThreads.some((t) => t.id === prev)) return prev;
             if (storedValid) return stored!;
@@ -490,10 +494,10 @@ export default function CoachChatPage() {
           },
           async (err) => {
             console.warn("coachChat.snapshot_failed", err);
-          recordPermissionDenied(err, {
-            op: "coachChatLegacy.onSnapshot",
-            path: uid ? coachChatCollectionPath(uid) : undefined,
-          });
+            recordPermissionDenied(err, {
+              op: "coachChatLegacy.onSnapshot",
+              path: uid ? coachChatCollectionPath(uid) : undefined,
+            });
             void reportError({
               kind: "coach_legacy_snapshot_failed",
               message: err?.message || "coachChat legacy snapshot failed",
@@ -632,6 +636,21 @@ export default function CoachChatPage() {
       });
       return;
     }
+    if (!coachInteractive) {
+      const message = !coachAvailable
+        ? (coachPrereqMessage ??
+          "Coach chat is disabled until it is fully configured.")
+        : isNative()
+          ? "Coach is a Pro feature. Upgrade to Pro to unlock Coach."
+          : "Coach is a Pro feature. Visit Plans to upgrade and unlock Coach.";
+      setCoachError(message);
+      toast({
+        title: "Coach unavailable",
+        description: message,
+        variant: "destructive",
+      });
+      return;
+    }
     const threadId =
       typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
         ? crypto.randomUUID()
@@ -695,10 +714,13 @@ export default function CoachChatPage() {
       demoToast();
       return;
     }
-    if (!coachAvailable) {
-      const message =
-        coachPrereqMessage ??
-        "Coach chat is disabled until it is fully configured.";
+    if (!coachInteractive) {
+      const message = !coachAvailable
+        ? (coachPrereqMessage ??
+          "Coach chat is disabled until it is fully configured.")
+        : isNative()
+          ? "Coach is a Pro feature. Upgrade to Pro to unlock Coach."
+          : "Coach is a Pro feature. Visit Plans to upgrade and unlock Coach.";
       setCoachError(message);
       return;
     }
@@ -772,21 +794,20 @@ export default function CoachChatPage() {
       // Optimistic UI: add the user message immediately so the chat feels responsive.
       // Firestore snapshot will reconcile this once the write lands.
       setMessages((prev) =>
-        sortMessages(dedupeMessages([
-          ...prev.filter((m) => m.id !== messageId),
-          {
-            id: messageId,
-            role: "user",
-            content: sanitized,
-            createdAt: new Date(),
-          },
-        ]))
+        sortMessages(
+          dedupeMessages([
+            ...prev.filter((m) => m.id !== messageId),
+            {
+              id: messageId,
+              role: "user",
+              content: sanitized,
+              createdAt: new Date(),
+            },
+          ])
+        )
       );
       await setDoc(
-        doc(
-          coachThreadMessagesCollection(uid, threadId),
-          messageId
-        ) as any,
+        doc(coachThreadMessagesCollection(uid, threadId), messageId) as any,
         {
           role: "user",
           content: sanitized,
@@ -799,10 +820,7 @@ export default function CoachChatPage() {
         if (isPermissionDenied(err)) {
           await refreshAuthTokenSoft();
           return setDoc(
-            doc(
-              coachThreadMessagesCollection(uid, threadId),
-              messageId
-            ) as any,
+            doc(coachThreadMessagesCollection(uid, threadId), messageId) as any,
             {
               role: "user",
               content: sanitized,
@@ -872,6 +890,20 @@ export default function CoachChatPage() {
       toast({
         title: "Initializing",
         description: "Secure services are almost ready. Try again in a moment.",
+      });
+      return;
+    }
+    if (!coachInteractive) {
+      const message = !coachAvailable
+        ? (coachPrereqMessage ?? "Coach is unavailable right now.")
+        : isNative()
+          ? "Coach is a Pro feature. Upgrade to Pro to unlock Coach."
+          : "Coach is a Pro feature. Visit Plans to upgrade and unlock Coach.";
+      setCoachError(message);
+      toast({
+        title: "Coach unavailable",
+        description: message,
+        variant: "destructive",
       });
       return;
     }
@@ -984,12 +1016,16 @@ export default function CoachChatPage() {
                       size="sm"
                       variant="outline"
                       onClick={handleNewChat}
-                      disabled={readOnlyDemo || initializing || !coachAvailable}
+                      disabled={
+                        readOnlyDemo || initializing || !coachInteractive
+                      }
                       title={
                         readOnlyDemo
                           ? "Demo preview"
-                          : !coachAvailable
-                            ? coachPrereqMessage ?? "Coach unavailable"
+                          : !coachInteractive
+                            ? !coachAvailable
+                              ? (coachPrereqMessage ?? "Coach unavailable")
+                              : "Coach requires an active plan"
                             : undefined
                       }
                     >
@@ -1027,7 +1063,9 @@ export default function CoachChatPage() {
                             <div className="flex items-center justify-between text-xs text-muted-foreground">
                               <span>Coach</span>
                               <Badge
-                                variant={message.usedLLM ? "default" : "secondary"}
+                                variant={
+                                  message.usedLLM ? "default" : "secondary"
+                                }
                                 className="uppercase tracking-wide"
                               >
                                 {message.usedLLM ? "LLM" : "Rules"}
@@ -1055,8 +1093,8 @@ export default function CoachChatPage() {
                     </div>
                   ) : (
                     <p className="text-sm text-muted-foreground">
-                      No messages yet. Ask a question to get personalized training
-                      and nutrition tips.
+                      No messages yet. Ask a question to get personalized
+                      training and nutrition tips.
                     </p>
                   )}
                 </div>
@@ -1090,7 +1128,10 @@ export default function CoachChatPage() {
                     }
                     rows={4}
                     disabled={
-                      pending || readOnlyDemo || initializing || !coachAvailable
+                      pending ||
+                      readOnlyDemo ||
+                      initializing ||
+                      !coachInteractive
                     }
                     data-testid="coach-message-input"
                   />
@@ -1104,7 +1145,7 @@ export default function CoachChatPage() {
                           pending ||
                           readOnlyDemo ||
                           initializing ||
-                          !coachAvailable
+                          !coachInteractive
                         }
                         data-testid="coach-mic"
                       >
@@ -1129,7 +1170,7 @@ export default function CoachChatPage() {
                             pending ||
                             !input.trim() ||
                             initializing ||
-                            !coachAvailable
+                            !coachInteractive
                           }
                           data-testid="coach-send-button"
                         >
@@ -1165,7 +1206,9 @@ export default function CoachChatPage() {
                   ) : (
                     <Button
                       onClick={regeneratePlan}
-                      disabled={regenerating || initializing}
+                      disabled={
+                        regenerating || initializing || !coachInteractive
+                      }
                       className="w-full"
                     >
                       {regenerating

--- a/src/pages/TransformationPreview.tsx
+++ b/src/pages/TransformationPreview.tsx
@@ -34,14 +34,17 @@ export default function TransformationPreviewPage() {
   );
   const paidScanPreviewEligible = Boolean((scan as any)?.charged);
   const previewEligible = pro || paidScanPreviewEligible;
+  const canAccessPreview = previewEligible || internalAccess;
   const [state, setState] = useState<any>(null);
   const [loadingState, setLoadingState] = useState(true);
 
   useEffect(() => {
-    if (!user?.uid || !scanId) {
+    if (!user?.uid || !scanId || !canAccessPreview) {
+      setState(null);
       setLoadingState(false);
       return;
     }
+    setLoadingState(true);
     const unsub = subscribeTransformationPreview(
       user.uid,
       scanId,
@@ -52,7 +55,7 @@ export default function TransformationPreviewPage() {
       () => setLoadingState(false)
     );
     return () => unsub();
-  }, [user?.uid, scanId]);
+  }, [user?.uid, scanId, canAccessPreview]);
 
   const vm = useMemo(
     () =>
@@ -110,7 +113,7 @@ export default function TransformationPreviewPage() {
         copy: "Complete your plan setup so the preview can reflect your training target.",
       };
     }
-    if (state?.status === "ready" && state?.imageUrl) {
+    if (canAccessPreview && state?.status === "ready" && state?.imageUrl) {
       return {
         label: "Ready",
         copy: "Your Transformation Preview is ready.",
@@ -146,7 +149,8 @@ export default function TransformationPreviewPage() {
           </p>
         </CardHeader>
         <CardContent className="space-y-4">
-          {state?.status === "ready" &&
+          {canAccessPreview &&
+          state?.status === "ready" &&
           state?.imageUrl &&
           TRANSFORMATION_PREVIEW_ENTRY_ENABLED ? (
             <img


### PR DESCRIPTION
### Motivation
- Prevent an HTTP entitlement bypass in the Coach endpoint and lock down UI/preview surfaces so unpaid or unauthenticated users cannot trigger paid AI calls, deterministic fallbacks, or thread writes. 
- Ensure threaded Coach conversations use the same strict MyBodyScan persona and safety rules as single-shot chat and preserve small client-provided context fields. 

### Description
- Enforced shared entitlement check by adding `ensureCoachEntitled(uid, tokenOrClaims?, email?)` and using it in both the callable `coachChat` and HTTP `coachChatHandler` paths so unpaid/unauthenticated requests are rejected before any OpenAI call, fallback, thread write, assistant response, or paid-context reads. 
- Hardened threaded coach prompt by introducing a single `COACH_PERSONA_AND_SAFETY_PROMPT` reused for single-shot and threaded flows with explicit safety refusals and concise motivational guidance. 
- Preserved coach context fields by adding `timelineWeeks`, `trainingDaysPerWeek`, and `dietPreference` to `CoachChatContext`, updating `normalizeContext`, `mergeContext`, and `buildCoachContextBlock` so context is not dropped when only these fields are present. 
- Gated UI interactions by adding `coachInteractive = coachAvailable && coachEntitled` and applying it to New chat, Send, Regenerate and other callable/write entry points so non-entitled users cannot trigger backend writes or callable flows from the UI. 
- Gate Transformation Preview reads/renders so preview docs are only subscribed to and ready images rendered when `previewEligible || internalAccess`. 
- Exact files changed: `functions/src/coachChat.ts`, `src/pages/Coach/Chat.tsx`, `src/pages/TransformationPreview.tsx`. 
- Confirmed the temporary workflow `.github/workflows/pr-722-one-time-patch.yml` is absent/deleted from the branch and not in the diff, no Firestore/Storage rules were modified, and no secrets were added. 

### Testing
- Ran `npm run lint` (ESLint) which completed with warnings but 0 errors, satisfying the lint requirement. 
- Ran `npm run typecheck` (`tsc --noEmit`) which succeeded with no errors. 
- Ran `npm run build` (web) which completed successfully and produced production bundles. 
- Ran `npm --prefix functions run build` which completed successfully and produced the functions build artifacts. 
- Additional verification: `git` diff checks confirm the workflow file is absent and the only files changed are the three listed, and secret/key pattern search found no new secrets. 
- Status: PR #722 branch has the required blocker fixes applied and validated by the above automated checks and is ready for lead review again.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c2dce792c8325851a97c2496190d0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coach chat now captures diet preferences and training schedule details for improved personalization.

* **Improvements**
  * Enhanced coach feature availability checks with more specific error messaging to users.
  * Transformation preview now enforces proper access controls based on user eligibility status.
  * Refined message handling and UI responsiveness for coach interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->