### PR TITLE
Document scheduled Functions deployment permission

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -182,7 +182,9 @@ the current-state notes below say it was configured:
    The provider condition must remain restricted to repository
    `Antisgoat/mybodyscan` and `refs/heads/main`, and the service account must have
    zero user-managed keys. Its project roles are Firebase Admin, Cloud Functions
-   Admin, Cloud Build Editor, Service Account User, and Secret Manager Viewer.
+   Admin, Cloud Scheduler Admin (required to create and update Firebase scheduled
+   Function jobs), Cloud Build Editor, Service Account User, and Secret Manager
+   Viewer.
    Secret Manager Viewer exposes metadata, not secret payloads. Every declared
    Function secret must separately grant `roles/secretmanager.secretAccessor`
    to the Function runtime account


### PR DESCRIPTION
## Summary
- document the Cloud Scheduler Admin role required by Firebase scheduled function deployment
- keep the production IAM checklist aligned with the verified MyBodyScan deployment account

## Verification
- `git diff --check`
- production deployment rerun separately verifies the role against `mybodyscan-f3daf`