### PR TITLE
Bind aggregate API production secrets

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -5,10 +5,13 @@ import expressModule from "express";
 import type { NextFunction, Request, Response } from "express";
 import { randomUUID } from "node:crypto";
 import { onRequest } from "firebase-functions/v2/https";
+import { defineSecret } from "firebase-functions/params";
 import { billingRouter } from "./billing.js";
 import { coachRouter } from "./coach.js";
 import { allowCorsAndOptionalAppCheck } from "./http.js";
 import { nutritionRouter } from "./nutrition.js";
+import { openAiSecretParam } from "./openai/keys.js";
+import { stripeSecretKeyParam, stripeSecretParam } from "./stripe/keys.js";
 import { systemRouter } from "./systemRouter.js";
 
 export { health } from "./health.js";
@@ -67,6 +70,7 @@ export {
 } from "./nutrition.js";
 
 const express = expressModule as any;
+const usdaFdcApiKeyParam = defineSecret("USDA_FDC_API_KEY");
 const app = express();
 const apiRouter = express.Router();
 app.use(express.json({ limit: "2mb" }));
@@ -257,5 +261,18 @@ app.use((error: unknown, req: Request, res: Response, _next: NextFunction) => {
 });
 
 export const apiAppForTest = app;
-export const api = onRequest({ region: "us-central1" }, app);
+export const api = onRequest(
+  {
+    region: "us-central1",
+    // The aggregate API runs handlers from these routers in the API process.
+    // Their standalone Functions bindings do not carry over automatically.
+    secrets: [
+      openAiSecretParam,
+      stripeSecretParam,
+      stripeSecretKeyParam,
+      usdaFdcApiKeyParam,
+    ],
+  },
+  app
+);
 export { deleteScan } from "./http/deleteScan.js";

--- a/functions/test/apiSecrets.test.js
+++ b/functions/test/apiSecrets.test.js
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { api } from "../lib/index.js";
+
+test("aggregate API binds every router runtime secret", () => {
+  const secretKeys = (api.__endpoint?.secretEnvironmentVariables ?? [])
+    .map((entry) => entry.key)
+    .sort();
+
+  assert.deepEqual(secretKeys, [
+    "OPENAI_API_KEY",
+    "STRIPE_SECRET",
+    "STRIPE_SECRET_KEY",
+    "USDA_FDC_API_KEY",
+  ]);
+});

--- a/scripts/probe.mjs
+++ b/scripts/probe.mjs
@@ -42,6 +42,34 @@ const ENDPOINTS = [
     functionName: "api",
     path: "/api/nutrition/search?q=chicken breast",
     method: "GET",
+    expect: ({ status, parsed }) => {
+      if (status !== 200)
+        return { ok: false, message: `expected 200, got ${status}` };
+      if (!isObject(parsed) || parsed.status !== "ok") {
+        return { ok: false, message: "nutrition search was not healthy" };
+      }
+      if (!Array.isArray(parsed.results) || parsed.results.length === 0) {
+        return { ok: false, message: "nutrition search returned no results" };
+      }
+      return { ok: true };
+    },
+  },
+  {
+    name: "nutritionBarcode",
+    functionName: "api",
+    path: "/api/nutrition/barcode?code=737628064502",
+    method: "GET",
+    expect: ({ status, parsed }) => {
+      if (status !== 200)
+        return { ok: false, message: `expected 200, got ${status}` };
+      if (!isObject(parsed) || !Array.isArray(parsed.results)) {
+        return { ok: false, message: "unexpected barcode response shape" };
+      }
+      if (parsed.results.length === 0) {
+        return { ok: false, message: "barcode lookup returned no product" };
+      }
+      return { ok: true };
+    },
   },
   {
     name: "createCheckout",


### PR DESCRIPTION
## Summary

- bind OpenAI, Stripe, and USDA Secret Manager parameters to the aggregate `api` Function, whose in-process routers do not inherit bindings from standalone Functions
- add a Functions regression test for the aggregate API secret contract
- harden the production probe so nutrition search must return real results and a known barcode must resolve

## Production finding

After production workflow #85 deployed successfully, the authenticated production probe returned `503 nutrition_missing_usda_key` from `/api/nutrition/search`. The USDA secret exists and is correctly bound to the standalone nutrition Functions, but was not bound to the aggregate `api` Function serving the Hosting route. The same binding gap could affect entitled coach and legacy billing routes.

## Local verification

- `npm --prefix functions test` — 47/47 passed
- `npm run typecheck` — passed
- targeted ESLint — 0 errors (3 historical warnings in `functions/src/index.ts`)
- Prettier and `git diff --check` — passed

After merge, the production workflow will redeploy and the strengthened authenticated probe will be rerun against `mybodyscan-f3daf`.