### PR TITLE
Prevent stale native bundles from archiving

### DIFF
--- a/scripts/assert-ios-public-bundle.mjs
+++ b/scripts/assert-ios-public-bundle.mjs
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { findMissingLocalAssets } from "./lib/static-bundle-integrity.mjs";
 
 const PUBLIC_DIR = path.resolve(process.cwd(), "ios/App/App/public");
 const INDEX_HTML = path.join(PUBLIC_DIR, "index.html");
@@ -50,12 +51,40 @@ async function main() {
     );
   }
 
-  // eslint-disable-next-line no-console
-  console.log("[ios-public] OK: web assets present in ios/App/App/public");
+  const { references, missing } = await findMissingLocalAssets(
+    PUBLIC_DIR,
+    html
+  );
+  const scriptReferences = references.filter((reference) =>
+    /\.js$/i.test(reference)
+  );
+  const stylesheetReferences = references.filter((reference) =>
+    /\.css$/i.test(reference)
+  );
+  if (!scriptReferences.length || !stylesheetReferences.length) {
+    throw new Error(
+      "iOS public index is missing its built JavaScript or stylesheet reference. Run npm run build:native:ios && npx cap sync ios."
+    );
+  }
+
+  if (missing.length) {
+    const details = missing
+      .map(
+        ({ publicPath, filePath }) =>
+          ` - ${publicPath} (expected at ${filePath})`
+      )
+      .join("\n");
+    throw new Error(
+      `iOS public bundle references missing files:\n${details}\nRun npm run build:native:ios && npx cap sync ios.`
+    );
+  }
+
+  console.log(
+    `[ios-public] OK: ${references.length} referenced web assets present in ios/App/App/public`
+  );
 }
 
 main().catch((err) => {
-  // eslint-disable-next-line no-console
   console.error(String(err?.message || err));
   process.exit(1);
 });

--- a/scripts/lib/static-bundle-integrity.mjs
+++ b/scripts/lib/static-bundle-integrity.mjs
@@ -1,0 +1,56 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+function uniq(values) {
+  return Array.from(new Set(values));
+}
+
+export function extractLocalAssetPaths(html) {
+  const references = Array.from(
+    html.matchAll(/\b(?:src|href)\s*=\s*["']([^"']+)["']/gi)
+  ).map((match) => match[1]);
+
+  return uniq(
+    references
+      .filter(
+        (reference) => reference.startsWith("/") && !reference.startsWith("//")
+      )
+      .map((reference) => reference.split(/[?#]/, 1)[0])
+      .filter((reference) => reference && reference !== "/")
+  );
+}
+
+export function resolvePublicAssetPath(rootDir, publicPath) {
+  let decodedPath;
+  try {
+    decodedPath = decodeURIComponent(publicPath);
+  } catch {
+    throw new Error(`Invalid encoded asset path: ${publicPath}`);
+  }
+
+  const relativePath = decodedPath.replace(/^\/+/, "");
+  const root = path.resolve(rootDir);
+  const resolved = path.resolve(root, relativePath);
+  if (resolved !== root && !resolved.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`Asset path escapes the bundle root: ${publicPath}`);
+  }
+  return resolved;
+}
+
+export async function findMissingLocalAssets(rootDir, html) {
+  const references = extractLocalAssetPaths(html);
+  const missing = [];
+
+  for (const publicPath of references) {
+    const filePath = resolvePublicAssetPath(rootDir, publicPath);
+    const isFile = await fs
+      .stat(filePath)
+      .then((stat) => stat.isFile())
+      .catch(() => false);
+    if (!isFile) {
+      missing.push({ publicPath, filePath });
+    }
+  }
+
+  return { references, missing };
+}

--- a/scripts/verify-dist-assets.js
+++ b/scripts/verify-dist-assets.js
@@ -2,32 +2,22 @@
 
 import { promises as fs } from "fs";
 import path from "path";
+import {
+  extractLocalAssetPaths,
+  findMissingLocalAssets,
+} from "./lib/static-bundle-integrity.mjs";
 
 const DIST_DIR = path.resolve(process.cwd(), "dist");
 const INDEX_PATH = path.join(DIST_DIR, "index.html");
 const BUILD_TAG_PATH = path.join(DIST_DIR, "build.txt");
 
-function uniq(arr) {
-  return Array.from(new Set(arr));
-}
-
 function extractAssetPaths(html) {
   // Capture Vite-built asset references like:
   //   src="/assets/index-XXXX.js"
   //   href="/assets/index-XXXX.css"
-  const matches = Array.from(
-    html.matchAll(/(?:src|href)=["'](\/assets\/[^"']+\.(?:js|css))["']/g)
-  ).map((m) => m[1]);
-  return uniq(matches);
-}
-
-async function exists(filePath) {
-  try {
-    const stat = await fs.stat(filePath);
-    return stat.isFile();
-  } catch {
-    return false;
-  }
+  return extractLocalAssetPaths(html).filter((reference) =>
+    /^\/assets\/[^"']+\.(?:js|css)$/i.test(reference)
+  );
 }
 
 async function main() {
@@ -45,14 +35,14 @@ async function main() {
     process.exit(1);
   }
 
-  const missing = [];
-  for (const publicPath of assets) {
-    const rel = publicPath.replace(/^\//, ""); // "assets/..."
-    const filePath = path.join(DIST_DIR, rel);
-    if (!(await exists(filePath))) {
-      missing.push({ publicPath, filePath });
-    }
-  }
+  const { missing: localMissing } = await findMissingLocalAssets(
+    DIST_DIR,
+    indexHtml
+  );
+  const assetSet = new Set(assets);
+  const missing = localMissing.filter(({ publicPath }) =>
+    assetSet.has(publicPath)
+  );
 
   if (missing.length) {
     console.error(

--- a/tests/static-bundle-integrity.test.ts
+++ b/tests/static-bundle-integrity.test.ts
@@ -1,0 +1,63 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  extractLocalAssetPaths,
+  findMissingLocalAssets,
+  resolvePublicAssetPath,
+} from "../scripts/lib/static-bundle-integrity.mjs";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => fs.rm(directory, { recursive: true, force: true }))
+  );
+});
+
+describe("static bundle integrity", () => {
+  it("extracts unique local assets without treating external URLs as files", () => {
+    const html = `
+      <script src="/assets/app.js?cache=1"></script>
+      <link href="/assets/app.css#theme" rel="stylesheet">
+      <link href="/assets/app.css" rel="preload">
+      <link href="https://mybodyscanapp.com/" rel="canonical">
+      <script src="//cdn.example.com/library.js"></script>
+    `;
+
+    expect(extractLocalAssetPaths(html)).toEqual([
+      "/assets/app.js",
+      "/assets/app.css",
+    ]);
+  });
+
+  it("reports stale hashed references even when the assets directory is non-empty", async () => {
+    const root = await fs.mkdtemp(
+      path.join(os.tmpdir(), "mybodyscan-bundle-integrity-")
+    );
+    temporaryDirectories.push(root);
+    await fs.mkdir(path.join(root, "assets"));
+    await fs.writeFile(path.join(root, "assets", "current.js"), "export {};");
+
+    const result = await findMissingLocalAssets(
+      root,
+      '<script src="/assets/stale.js"></script>'
+    );
+
+    expect(result.missing).toEqual([
+      {
+        publicPath: "/assets/stale.js",
+        filePath: path.join(root, "assets", "stale.js"),
+      },
+    ]);
+  });
+
+  it("rejects paths that escape the bundle root", () => {
+    expect(() =>
+      resolvePublicAssetPath("/tmp/public", "/../private.txt")
+    ).toThrow(/escapes the bundle root/);
+  });
+});


### PR DESCRIPTION
## What changed
- verify every local `src`/`href` referenced by the iOS web bundle exists before archiving
- require built JavaScript and CSS entries, not merely a non-empty assets directory
- share the static-bundle reference checker with the production `dist` safeguard
- add a regression test for stale hashed asset references and path traversal

## Why
A stale tracked `ios/App/App/public/index.html` could point at old Vite hashes while the assets directory contained a different build. The previous guard only checked that the directory was non-empty, so that inconsistent state could pass and render a blank native app.

## Validation
- clean root and Functions dependency installs
- lint: 0 errors (historical warnings remain)
- typecheck: passed
- web tests: 101 files / 284 tests passed
- Functions build and tests: 67 passed
- production build: passed
- bundle limit and Storage REST safeguards: passed
- Firestore rule consistency: passed
- native release config and RevenueCat release guard: passed
- fresh native release build + Capacitor sync + strengthened iOS bundle guard: passed (13 referenced assets)
- physical iPhone launch: passed
- iPhone and iPad simulator render checks: passed
- disposable production Firebase probe: passed, including scan and account cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of iOS and distribution web bundles.
  * Checks that referenced JavaScript and stylesheet assets exist locally.
  * Reports missing or outdated asset files with clearer error details.
  * Prevents invalid asset paths from escaping the bundle directory.

* **Tests**
  * Added coverage for local asset detection, missing files, external URLs, and path safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->