### PR TITLE
Fix production App Check CI verification

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -10,6 +10,10 @@ jobs:
   web-build:
     name: Web build
     runs-on: ubuntu-latest
+    env:
+      # Exercise the same App Check-configured environment used by production
+      # deployment without exposing or depending on the real site key.
+      VITE_APPCHECK_SITE_KEY: ci-enterprise-verification
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/lib/appCheck.provider.test.ts
+++ b/src/lib/appCheck.provider.test.ts
@@ -15,4 +15,12 @@ describe("Firebase App Check provider", () => {
     );
     expect(APP_CHECK_SOURCE).not.toContain("ReCaptchaV3Provider");
   });
+
+  it("keeps App Check inert under Vitest even when CI provides a site key", () => {
+    expect(APP_CHECK_SOURCE).toContain('env.VITEST === "true"');
+    expect(APP_CHECK_SOURCE).toContain('env.MODE === "test"');
+    expect(APP_CHECK_SOURCE).toContain(
+      'isTestRuntime || siteKeyRaw === "__DISABLE__"'
+    );
+  });
 });

--- a/src/lib/appCheck.ts
+++ b/src/lib/appCheck.ts
@@ -6,12 +6,13 @@ import {
 } from "firebase/app-check";
 import { firebaseApp } from "@/lib/firebase";
 
+const env = (import.meta as any).env ?? {};
+const isTestRuntime =
+  env.VITEST === true || env.VITEST === "true" || env.MODE === "test";
 const siteKeyRaw =
-  (import.meta as any).env?.VITE_APPCHECK_SITE_KEY ||
-  (import.meta as any).env?.VITE_RECAPTCHA_SITE_KEY ||
-  "";
-const siteKey = siteKeyRaw === "__DISABLE__" ? "" : siteKeyRaw;
-const debug = (import.meta as any).env?.VITE_APPCHECK_DEBUG_TOKEN || "";
+  env.VITE_APPCHECK_SITE_KEY || env.VITE_RECAPTCHA_SITE_KEY || "";
+const siteKey = isTestRuntime || siteKeyRaw === "__DISABLE__" ? "" : siteKeyRaw;
+const debug = isTestRuntime ? "" : env.VITE_APPCHECK_DEBUG_TOKEN || "";
 let initAttempted = false;
 let recaptchaWarned = false;
 

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -10,6 +10,10 @@ const SMOKE_WORKFLOW = fs.readFileSync(
   path.resolve(__dirname, "../.github/workflows/prod-smoke.yml"),
   "utf8"
 );
+const VERIFY_WORKFLOW = fs.readFileSync(
+  path.resolve(__dirname, "../.github/workflows/verify.yml"),
+  "utf8"
+);
 
 describe("production deployment authentication", () => {
   it("uses repository-restricted keyless Google authentication", () => {
@@ -27,5 +31,11 @@ describe("production deployment authentication", () => {
 
   it("does not require a GitHub secret for committed public Firebase config", () => {
     expect(SMOKE_WORKFLOW).not.toContain("secrets.FIREBASE_WEB_API_KEY");
+  });
+
+  it("runs PR verification with App Check configured like production", () => {
+    expect(VERIFY_WORKFLOW).toContain(
+      "VITE_APPCHECK_SITE_KEY: ci-enterprise-verification"
+    );
   });
 });


### PR DESCRIPTION
## Summary

- keep Firebase App Check disabled only inside Vitest, even when a production-style site-key environment variable is present
- run PR web verification with a safe non-secret App Check placeholder so this deployment path is covered before merging
- add regression coverage for both behaviors

## Root cause

The first production deploy workflow after #733 authenticated successfully but stopped in `Verify web release`: the real `VITE_APPCHECK_SITE_KEY` was available to Vitest, so telemetry tests attempted App Check token acquisition and timed out. No Firebase deploy step ran.

## Verification

- `VITE_APPCHECK_SITE_KEY=local-enterprise-verification npm test` — 86 files / 224 tests passed
- `npm run typecheck` — passed
- `npm run lint` — passed with 0 errors (historical warnings remain)
- `VITE_APPCHECK_SITE_KEY=local-enterprise-verification npm run build:prod` — passed, including bundle and Storage REST safeguards
- `node scripts/verify-dist-assets.js` — passed
- targeted Prettier and `git diff --check` — passed

Production App Check behavior remains unchanged; this only makes the test runtime inert and gives PR CI production-equivalent coverage.