### PR TITLE
Keep production credentials out of release tests

### DIFF
--- a/.github/workflows/deploy-functions-on-main.yml
+++ b/.github/workflows/deploy-functions-on-main.yml
@@ -22,14 +22,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - id: google-auth
-        name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v3
-        with:
-          project_id: mybodyscan-f3daf
-          workload_identity_provider: projects/157018993008/locations/global/workloadIdentityPools/github-actions/providers/mybodyscan
-          service_account: github-mybodyscan-deploy@mybodyscan-f3daf.iam.gserviceaccount.com
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -66,6 +58,17 @@ jobs:
 
       - name: Verify scan, credit, refund, and account deletion pipeline
         run: npm run verify:scan
+
+      # Keep production ADC out of unit tests and emulators. Firebase Admin v12
+      # does not parse the external-account file emitted for Workload Identity
+      # when it initializes during tests; deployment tools authenticate below.
+      - id: google-auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: mybodyscan-f3daf
+          workload_identity_provider: projects/157018993008/locations/global/workloadIdentityPools/github-actions/providers/mybodyscan
+          service_account: github-mybodyscan-deploy@mybodyscan-f3daf.iam.gserviceaccount.com
 
       - name: Deploy production in dependency order
         run: |

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -29,6 +29,20 @@ describe("production deployment authentication", () => {
     expect(WORKFLOW).toContain("npm run storage:cors:apply");
   });
 
+  it("keeps production cloud credentials out of tests and emulators", () => {
+    const verifyIndex = WORKFLOW.indexOf(
+      "Verify scan, credit, refund, and account deletion pipeline"
+    );
+    const authIndex = WORKFLOW.indexOf("Authenticate to Google Cloud");
+    const deployIndex = WORKFLOW.indexOf(
+      "Deploy production in dependency order"
+    );
+
+    expect(verifyIndex).toBeGreaterThan(-1);
+    expect(authIndex).toBeGreaterThan(verifyIndex);
+    expect(deployIndex).toBeGreaterThan(authIndex);
+  });
+
   it("does not require a GitHub secret for committed public Firebase config", () => {
     expect(SMOKE_WORKFLOW).not.toContain("secrets.FIREBASE_WEB_API_KEY");
   });


### PR DESCRIPTION
## Summary

- move keyless Google Cloud authentication to after all unit and emulator verification
- keep production ADC credentials out of Firebase Admin v12 test initialization
- retain authentication immediately before the dependency-ordered production deploy
- add a workflow-ordering regression test

## Root cause

Production workflow run #81 passed the web release gate, then seven Functions test files failed because `google-github-actions/auth` had already exported a Workload Identity external-account file through `GOOGLE_APPLICATION_CREDENTIALS`. Firebase Admin v12 attempted to parse that as a service-account key during test imports and rejected it. No deploy step ran.

## Verification

- `VITE_APPCHECK_SITE_KEY=local-enterprise-verification npm test` — 86 files / 225 tests passed
- `npm --prefix functions test` — 46/46 passed
- focused workflow regression test — 4/4 passed
- `npm run typecheck` — passed
- targeted Prettier and `git diff --check` — passed

This narrows production credential exposure and does not alter the deployment identity, project, permissions, or deployment order.