### PR TITLE
Fix production nutrition provider requests

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -415,9 +415,10 @@ Run all items with a non-admin production test account and inspect data/logs
 without recording photo, health, token, or payment details in tickets.
 
 `npm run smoke` is a safe preliminary probe: it creates and deletes a
-disposable anonymous account, verifies health and nutrition responses, and
-confirms that Coach and Checkout reject an account without an entitlement or
-email. It does not replace the real-account scan and purchase checks below.
+disposable anonymous account, requires non-empty healthy nutrition search and
+barcode-fallback responses, and confirms that Coach and Checkout reject an
+account without an entitlement or email. It does not replace the real-account
+scan and purchase checks below.
 
 - `GET /api/system/health`, `/system/health`, and the public health endpoint
   return success and report scan/OpenAI/Stripe/USDA wiring as configured.

--- a/functions/src/nutritionBarcode.ts
+++ b/functions/src/nutritionBarcode.ts
@@ -185,14 +185,19 @@ async function fetchOff(code: string) {
 async function fetchUsdaByBarcode(apiKey: string, code: string) {
   const url = new URL("https://api.nal.usda.gov/fdc/v1/foods/search");
   url.searchParams.set("api_key", apiKey);
-  url.searchParams.set("query", code);
-  url.searchParams.set("pageSize", "5");
-  url.searchParams.set("dataType", "Branded");
   const data = (await requestJson(
     url,
     {
-      method: "GET",
-      headers: { Accept: "application/json" },
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: code,
+        pageSize: 5,
+        dataType: ["Branded"],
+      }),
     },
     "usda_barcode"
   )) as any;

--- a/functions/src/nutritionSearch.ts
+++ b/functions/src/nutritionSearch.ts
@@ -573,15 +573,20 @@ async function searchUsda(
   if (!apiKey) return [];
   const url = new URL(USDA_SEARCH_URL);
   url.searchParams.set("api_key", apiKey);
-  url.searchParams.set("query", query);
-  url.searchParams.set("pageSize", "20");
-  url.searchParams.set("dataType", USDA_DATA_TYPES.join(","));
 
   const data = (await requestJson(
     url,
     {
-      method: "GET",
-      headers: { Accept: "application/json" },
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query,
+        pageSize: 20,
+        dataType: USDA_DATA_TYPES,
+      }),
     },
     "usda"
   )) as any;

--- a/functions/test/productionFeatureFoundations.test.js
+++ b/functions/test/productionFeatureFoundations.test.js
@@ -73,3 +73,25 @@ test("RevenueCat credit grants keep bucket totals as the balance source of truth
   assert.doesNotMatch(source, /currentCredits/);
   assert.doesNotMatch(source, /credits:\s*currentCredits/);
 });
+
+test("USDA search filters are sent as JSON arrays for search and barcode fallback", () => {
+  const searchSource = readFileSync(
+    new URL("../src/nutritionSearch.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(
+    searchSource,
+    /method:\s*"POST"[\s\S]*dataType:\s*USDA_DATA_TYPES/
+  );
+  assert.doesNotMatch(searchSource, /searchParams\.set\("dataType"/);
+
+  const barcodeSource = readFileSync(
+    new URL("../src/nutritionBarcode.ts", import.meta.url),
+    "utf8"
+  );
+  assert.match(
+    barcodeSource,
+    /method:\s*"POST"[\s\S]*dataType:\s*\["Branded"\]/
+  );
+  assert.doesNotMatch(barcodeSource, /searchParams\.set\("dataType"/);
+});

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -31,6 +31,7 @@ BASE_URL="${BASE_URL:-https://mybodyscanapp.com}"
 COACH_URL="${BASE_URL}/api/coach/chat"
 CHECKOUT_URL="${BASE_URL}/api/createCheckout"
 NUTRITION_URL="${BASE_URL}/api/nutrition/search?q=chicken%20breast"
+BARCODE_URL="${BASE_URL}/api/nutrition/barcode?code=737628064502"
 SYSTEM_URL="${BASE_URL}/systemHealth?clientKey=${FIREBASE_API_KEY}"
 
 PRICE_ID="${VITE_PRICE_STARTER:-}"
@@ -107,6 +108,13 @@ call_endpoint() {
     echo "$value"
   }
 
+  json_array_length() {
+    local key="$1"
+    local value=""
+    value=$(printf '%s' "$content" | node -e "const fs=require('fs');try{const d=JSON.parse(fs.readFileSync(0,'utf8'));const v=d&&typeof d==='object'?d['$key']:undefined;process.stdout.write(Array.isArray(v)?String(v.length):'');}catch(e){}" 2>/dev/null || true)
+    echo "$value"
+  }
+
   case "$name" in
     coachChat)
       # Accept healthy responses or transient upstream failures.
@@ -147,14 +155,11 @@ call_endpoint() {
       ;;
     nutritionSearch)
       if [[ "$status" == "200" ]]; then
-        return
-      fi
-      # Treat missing USDA key / not-configured as a soft skip.
-      if [[ "$status" == "501" ]]; then
-        local code
-        code="$(json_field code)"
-        if [[ "$code" == "nutrition_not_configured" ]] || echo "$content" | grep -qi 'USDA_FDC_API_KEY'; then
-          echo "[smoke] nutritionSearch skipped (backend not configured)"
+        local response_status
+        local result_count
+        response_status="$(json_field status)"
+        result_count="$(json_array_length results)"
+        if [[ "$response_status" == "ok" ]] && [[ "$result_count" =~ ^[1-9][0-9]*$ ]]; then
           return
         fi
       fi
@@ -164,6 +169,16 @@ call_endpoint() {
         return
       fi
       FAILURES+=("nutritionSearch:${status}")
+      ;;
+    nutritionBarcode)
+      if [[ "$status" == "200" ]]; then
+        local result_count
+        result_count="$(json_array_length results)"
+        if [[ "$result_count" =~ ^[1-9][0-9]*$ ]]; then
+          return
+        fi
+      fi
+      FAILURES+=("nutritionBarcode:${status}")
       ;;
     systemHealth)
       if [[ "$status" == "200" ]]; then
@@ -176,6 +191,7 @@ call_endpoint() {
 
 call_endpoint "systemHealth" "GET" "$SYSTEM_URL"
 call_endpoint "nutritionSearch" "GET" "$NUTRITION_URL"
+call_endpoint "nutritionBarcode" "GET" "$BARCODE_URL"
 call_endpoint "coachChat" "POST" "$COACH_URL" '{"message":"Diagnostics smoke test"}'
 
 if [[ -n "$PRICE_ID" ]]; then

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -202,6 +202,13 @@ describe("production deployment authentication", () => {
     expect(PRODUCTION_SMOKE).not.toContain(
       'echo "[smoke] ${name}: ${method} ${url}"'
     );
+    expect(PRODUCTION_SMOKE).toContain(
+      'response_status="$(json_field status)"'
+    );
+    expect(PRODUCTION_SMOKE).toContain('response_status" == "ok"');
+    expect(PRODUCTION_SMOKE).toContain('call_endpoint "nutritionBarcode"');
+    expect(PRODUCTION_SMOKE).toContain("json_array_length results");
+    expect(PRODUCTION_SMOKE).not.toContain("nutritionSearch skipped");
     expect(PRODUCTION_SMOKE).toContain("permission-denied");
     expect(PRODUCTION_SMOKE).toContain("missing_email");
   });


### PR DESCRIPTION
## Summary
- send USDA text-search and barcode filters as JSON arrays in POST bodies per the official FoodData Central contract
- require healthy non-empty text and barcode results in the production smoke probe
- add regression guards and update the production runbook

## Verification
- USDA public DEMO_KEY request: HTTP 200 with results
- npm --prefix functions test: 65 passed
- npm test: 95 files, 260 tests passed
- npm run lint: 0 errors, 1437 historical warnings
- npm run typecheck: passed
- npm run build:prod: passed, including bundle and Storage REST safeguards
- bash -n scripts/smoke.sh: passed
- npm run smoke: passed against production with USDA text results and a known barcode product