### PR TITLE
Remove invalid one-field Firestore composites

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -20,26 +20,11 @@
     {
       "collectionGroup": "scans",
       "queryScope": "COLLECTION",
-      "fields": [{ "fieldPath": "createdAt", "order": "DESCENDING" }]
-    },
-    {
-      "collectionGroup": "scans",
-      "queryScope": "COLLECTION",
       "fields": [
         { "fieldPath": "charged", "order": "ASCENDING" },
         { "fieldPath": "status", "order": "ASCENDING" },
         { "fieldPath": "completedAt", "order": "DESCENDING" }
       ]
-    },
-    {
-      "collectionGroup": "stripeEvents",
-      "queryScope": "COLLECTION",
-      "fields": [{ "fieldPath": "created", "order": "DESCENDING" }]
-    },
-    {
-      "collectionGroup": "telemetryEvents",
-      "queryScope": "COLLECTION",
-      "fields": [{ "fieldPath": "createdAt", "order": "DESCENDING" }]
     }
   ],
   "fieldOverrides": []

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -71,6 +71,12 @@ describe("production deployment authentication", () => {
     );
   });
 
+  it("does not declare redundant one-field composite indexes", () => {
+    for (const index of FIRESTORE_INDEXES.indexes) {
+      expect(index.fields.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
   it("does not require a GitHub secret for committed public Firebase config", () => {
     expect(SMOKE_WORKFLOW).not.toContain("secrets.FIREBASE_WEB_API_KEY");
   });


### PR DESCRIPTION
## Summary

- remove three redundant one-field composite index declarations that Firestore rejects
- retain both existing production collection-group indexes
- retain the valid three-field paid-scan index required by application logic
- add regression coverage preventing future one-field composite declarations

## Root cause

Production workflow run #83 preserved the existing live indexes successfully, then Firestore rejected the first one-field `COLLECTION` composite with HTTP 400 because single-field indexes are automatic. The same defect existed for Stripe events and telemetry. The workflow stopped before deploying Functions, rules, or Hosting.

## Verification

- read-only live index check confirms production remains unchanged at exactly two indexes
- focused workflow/index regression tests — 6/6 passed
- `npm run rules:check` — passed
- JSON/TypeScript Prettier and `git diff --check` — passed

This remains non-destructive: no live index is removed and the workflow still does not use `--force`.