### PR TITLE
Harden production smoke validation

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -414,6 +414,11 @@ checklist below.
 Run all items with a non-admin production test account and inspect data/logs
 without recording photo, health, token, or payment details in tickets.
 
+`npm run smoke` is a safe preliminary probe: it creates and deletes a
+disposable anonymous account, verifies health and nutrition responses, and
+confirms that Coach and Checkout reject an account without an entitlement or
+email. It does not replace the real-account scan and purchase checks below.
+
 - `GET /api/system/health`, `/system/health`, and the public health endpoint
   return success and report scan/OpenAI/Stripe/USDA wiring as configured.
 - Email, Google, and Apple sign-in work on the apex domain, `www`, and Firebase

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -57,7 +57,6 @@ SIGNUP_RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" \
   "https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=${FIREBASE_API_KEY}")
 
 ID_TOKEN=$(printf '%s' "$SIGNUP_RESPONSE" | node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync(0,'utf8'));console.log(d.idToken||'');")
-LOCAL_ID=$(printf '%s' "$SIGNUP_RESPONSE" | node -e "const fs=require('fs');const d=JSON.parse(fs.readFileSync(0,'utf8'));console.log(d.localId||'');")
 
 if [[ -z "$ID_TOKEN" ]]; then
   echo "[smoke] Failed to obtain ID token" >&2
@@ -74,7 +73,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "[smoke] Temporary UID ${LOCAL_ID}"
+echo "[smoke] Temporary account created"
 
 FAILURES=()
 
@@ -84,7 +83,8 @@ call_endpoint() {
   local url="$3"
   local body="${4:-}"
 
-  echo "[smoke] ${name}: ${method} ${url}"
+  local display_url="${url%%\?*}"
+  echo "[smoke] ${name}: ${method} ${display_url}"
   local response
   if [[ "$method" == "GET" ]]; then
     response=$(curl -s -w '\n%{http_code}' -H "Accept: application/json" -H "Authorization: Bearer ${ID_TOKEN}" "$url")
@@ -117,6 +117,10 @@ call_endpoint() {
         echo "[smoke] coachChat responded with app_check requirement"
         return
       fi
+      if [[ "$status" == "403" ]] && echo "$content" | grep -q 'permission-denied'; then
+        echo "[smoke] coachChat entitlement gate verified for disposable account"
+        return
+      fi
       # Treat missing OpenAI key / not-configured as a soft skip (still reported in logs).
       if [[ "$status" == "400" ]]; then
         local code
@@ -134,6 +138,10 @@ call_endpoint() {
         if [[ "$sessionField" == "1" ]]; then
           return
         fi
+      fi
+      if [[ "$status" == "400" ]] && echo "$content" | grep -q 'missing_email'; then
+        echo "[smoke] checkout email gate verified for disposable account"
+        return
       fi
       FAILURES+=("createCheckout:${status}")
       ;;

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -195,7 +195,13 @@ describe("production deployment authentication", () => {
 
   it("keeps disposable smoke output private and recognizes expected access gates", () => {
     expect(PRODUCTION_SMOKE).toContain('display_url="${url%%\\?*}"');
-    expect(PRODUCTION_SMOKE).not.toContain("Temporary UID ${LOCAL_ID}");
+    expect(PRODUCTION_SMOKE).not.toContain("LOCAL_ID");
+    expect(PRODUCTION_SMOKE).toContain(
+      'echo "[smoke] ${name}: ${method} ${display_url}"'
+    );
+    expect(PRODUCTION_SMOKE).not.toContain(
+      'echo "[smoke] ${name}: ${method} ${url}"'
+    );
     expect(PRODUCTION_SMOKE).toContain("permission-denied");
     expect(PRODUCTION_SMOKE).toContain("missing_email");
   });

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -18,6 +18,10 @@ const PROD_PROBE = fs.readFileSync(
   path.resolve(__dirname, "../scripts/probe.mjs"),
   "utf8"
 );
+const PRODUCTION_SMOKE = fs.readFileSync(
+  path.resolve(__dirname, "../scripts/smoke.sh"),
+  "utf8"
+);
 const FIRESTORE_INDEXES = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "../firestore.indexes.json"), "utf8")
 );
@@ -187,5 +191,12 @@ describe("production deployment authentication", () => {
     expect(scanCleanupIndex).toBeGreaterThan(-1);
     expect(accountCleanupIndex).toBeGreaterThan(scanCleanupIndex);
     expect(PROD_PROBE).toContain('functionName: "deleteAccount"');
+  });
+
+  it("keeps disposable smoke output private and recognizes expected access gates", () => {
+    expect(PRODUCTION_SMOKE).toContain('display_url="${url%%\\?*}"');
+    expect(PRODUCTION_SMOKE).not.toContain("Temporary UID ${LOCAL_ID}");
+    expect(PRODUCTION_SMOKE).toContain("permission-denied");
+    expect(PRODUCTION_SMOKE).toContain("missing_email");
   });
 });


### PR DESCRIPTION
## What changed

- redacts query strings and temporary account identifiers from production smoke output
- recognizes the expected Coach entitlement and Checkout email gates for the disposable anonymous account
- documents that this preliminary probe does not replace real-account scan and purchase testing
- adds regression coverage for the smoke-test privacy and access-gate behavior

## Why

The first post-deploy run proved production health and nutrition were working, but the smoke script incorrectly classified the expected access controls on an anonymous account as product failures and logged more identifier/config detail than necessary.

## Verification

- `npm run smoke` — passed against production; temporary account created and deleted
- `npm test` — 95 files, 260 tests passed
- `npm run lint` — 0 errors
- `npm run typecheck` — passed
- `npm run build:prod` — passed with bundle and Storage REST safeguards
- `bash -n scripts/smoke.sh` — passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated post-deployment smoke tests with a “safe preliminary probe” using a disposable anonymous account to verify health, nutrition, Coach access, and Checkout email requirements.
* **Bug Fixes**
  * Improved smoke-test reporting to avoid exposing temporary account identifiers.
  * Adjusted access-gate checks so expected entitlement/email denials are treated as successful validations.
  * Reduced URL detail in logs by omitting query parameters.
* **Tests**
  * Added assertions to confirm privacy-safe smoke output and verify expected access-gate indicators and display URL formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->