### PR TITLE
Clean up production probe accounts

### DIFF
--- a/scripts/probe.mjs
+++ b/scripts/probe.mjs
@@ -150,6 +150,24 @@ const ENDPOINTS = [
       return { ok: false, message: "deleteScan did not return ok:true" };
     },
   },
+  {
+    name: "accountDelete",
+    functionName: "deleteAccount",
+    path: "/",
+    method: "POST",
+    body: {},
+    expect: ({ status, parsed }) => {
+      if (status !== 200)
+        return { ok: false, message: `expected 200, got ${status}` };
+      if (!isObject(parsed) || parsed.ok !== true) {
+        return {
+          ok: false,
+          message: "account deletion did not return ok:true",
+        };
+      }
+      return { ok: true };
+    },
+  },
 ];
 
 function ensureTrailingSlash(value) {

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -14,6 +14,10 @@ const VERIFY_WORKFLOW = fs.readFileSync(
   path.resolve(__dirname, "../.github/workflows/verify.yml"),
   "utf8"
 );
+const PROD_PROBE = fs.readFileSync(
+  path.resolve(__dirname, "../scripts/probe.mjs"),
+  "utf8"
+);
 const FIRESTORE_INDEXES = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "../firestore.indexes.json"), "utf8")
 );
@@ -122,5 +126,14 @@ describe("production deployment authentication", () => {
     expect(VERIFY_WORKFLOW).toContain(
       "VITE_APPCHECK_SITE_KEY: ci-enterprise-verification"
     );
+  });
+
+  it("deletes the temporary production probe account after scan cleanup", () => {
+    const scanCleanupIndex = PROD_PROBE.indexOf('name: "scanDelete"');
+    const accountCleanupIndex = PROD_PROBE.indexOf('name: "accountDelete"');
+
+    expect(scanCleanupIndex).toBeGreaterThan(-1);
+    expect(accountCleanupIndex).toBeGreaterThan(scanCleanupIndex);
+    expect(PROD_PROBE).toContain('functionName: "deleteAccount"');
   });
 });


### PR DESCRIPTION
## Summary

- finish the authenticated production probe with the real `deleteAccount` Function
- require HTTP 200 and `{ ok: true }`, so account deletion is now a production smoke gate
- keep scan cleanup before account cleanup
- add regression coverage that prevents the account cleanup step from being removed or reordered

## Production verification

The updated probe passed against `mybodyscan-f3daf`: health, entitlement gating, real nutrition search, known barcode lookup, checkout validation, scan start, missing-photo handling, scan deletion, and account deletion all returned the expected results. The temporary Auth account created by this run was deleted successfully.

## Local verification

- `PROJECT_ID=mybodyscan-f3daf npm run probe` — passed, including `deleteAccount` 200 `{ ok: true }`
- `npx vitest run tests/deploy-workflow.test.ts` — 10/10 passed
- Prettier and `git diff --check` — passed