### PR TITLE
Update TestFlight release status

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -286,11 +286,11 @@ the current-state notes below say it was configured:
 
 Current iOS external state on 2026-07-23: the App Store app record exists;
 Xcode is signed into the ADLR Labs team; the physical iPhone is paired with
-Developer Mode; App Store build 3 was signed, exported, accepted by Apple's
-upload service, and is processing for TestFlight. This release increments the
-repository to build 4; build 4 must be archived, validated, uploaded, and
-device-tested after the web/Firebase release gates pass. The three exact App
-Store products exist at the approved prices. RevenueCat accepts in-app-purchase key
+Developer Mode; App Store build 4 was archived, distribution-signed, accepted
+by Apple's upload service, and is processing for TestFlight. The same build was
+installed and launched on the paired iPhone, but the real photo, purchase,
+restore, notification, and offline device checklist remains mandatory. The
+three exact App Store products exist at the approved prices. RevenueCat accepts in-app-purchase key
 `9Z23GBB5M7`; monthly and yearly are attached to `pro`; all three products are
 in the current/default offering. App Store production and sandbox server
 notification URLs are set, and APNs key `9R5X23CQQ9` is uploaded to Firebase


### PR DESCRIPTION
## What changed

- Update the production release runbook to record that iOS build 4 was archived, distribution-signed, accepted by Apple's upload service, and installed/launched on the paired iPhone.
- Keep the remaining real-photo, purchase, restore, notification, and offline TestFlight checks explicitly mandatory.

## Why

The runbook still said build 4 had not been uploaded, which became inaccurate after today's release work. This keeps the production source of truth aligned with the actual external state without overstating App Store readiness.

## Validation

- `git diff --check`
- Verified archive version `1.0.0` / build `4`
- Xcode upload result: `Upload succeeded` / `EXPORT SUCCEEDED`
- Installed and launched build 4 on the paired physical iPhone
- Production E2E smoke: 2 passed, 3 credential-dependent tests skipped
- Post-smoke production function logs: 0 unexpected error markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the iOS production release runbook to reflect the current App Store build processing status.
  * Retained the required real-device validation checklist and confirmation of approved App Store products and pricing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->