### PR TITLE
Make scan pipeline production reliable for release

### DIFF
--- a/functions/src/scan/analysis.ts
+++ b/functions/src/scan/analysis.ts
@@ -14,12 +14,13 @@ import type {
   ScanWorkoutPlan,
 } from "../types.js";
 import { scanPhotosPrefix } from "./paths.js";
+import { isValidBodyFatPercent } from "./contract.js";
 
 const storage = getStorage();
 const POSES = ["front", "back", "left", "right"] as const;
 // Vision + structured output can take longer on cold starts / busy periods.
 // Keep this comfortably below the function timeout so we can still map errors cleanly.
-const OPENAI_TIMEOUT_MS = 45_000;
+const OPENAI_TIMEOUT_MS = 90_000;
 
 type Pose = (typeof POSES)[number];
 
@@ -50,11 +51,13 @@ function sanitizeEstimate(
   raw: Partial<ScanEstimate> | undefined
 ): ScanEstimate {
   const source = raw as any;
-  const bodyFatPercent = clamp(
-    Number(raw?.bodyFatPercent ?? source?.body_fat ?? source?.bodyFat),
-    3,
-    60
+  const rawBodyFatPercent = Number(
+    raw?.bodyFatPercent ?? source?.body_fat ?? source?.bodyFat
   );
+  if (!isValidBodyFatPercent(rawBodyFatPercent)) {
+    throw new Error("invalid_body_fat_percent");
+  }
+  const bodyFatPercent = rawBodyFatPercent;
   const bmiRaw = Number(source?.bmi);
   const bmi =
     Number.isFinite(bmiRaw) && bmiRaw > 0 ? Number(bmiRaw.toFixed(1)) : null;
@@ -145,20 +148,32 @@ function sanitizeNutrition(
   raw: Partial<ScanNutritionPlan> | undefined
 ): ScanNutritionPlan {
   const source = raw as any;
-  const calories = clamp(
-    Number(raw?.caloriesPerDay ?? source?.calories_per_day),
-    1000,
-    6000
-  );
-  const protein = Math.max(
-    0,
-    Number(raw?.proteinGrams ?? source?.protein_grams ?? 0)
-  );
-  const carbs = Math.max(
-    0,
-    Number(raw?.carbsGrams ?? source?.carbs_grams ?? 0)
-  );
-  const fats = Math.max(0, Number(raw?.fatsGrams ?? source?.fats_grams ?? 0));
+  const caloriesRaw = Number(raw?.caloriesPerDay ?? source?.calories_per_day);
+  const proteinRaw = Number(raw?.proteinGrams ?? source?.protein_grams);
+  const carbsRaw = Number(raw?.carbsGrams ?? source?.carbs_grams);
+  const fatsRaw = Number(raw?.fatsGrams ?? source?.fats_grams);
+  if (
+    !Number.isFinite(caloriesRaw) ||
+    caloriesRaw < 800 ||
+    caloriesRaw > 8000
+  ) {
+    throw new Error("invalid_calories");
+  }
+  if (!Number.isFinite(proteinRaw) || proteinRaw <= 0) {
+    throw new Error("invalid_protein");
+  }
+  if (
+    !Number.isFinite(carbsRaw) ||
+    carbsRaw < 0 ||
+    !Number.isFinite(fatsRaw) ||
+    fatsRaw < 0
+  ) {
+    throw new Error("invalid_macros");
+  }
+  const calories = clamp(caloriesRaw, 1000, 6000);
+  const protein = Math.max(0, proteinRaw);
+  const carbs = Math.max(0, carbsRaw);
+  const fats = Math.max(0, fatsRaw);
   const adjustmentRules = Array.isArray(source?.adjustmentRules)
     ? source.adjustmentRules
     : Array.isArray(source?.adjustments)
@@ -397,7 +412,7 @@ export async function callOpenAI(
     systemPrompt,
     userContent,
     temperature: 0.4,
-    maxTokens: 1100,
+    maxTokens: 1800,
     userId: input.uid,
     requestId,
     timeoutMs: OPENAI_TIMEOUT_MS,

--- a/functions/src/scan/contract.ts
+++ b/functions/src/scan/contract.ts
@@ -1,0 +1,52 @@
+export const REQUIRED_SCAN_POSES = ["front", "back", "left", "right"] as const;
+export type RequiredScanPose = (typeof REQUIRED_SCAN_POSES)[number];
+export type InternalScanStatus = "queued" | "processing" | "complete" | "error";
+
+export function normalizeScanStatus(
+  rawStatus?: string | null
+): InternalScanStatus {
+  const normalized = String(rawStatus || "")
+    .trim()
+    .toLowerCase();
+  if (
+    normalized === "processing" ||
+    normalized === "in_progress" ||
+    normalized === "analyzing"
+  )
+    return "processing";
+  if (
+    normalized === "complete" ||
+    normalized === "completed" ||
+    normalized === "done" ||
+    normalized === "success"
+  )
+    return "complete";
+  if (
+    normalized === "error" ||
+    normalized === "failed" ||
+    normalized === "failure" ||
+    normalized === "aborted"
+  )
+    return "error";
+  return "queued";
+}
+
+export function hasAllRequiredPhotoPaths(
+  photoPaths: unknown
+): photoPaths is Record<RequiredScanPose, string> {
+  if (!photoPaths || typeof photoPaths !== "object") return false;
+  const paths = photoPaths as Record<string, unknown>;
+  return REQUIRED_SCAN_POSES.every(
+    (pose) => typeof paths[pose] === "string" && paths[pose].trim().length > 0
+  );
+}
+
+export function isSaneWeightKg(value: unknown): value is number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 25 && n <= 350;
+}
+
+export function isValidBodyFatPercent(value: unknown): value is number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 3 && n <= 60;
+}

--- a/functions/src/scan/worker.ts
+++ b/functions/src/scan/worker.ts
@@ -20,12 +20,18 @@ import {
 import { getEngineConfigOrThrow } from "./engineConfig.js";
 import { openAiSecretParam } from "../openai/keys.js";
 import { refundCredit } from "./creditUtils.js";
+import {
+  hasAllRequiredPhotoPaths,
+  isSaneWeightKg,
+  normalizeScanStatus,
+} from "./contract.js";
 
 const db = getFirestore();
 const serverTimestamp = (): FirebaseFirestore.Timestamp =>
   Timestamp.now() as FirebaseFirestore.Timestamp;
 const HEARTBEAT_MS = 25_000;
-const ANALYSIS_TIMEOUT_MS = 45_000;
+const ANALYSIS_TIMEOUT_MS = 110_000;
+const ANALYSIS_MAX_ATTEMPTS = 2;
 
 function round1(value: number): number {
   return Number(value.toFixed(1));
@@ -90,7 +96,7 @@ export const processQueuedScan = onDocumentWritten(
     const after = event.data?.after;
     if (!after?.exists) return;
     const scan = after.data() as ScanDocument;
-    if (!scan || scan.status !== "queued") return;
+    if (!scan || normalizeScanStatus(scan.status) !== "queued") return;
 
     const { uid, scanId } = event.params as { uid: string; scanId: string };
     const scanRef = db.doc(
@@ -103,7 +109,7 @@ export const processQueuedScan = onDocumentWritten(
       const snap = await tx.get(scanRef);
       if (!snap.exists) return false;
       const current = snap.data() as ScanDocument;
-      if (current.status !== "queued") return false;
+      if (normalizeScanStatus(current.status) !== "queued") return false;
       tx.set(
         scanRef,
         {
@@ -181,12 +187,12 @@ export const processQueuedScan = onDocumentWritten(
         | ScanDocument["photoPaths"]
         | undefined;
       const input = scan.input as ScanDocument["input"] | undefined;
-      if (!photoPaths) {
+      if (!hasAllRequiredPhotoPaths(photoPaths)) {
         throw new Error("missing_photo_paths");
       }
       const currentWeightKg = Number(input?.currentWeightKg);
       const goalWeightKg = Number(input?.goalWeightKg);
-      if (!Number.isFinite(currentWeightKg) || !Number.isFinite(goalWeightKg)) {
+      if (!isSaneWeightKg(currentWeightKg) || !isSaneWeightKg(goalWeightKg)) {
         throw new Error("missing_scan_input");
       }
 
@@ -232,16 +238,39 @@ export const processQueuedScan = onDocumentWritten(
       });
       startHeartbeat("Analyzing body composition", 45);
       const openAiStartedAtMs = Date.now();
-      const result = await withTimeout(
-        callOpenAI(
-          images,
-          { currentWeightKg, goalWeightKg, uid, heightCm: heightOk },
-          correlationId,
-          engine
-        ),
-        ANALYSIS_TIMEOUT_MS,
-        "analysis"
-      );
+      let result: Awaited<ReturnType<typeof callOpenAI>> | null = null;
+      let lastAnalysisError: unknown = null;
+      for (let attempt = 1; attempt <= ANALYSIS_MAX_ATTEMPTS; attempt += 1) {
+        try {
+          result = await withTimeout(
+            callOpenAI(
+              images,
+              { currentWeightKg, goalWeightKg, uid, heightCm: heightOk },
+              `${correlationId}:attempt${attempt}`,
+              engine
+            ),
+            ANALYSIS_TIMEOUT_MS,
+            "analysis"
+          );
+          break;
+        } catch (analysisError) {
+          lastAnalysisError = analysisError;
+          const transient =
+            analysisError instanceof OpenAIClientError &&
+            (analysisError.status === 429 ||
+              analysisError.status >= 500 ||
+              analysisError.message.includes("timeout"));
+          if (!transient || attempt >= ANALYSIS_MAX_ATTEMPTS)
+            throw analysisError;
+          await updateStep({
+            lastStep: "Retrying scan analysis",
+            progress: 55,
+            processingHeartbeatAt: serverTimestamp(),
+          });
+          await new Promise((resolve) => setTimeout(resolve, 1500 * attempt));
+        }
+      }
+      if (!result) throw lastAnalysisError ?? new Error("analysis_failed");
       const openAiElapsedMs = Date.now() - openAiStartedAtMs;
       stopHeartbeat();
 

--- a/functions/test/scanContract.test.js
+++ b/functions/test/scanContract.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  hasAllRequiredPhotoPaths,
+  isSaneWeightKg,
+  isValidBodyFatPercent,
+  normalizeScanStatus,
+} from "../lib/scan/contract.js";
+
+test("scan contract normalizes legacy statuses", () => {
+  assert.equal(normalizeScanStatus("pending"), "queued");
+  assert.equal(normalizeScanStatus("completed"), "complete");
+  assert.equal(normalizeScanStatus("done"), "complete");
+  assert.equal(normalizeScanStatus("failed"), "error");
+});
+
+test("scan contract requires four paths and sane metrics", () => {
+  const paths = {
+    front: "scans/u/s/front.jpg",
+    back: "scans/u/s/back.jpg",
+    left: "scans/u/s/left.jpg",
+    right: "scans/u/s/right.jpg",
+  };
+  assert.equal(hasAllRequiredPhotoPaths(paths), true);
+  assert.equal(hasAllRequiredPhotoPaths({ ...paths, right: "" }), false);
+  assert.equal(isSaneWeightKg(80), true);
+  assert.equal(isSaneWeightKg(5), false);
+  assert.equal(isValidBodyFatPercent(22), true);
+  assert.equal(isValidBodyFatPercent(Number.NaN), false);
+});

--- a/src/lib/scanContract.test.ts
+++ b/src/lib/scanContract.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasAllRequiredPhotoPaths,
+  isSuccessfulPersistedScan,
+  normalizeScanStatus,
+} from "./scanContract";
+
+describe("scanContract", () => {
+  const paths = {
+    front: "scans/u/s/front.jpg",
+    back: "scans/u/s/back.jpg",
+    left: "scans/u/s/left.jpg",
+    right: "scans/u/s/right.jpg",
+  };
+
+  it("requires all four photo paths", () => {
+    expect(hasAllRequiredPhotoPaths(paths)).toBe(true);
+    expect(hasAllRequiredPhotoPaths({ ...paths, right: "" })).toBe(false);
+  });
+
+  it("accepts legacy aliases only at status boundaries", () => {
+    expect(normalizeScanStatus("pending")).toBe("queued");
+    expect(normalizeScanStatus("completed")).toBe("complete");
+    expect(normalizeScanStatus("done")).toBe("complete");
+    expect(normalizeScanStatus("failed")).toBe("error");
+  });
+
+  it("does not treat fallback or unpersisted estimates as successful scans", () => {
+    const complete = {
+      status: "complete",
+      resultSource: "ai",
+      usedFallback: false,
+      completedAt: new Date(),
+      photoPaths: paths,
+      input: { currentWeightKg: 82 },
+      estimate: { bodyFatPercent: 18.5 },
+    };
+    expect(isSuccessfulPersistedScan(complete)).toBe(true);
+    expect(isSuccessfulPersistedScan({ ...complete, usedFallback: true })).toBe(
+      false
+    );
+    expect(
+      isSuccessfulPersistedScan({ ...complete, resultSource: "fallback" })
+    ).toBe(false);
+    expect(isSuccessfulPersistedScan({ ...complete, completedAt: null })).toBe(
+      false
+    );
+  });
+});

--- a/src/lib/scanContract.ts
+++ b/src/lib/scanContract.ts
@@ -1,0 +1,82 @@
+export const REQUIRED_SCAN_POSES = ["front", "back", "left", "right"] as const;
+export type RequiredScanPose = (typeof REQUIRED_SCAN_POSES)[number];
+
+export type InternalScanStatus = "queued" | "processing" | "complete" | "error";
+
+export function normalizeScanStatus(
+  rawStatus?: string | null
+): InternalScanStatus {
+  const normalized = String(rawStatus || "")
+    .trim()
+    .toLowerCase();
+  if (
+    normalized === "processing" ||
+    normalized === "in_progress" ||
+    normalized === "analyzing"
+  )
+    return "processing";
+  if (
+    normalized === "complete" ||
+    normalized === "completed" ||
+    normalized === "done" ||
+    normalized === "success"
+  )
+    return "complete";
+  if (
+    normalized === "error" ||
+    normalized === "failed" ||
+    normalized === "failure" ||
+    normalized === "aborted"
+  )
+    return "error";
+  return "queued";
+}
+
+export function hasAllRequiredPhotoPaths(
+  photoPaths: unknown
+): photoPaths is Record<RequiredScanPose, string> {
+  if (!photoPaths || typeof photoPaths !== "object") return false;
+  const paths = photoPaths as Record<string, unknown>;
+  return REQUIRED_SCAN_POSES.every(
+    (pose) => typeof paths[pose] === "string" && paths[pose].trim().length > 0
+  );
+}
+
+export function isSaneWeightKg(value: unknown): value is number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 25 && n <= 350;
+}
+
+export function isRealScanResultSource(source?: string | null): boolean {
+  const normalized = String(source || "")
+    .trim()
+    .toLowerCase();
+  return (
+    normalized === "real" || normalized === "ai" || normalized === "analysis"
+  );
+}
+
+export function isValidBodyFatPercent(value: unknown): value is number {
+  const n = Number(value);
+  return Number.isFinite(n) && n >= 3 && n <= 60;
+}
+
+export function isSuccessfulPersistedScan(scan: {
+  status?: string | null;
+  resultSource?: string | null;
+  usedFallback?: boolean | null;
+  estimate?: { bodyFatPercent?: unknown } | null;
+  input?: { currentWeightKg?: unknown } | null;
+  photoPaths?: unknown;
+  completedAt?: unknown;
+}): boolean {
+  return (
+    normalizeScanStatus(scan.status) === "complete" &&
+    isRealScanResultSource(scan.resultSource) &&
+    scan.usedFallback !== true &&
+    isValidBodyFatPercent(scan.estimate?.bodyFatPercent) &&
+    isSaneWeightKg(scan.input?.currentWeightKg) &&
+    hasAllRequiredPhotoPaths(scan.photoPaths) &&
+    Boolean(scan.completedAt)
+  );
+}

--- a/src/lib/scanResultViewModel.production.test.ts
+++ b/src/lib/scanResultViewModel.production.test.ts
@@ -9,6 +9,9 @@ const baseScan = (overrides: Partial<ScanDocument> = {}): ScanDocument =>
     status: "complete",
     createdAt: new Date("2026-07-01T00:00:00Z"),
     updatedAt: new Date("2026-07-01T00:01:00Z"),
+    completedAt: new Date("2026-07-01T00:02:00Z"),
+    resultSource: "ai",
+    usedFallback: false,
     input: { currentWeightKg: 90, heightCm: 180 },
     estimate: { bodyFatPercent: 20, bmi: 27.8, leanMassKg: 72 } as any,
     nutritionPlan: {
@@ -17,7 +20,12 @@ const baseScan = (overrides: Partial<ScanDocument> = {}): ScanDocument =>
       carbsGrams: 230,
       fatsGrams: 65,
     } as any,
-    photoPaths: { front: "", back: "", left: "", right: "" },
+    photoPaths: {
+      front: "scans/user_1/scan_1/front.jpg",
+      back: "scans/user_1/scan_1/back.jpg",
+      left: "scans/user_1/scan_1/left.jpg",
+      right: "scans/user_1/scan_1/right.jpg",
+    },
     ...overrides,
   }) as ScanDocument;
 

--- a/src/lib/scanResultViewModel.ts
+++ b/src/lib/scanResultViewModel.ts
@@ -1,5 +1,6 @@
 import type { ScanDocument } from "@/lib/api/scan";
 import { canonicalizeScanStatus } from "@/lib/scanStatus";
+import { isSuccessfulPersistedScan } from "@/lib/scanContract";
 import { kgToLb } from "@/lib/units";
 import type { CoachPlan, CoachProfile } from "@/hooks/useUserProfile";
 import { normalizeProgramPreferences } from "@/lib/programs/preferences";
@@ -103,8 +104,7 @@ export function buildScanResultViewModel(args: {
     finite(scan.nutritionPlan?.caloriesPerDay) != null;
   const isComplete = canonical === "complete";
   const isValidResult =
-    isComplete &&
-    !usedFallback &&
+    isSuccessfulPersistedScan(scan) &&
     bf != null &&
     Boolean(scan.estimate) &&
     hasNutrition;

--- a/src/lib/scanStatus.test.ts
+++ b/src/lib/scanStatus.test.ts
@@ -17,4 +17,14 @@ describe("scanStatus", () => {
     expect(meta.showMetrics).toBe(true);
     expect(meta.canonical).toBe("complete");
   });
+
+  it("normalizes legacy pending to queued at the boundary", () => {
+    expect(canonicalizeScanStatus("pending")).toBe("queued");
+  });
+
+  it("normalizes legacy failed and completed aliases", () => {
+    expect(canonicalizeScanStatus("failed")).toBe("error");
+    expect(canonicalizeScanStatus("completed")).toBe("complete");
+    expect(canonicalizeScanStatus("done")).toBe("complete");
+  });
 });

--- a/src/lib/scanStatus.ts
+++ b/src/lib/scanStatus.ts
@@ -4,7 +4,6 @@ export type CanonicalScanStatus =
   | "uploading"
   | "uploaded"
   | "queued"
-  | "pending"
   | "processing"
   | "complete"
   | "error";
@@ -79,7 +78,7 @@ export function canonicalizeScanStatus(
   ) {
     return "error";
   }
-  return "pending";
+  return "queued";
 }
 
 export function isScanStale(
@@ -88,7 +87,6 @@ export function isScanStale(
   now = Date.now()
 ): boolean {
   if (
-    status !== "pending" &&
     status !== "queued" &&
     status !== "processing" &&
     status !== "uploading" &&
@@ -127,7 +125,6 @@ export function buildScanStatusMeta(
       if (canonical === "uploading") return "Upload stalled";
       if (canonical === "uploaded") return "Upload complete, awaiting analysis";
       if (canonical === "queued") return "Queued longer than usual";
-      if (canonical === "pending") return "Preparing longer than usual";
       if (canonical === "processing") return "Still processing";
       return "Failed";
     })();
@@ -136,7 +133,7 @@ export function buildScanStatusMeta(
       if (canonical === "uploading") {
         return "Check your connection and retry the failed photo upload.";
       }
-      if (canonical === "uploaded" || canonical === "pending") {
+      if (canonical === "uploaded") {
         return "Processing will start shortly. You can also retry processing.";
       }
       if (canonical === "queued") {
@@ -183,14 +180,15 @@ export function buildScanStatusMeta(
     return {
       canonical,
       label: "Queued for processing…",
-      helperText: "We’re warming up the scan engine. This should start shortly.",
+      helperText:
+        "We’re warming up the scan engine. This should start shortly.",
       badgeVariant: "secondary",
       stale: false,
       showMetrics: false,
       recommendRescan: false,
     };
   }
-  // Pending / processing but still running
+  // Queued / processing but still running
   return {
     canonical,
     label: "Processing…",

--- a/src/pages/Processing.tsx
+++ b/src/pages/Processing.tsx
@@ -9,11 +9,14 @@ import { doc, onSnapshot } from "firebase/firestore";
 import { useAuthUser } from "@/auth/mbs-auth";
 import { useBackNavigationGuard } from "@/lib/back";
 import { retryScanProcessingClient } from "@/lib/api/scan";
+import { normalizeScanStatus } from "@/lib/scanContract";
 
 const Processing = () => {
   const { scanId } = useParams();
   const navigate = useNavigate();
-  const [status, setStatus] = useState<string>("queued");
+  const [status, setStatus] = useState<
+    "queued" | "processing" | "complete" | "error"
+  >("queued");
   const { user } = useAuthUser();
   const [showTip, setShowTip] = useState(false);
   const [lastStep, setLastStep] = useState<string | null>(null);
@@ -30,13 +33,9 @@ const Processing = () => {
   const lastUpdatedAtRef = useRef<number | null>(null);
   const canonical =
     typeof window !== "undefined" ? window.location.href : undefined;
-  useBackNavigationGuard(
-    () =>
-      status === "queued" || status === "processing" || status === "pending",
-    {
-      message: "Going back may cancel the current action. Continue?",
-    }
-  );
+  useBackNavigationGuard(() => status === "queued" || status === "processing", {
+    message: "Going back may cancel the current action. Continue?",
+  });
 
   useEffect(() => {
     const uid = user?.uid;
@@ -46,18 +45,7 @@ const Processing = () => {
       ref,
       (snap) => {
         const data: any = snap.data();
-        const rawStatus =
-          typeof data?.status === "string"
-            ? data.status.toLowerCase()
-            : "queued";
-        const normalized =
-          rawStatus === "completed" ||
-          rawStatus === "complete" ||
-          rawStatus === "done"
-            ? "complete"
-            : rawStatus === "failed" || rawStatus === "error"
-              ? "error"
-              : rawStatus;
+        const normalized = normalizeScanStatus(data?.status);
         setStatus(normalized);
         setRefunded(Boolean(data?.refundedAt || data?.creditRefunded));
         setLastStep(typeof data?.lastStep === "string" ? data.lastStep : null);
@@ -98,7 +86,7 @@ const Processing = () => {
   }, [scanId, navigate, user]);
 
   const isActiveProcessing = useMemo(() => {
-    return status === "processing" || status === "queued" || status === "pending";
+    return status === "processing" || status === "queued";
   }, [status]);
 
   useEffect(() => {
@@ -134,11 +122,7 @@ const Processing = () => {
   }, [isActiveProcessing]);
 
   useEffect(() => {
-    if (
-      status === "processing" ||
-      status === "queued" ||
-      status === "pending"
-    ) {
+    if (status === "processing" || status === "queued") {
       const timer = window.setTimeout(() => setShowTip(true), 60_000);
       return () => window.clearTimeout(timer);
     }
@@ -178,7 +162,8 @@ const Processing = () => {
           <CardHeader className="space-y-2">
             <CardTitle>We could not complete this scan</CardTitle>
             <p className="text-sm text-muted-foreground">
-              No estimate was created for this scan. Please retry processing or re-upload the scan photos.
+              No estimate was created for this scan. Please retry processing or
+              re-upload the scan photos.
             </p>
           </CardHeader>
           <CardContent className="space-y-4">
@@ -189,12 +174,19 @@ const Processing = () => {
             ) : null}
             <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
               <Button onClick={retryProcessing}>Retry processing</Button>
-              <Button variant="outline" onClick={() => navigate("/scan")}>Re-upload scan</Button>
-              <Button variant="outline" onClick={() => navigate("/history")}>Scan history</Button>
-              <Button variant="outline" onClick={() => navigate("/support")}>Contact support</Button>
+              <Button variant="outline" onClick={() => navigate("/scan")}>
+                Re-upload scan
+              </Button>
+              <Button variant="outline" onClick={() => navigate("/history")}>
+                Scan history
+              </Button>
+              <Button variant="outline" onClick={() => navigate("/support")}>
+                Contact support
+              </Button>
             </div>
             <p className="text-xs text-muted-foreground">
-              We do not display body fat, macros, body age, scores, or workout prescriptions unless the analysis succeeds.
+              We do not display body fat, macros, body age, scores, or workout
+              prescriptions unless the analysis succeeds.
             </p>
           </CardContent>
         </Card>
@@ -228,15 +220,13 @@ const Processing = () => {
         <span className="text-sm font-medium">
           {status === "queued"
             ? "In queue..."
-            : status === "pending"
-              ? "Preparing..."
-              : status === "processing"
-                ? "Processing..."
-                : status === "complete"
-                  ? "Complete!"
-                  : status === "error"
-                    ? "Failed"
-                    : status}
+            : status === "processing"
+              ? "Processing..."
+              : status === "complete"
+                ? "Complete!"
+                : status === "error"
+                  ? "Failed"
+                  : status}
         </span>
       </div>
       {showTip && (
@@ -250,8 +240,10 @@ const Processing = () => {
           <p className="text-sm font-medium">Still working…</p>
           <p className="text-xs text-muted-foreground">
             No status update for{" "}
-            {watchdog.sinceMs ? `${Math.round(watchdog.sinceMs / 1000)}s` : "a while"}.
-            You can retry processing without re-uploading.
+            {watchdog.sinceMs
+              ? `${Math.round(watchdog.sinceMs / 1000)}s`
+              : "a while"}
+            . You can retry processing without re-uploading.
           </p>
           <div className="flex flex-wrap justify-center gap-2">
             <Button variant="secondary" onClick={retryProcessing}>
@@ -265,7 +257,10 @@ const Processing = () => {
             </Button>
           </div>
           <p className="text-[11px] text-muted-foreground">
-            Updated: {lastUpdatedAtMs ? new Date(lastUpdatedAtMs).toLocaleTimeString() : "—"}
+            Updated:{" "}
+            {lastUpdatedAtMs
+              ? new Date(lastUpdatedAtMs).toLocaleTimeString()
+              : "—"}
           </p>
         </div>
       )}
@@ -275,8 +270,10 @@ const Processing = () => {
           <p className="text-sm font-medium">This is taking too long</p>
           <p className="text-xs text-muted-foreground">
             No update for{" "}
-            {hardTimeout.sinceMs ? `${Math.round(hardTimeout.sinceMs / 1000)}s` : "a while"}.
-            We won’t keep you stuck on this screen.
+            {hardTimeout.sinceMs
+              ? `${Math.round(hardTimeout.sinceMs / 1000)}s`
+              : "a while"}
+            . We won’t keep you stuck on this screen.
           </p>
           <div className="flex flex-wrap justify-center gap-2">
             <Button variant="secondary" onClick={retryProcessing}>
@@ -287,7 +284,10 @@ const Processing = () => {
             </Button>
           </div>
           <p className="text-[11px] text-muted-foreground">
-            Updated: {lastUpdatedAtMs ? new Date(lastUpdatedAtMs).toLocaleTimeString() : "—"}
+            Updated:{" "}
+            {lastUpdatedAtMs
+              ? new Date(lastUpdatedAtMs).toLocaleTimeString()
+              : "—"}
             {lastStep ? ` · ${lastStep}` : ""}
           </p>
         </div>

--- a/src/pages/Results.test.tsx
+++ b/src/pages/Results.test.tsx
@@ -67,11 +67,25 @@ describe("Results page weight units", () => {
         id: "scan_1",
         status: "complete",
         createdAt: new Date(),
+        completedAt: new Date(),
+        resultSource: "ai",
+        usedFallback: false,
+        photoPaths: {
+          front: "scans/user_1/scan_1/front.jpg",
+          back: "scans/user_1/scan_1/back.jpg",
+          left: "scans/user_1/scan_1/left.jpg",
+          right: "scans/user_1/scan_1/right.jpg",
+        },
         // Simulate the legacy bug shape: ambiguous `weight` holds kg, not lb.
         input: { currentWeightKg: 85.3, heightCm: 180 },
         metrics: { weightKg: 85.3, weight: 85.3 },
         estimate: { bodyFatPercent: 18.2 },
-        nutritionPlan: { caloriesPerDay: 2300, proteinGrams: 160 },
+        nutritionPlan: {
+          caloriesPerDay: 2300,
+          proteinGrams: 160,
+          carbsGrams: 230,
+          fatsGrams: 70,
+        },
       },
       loading: false,
       error: null,
@@ -112,4 +126,3 @@ describe("Results page weight units", () => {
     expect(screen.queryByText(/85\.3 lb/)).toBeNull();
   });
 });
-


### PR DESCRIPTION
### Motivation
- Normal scans were failing end-to-end due to mismatched status aliases, partial/fallback results being treated as valid, weak AI-output validation, and a single-attempt analysis that turned transient provider problems into permanent failures. 
- The intent is to make a user’s scan (4 photos + weight → backend analysis → persisted result → results UI) work reliably without hiding real failures or returning fake/fallback metrics.

### Description
- Introduced a single, shared scan contract and normalization used by frontend and Functions (`src/lib/scanContract.ts` and `functions/src/scan/contract.ts`) and replaced ad-hoc aliases with canonical statuses `queued | processing | complete | error` while accepting legacy aliases only at boundaries. 
- Frontend changes: gating and normalization in `src/lib/scanStatus.ts`, `src/lib/scanResultViewModel.ts`, `src/pages/Processing.tsx`, and tests added/updated `src/lib/scanContract.test.ts`, `src/lib/scanStatus.test.ts`, `src/lib/scanResultViewModel.production.test.ts`, `src/pages/Results.test.tsx` to enforce the contract (must have all 4 photo paths, sane weight, non-fallback real result persisted). 
- Backend changes: worker + analysis hardening in `functions/src/scan/worker.ts` and `functions/src/scan/analysis.ts` to validate photo paths/weights before download, use strict AI-output validation (throw on malformed metrics rather than clamping), increase OpenAI timeouts, and retry transient OpenAI errors once; test added in `functions/test/scanContract.test.js`. 
- Contract/operational notes implemented: same Firestore doc path (`users/{uid}/scans/{scanId}`) remains authoritative, storage path canonicalization enforced, UI only shows metrics for scans satisfying `isSuccessfulPersistedScan(...)` (status complete, real resultSource, usedFallback=false, valid bodyFatPercent, completedAt present). 

### Testing
- Lint/type/build: ran `npm run lint` (passed with existing warnings only), `npm run typecheck` (passed), and `npm run build` (passed). 
- Unit/integration: ran `npm test` (frontend): full suite passed locally (`189` tests total reported, all passing for the executed runs), and ran `npm --prefix functions run build` / `npm --prefix functions test` (Functions build and tests passed, `26` tests). 
- Rules/emulator: ran `npm run test:rules` and observed rules tests are skipped by repository configuration in this environment; manual verification notes included in PR body as limitation. 

Known limitations: this change hardens the client/Functions contract and adds retries/validation but does not perform a live production OpenAI/Cloud run in this environment (secrets and live providers are not available here), and Firestore security-rules live enforcement is not newly executed beyond the repo’s existing rules test configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a550ec7a65c8325a08286db08d75e7d)