### PR TITLE
Preserve existing production Firestore indexes

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -2,6 +2,23 @@
   "indexes": [
     {
       "collectionGroup": "scans",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "scans",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "uid", "order": "ASCENDING" },
+        { "fieldPath": "status", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "scans",
       "queryScope": "COLLECTION",
       "fields": [{ "fieldPath": "createdAt", "order": "DESCENDING" }]
     },

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -14,6 +14,9 @@ const VERIFY_WORKFLOW = fs.readFileSync(
   path.resolve(__dirname, "../.github/workflows/verify.yml"),
   "utf8"
 );
+const FIRESTORE_INDEXES = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, "../firestore.indexes.json"), "utf8")
+);
 
 describe("production deployment authentication", () => {
   it("uses repository-restricted keyless Google authentication", () => {
@@ -41,6 +44,31 @@ describe("production deployment authentication", () => {
     expect(verifyIndex).toBeGreaterThan(-1);
     expect(authIndex).toBeGreaterThan(verifyIndex);
     expect(deployIndex).toBeGreaterThan(authIndex);
+  });
+
+  it("preserves existing production indexes without a forced deletion", () => {
+    expect(WORKFLOW).not.toMatch(/firestore:indexes[^\n]*--force/);
+    expect(FIRESTORE_INDEXES.indexes).toEqual(
+      expect.arrayContaining([
+        {
+          collectionGroup: "scans",
+          queryScope: "COLLECTION_GROUP",
+          fields: [
+            { fieldPath: "uid", order: "ASCENDING" },
+            { fieldPath: "createdAt", order: "DESCENDING" },
+          ],
+        },
+        {
+          collectionGroup: "scans",
+          queryScope: "COLLECTION_GROUP",
+          fields: [
+            { fieldPath: "uid", order: "ASCENDING" },
+            { fieldPath: "status", order: "ASCENDING" },
+            { fieldPath: "createdAt", order: "DESCENDING" },
+          ],
+        },
+      ])
+    );
   });
 
   it("does not require a GitHub secret for committed public Firebase config", () => {


### PR DESCRIPTION
## Summary

- add the two existing production `scans` collection-group indexes to the repository index manifest
- retain the four release indexes already declared
- explicitly guard against forced index deletion in the production workflow
- add regression coverage for the preserved live index definitions

## Root cause

Production workflow run #82 passed every verification gate, created a rollback Hosting channel, and verified Storage CORS. Firestore then refused the non-interactive index deploy because two live indexes were absent from `firestore.indexes.json`; using `--force` would delete them. The workflow stopped before deploying indexes, Functions, rules, or Hosting.

## Verification

- live `mybodyscan-f3daf` indexes inspected read-only and copied exactly
- focused workflow/index regression tests — 5/5 passed
- `npm run rules:check` — passed
- targeted Prettier and `git diff --check` — passed

This is additive and non-destructive: no production index will be removed.