### PR TITLE
Remove stale production template and footer metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
     />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@lovable_dev" />
     <meta
       name="twitter:image"
       content="/logo-mbs.svg"

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -8,7 +8,7 @@ import { isNative } from "@/lib/platform";
 type Props = { children: ReactNode };
 type State = { hasError: boolean; message?: string; stack?: string };
 
-const SUPPORT_EMAIL = "support@mybodyscan.com";
+const SUPPORT_EMAIL = "support@mybodyscanapp.com";
 const CRASH_LOGGED_FLAG = "__mbs_app_crash_logged__";
 
 export class AppErrorBoundary extends Component<Props, State> {

--- a/src/components/BillingButtons.tsx
+++ b/src/components/BillingButtons.tsx
@@ -160,7 +160,7 @@ export default function BillingButtons({ className }: Props) {
       </div>
       {!enabled && !native && (
         <div className="mt-1 text-xs text-muted-foreground">
-          Billing disabled (no Stripe key).
+          Billing is unavailable in this session.
         </div>
       )}
     </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,6 +8,7 @@ interface BuildMeta {
 
 export default function Footer() {
   const [build, setBuild] = useState<BuildMeta | null>(null);
+  const currentYear = new Date().getFullYear();
 
   useEffect(() => {
     let cancelled = false;
@@ -33,14 +34,14 @@ export default function Footer() {
       <div className="mx-auto max-w-3xl px-4 py-6">
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-muted-foreground">
           <div className="flex items-center gap-1">
-            <span>© 2024 MyBodyScan</span>
+            <span>© {currentYear} MyBodyScan</span>
             {buildLabel ? (
               <span className="text-xs text-muted-foreground">
                 • Build {buildLabel}
               </span>
             ) : null}
           </div>
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center justify-center gap-4">
             <Link
               to="/privacy"
               className="hover:text-foreground transition-colors"
@@ -66,7 +67,7 @@ export default function Footer() {
               Health & Safety
             </Link>
             <a
-              href="mailto:support@mybodyscan.com"
+              href="mailto:support@mybodyscanapp.com"
               className="hover:text-foreground transition-colors"
             >
               Support

--- a/tests/production-metadata.test.ts
+++ b/tests/production-metadata.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "..");
+const read = (file: string) => fs.readFileSync(path.join(root, file), "utf8");
+
+describe("production document metadata", () => {
+  it("uses the canonical MyBodyScan domain without template attribution", () => {
+    const document = read("index.html");
+
+    expect(document).toContain(
+      '<link rel="canonical" href="https://mybodyscanapp.com/" />'
+    );
+    expect(document).toContain("MyBodyScan");
+    expect(document).not.toContain("lovable_dev");
+    expect(document).not.toContain("@lovable");
+  });
+
+  it("keeps public support links and status copy production-safe", () => {
+    const footer = read("src/components/Footer.tsx");
+    const errorBoundary = read("src/components/AppErrorBoundary.tsx");
+    const billing = read("src/components/BillingButtons.tsx");
+
+    expect(footer).toContain("new Date().getFullYear()");
+    expect(footer).toContain("support@mybodyscanapp.com");
+    expect(errorBoundary).toContain("support@mybodyscanapp.com");
+    expect(`${footer}\n${errorBoundary}`).not.toContain(
+      "support@mybodyscan.com"
+    );
+    expect(billing).not.toContain("no Stripe key");
+  });
+});


### PR DESCRIPTION
## Summary
- remove the stale `@lovable_dev` Twitter attribution from the production document
- make the public footer year current and align every visible/crash support link with `support@mybodyscanapp.com`
- replace a misleading client-side “no Stripe key” diagnostic with neutral session-availability copy; the live bundle separately passed a status-only `pk_live_…` presence check
- allow the public footer links to wrap on narrow screens
- add regression coverage for canonical domain, template attribution, support domain, year handling, and billing status copy

## Verification
- `npx vitest run tests/production-metadata.test.ts` (2/2)
- `npx eslint src/components/Footer.tsx src/components/AppErrorBoundary.tsx src/components/BillingButtons.tsx` (0 errors; 4 historical warnings)
- `npm run typecheck`
- `npm run build:prod`
- bundle-size and Storage REST safeguards passed as part of the production build

Follow-up from the post-deploy browser smoke check for #743.