### PR TITLE
Fix nutrition subscription gate response

### DIFF
--- a/functions/src/nutritionSearch.ts
+++ b/functions/src/nutritionSearch.ts
@@ -875,41 +875,70 @@ async function runNutritionSearchCore(
   };
 }
 
-function handleError(res: Response, error: unknown, requestId: string): void {
-  if (error instanceof HttpError) {
-    if (error.status === 429) {
-      res.status(429).json({
+export function nutritionHttpErrorResponse(
+  error: HttpError,
+  requestId: string
+): { status: number; body: Record<string, unknown> } {
+  if (error.status === 429) {
+    return {
+      status: 429,
+      body: {
         code: "rate_limited",
         message: "Too many requests. Please slow down.",
         debugId: requestId,
         reason: "rate_limited",
-      });
-      return;
-    }
-    if (error.status === 401) {
-      res.status(401).json({
+      },
+    };
+  }
+  if (error.status === 401) {
+    return {
+      status: 401,
+      body: {
         code: error.code || "unauthorized",
         message: error.message || "Unauthorized",
         debugId: requestId,
         reason: "unauthorized",
-      });
-      return;
-    }
-    if (error.status === 501) {
-      res.status(503).json({
+      },
+    };
+  }
+  if (error.status === 403) {
+    return {
+      status: 403,
+      body: {
+        code: "permission_denied",
+        error: "permission_denied",
+        message: "An active monthly or yearly plan is required.",
+        debugId: requestId,
+        reason: "subscription_required",
+      },
+    };
+  }
+  if (error.status === 501) {
+    return {
+      status: 503,
+      body: {
         code: error.code || "nutrition_missing_usda_key",
         message: error.message || "Missing USDA_API_KEY",
         debugId: requestId,
         reason: "nutrition_not_configured",
-      });
-      return;
-    }
-    res.status(503).json({
+      },
+    };
+  }
+  return {
+    status: 503,
+    body: {
       code: "nutrition_backend_error",
       message: "Food database temporarily unavailable; please try again.",
       debugId: requestId,
       reason: "upstream_unavailable",
-    });
+    },
+  };
+}
+
+function handleError(res: Response, error: unknown, requestId: string): void {
+  if (error instanceof HttpError) {
+    const response = nutritionHttpErrorResponse(error, requestId);
+    res.status(response.status).json(response.body);
     return;
   }
 

--- a/functions/test/productionFeatureFoundations.test.js
+++ b/functions/test/productionFeatureFoundations.test.js
@@ -10,6 +10,10 @@ const { buildTransformationPrompt } = await import(
 const { buildPlateauMulticastMessage, deriveServerPlateauSignature } = await import(
   "../lib/pushNotifications.js"
 );
+const { nutritionHttpErrorResponse } = await import(
+  "../lib/nutritionSearch.js"
+);
+const { HttpError } = await import("../lib/util/http.js");
 
 test("transformation prompt is restrained and prohibits predictive or revealing output", () => {
   const prompt = buildTransformationPrompt({
@@ -30,6 +34,16 @@ test("transformation preview requires the canonical Pro entitlement", () => {
   );
   assert.match(source, /await requireProEntitlement\(uid\)/);
   assert.doesNotMatch(source, /paidScan|eligible paid scan/);
+});
+
+test("nutrition subscription failures remain 403 instead of looking like upstream outages", () => {
+  const response = nutritionHttpErrorResponse(
+    new HttpError(403, "permission_denied", "subscription_required"),
+    "request-id"
+  );
+  assert.equal(response.status, 403);
+  assert.equal(response.body.reason, "subscription_required");
+  assert.equal(response.body.code, "permission_denied");
 });
 
 test("server plateau detector uses current scan schema and rejects failed scans", () => {


### PR DESCRIPTION
## Production smoke finding
A disposable non-Pro account was correctly rejected before nutrition search, but the shared HTTP error mapper converted the entitlement HttpError 403 into a generic 503 upstream outage.

## Fix
- preserve subscription failures as HTTP 403 with a stable permission_denied / subscription_required payload
- keep rate-limit, auth, configuration, and true upstream mappings unchanged
- add a regression test for the exact response contract

## Verification
- TypeScript passed
- lint quiet passed
- all 67 Functions tests passed
- diff checks passed

After merge, the main workflow will redeploy MyBodyScan and the production smoke will be rerun.