### PR TITLE
Prepare verified iPhone and iPad release assets

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -294,33 +294,39 @@ Current iOS external state on 2026-07-23: the App Store app record exists;
 Xcode is signed into the ADLR Labs team; the physical iPhone is paired with
 Developer Mode. Build 6 is the final replacement candidate with the RevenueCat
 paywall and redirect-hardening fixes. It was archived, validated,
-distribution-signed, and accepted by Apple's upload service for TestFlight
-processing. The paired iPhone was unavailable after upload, so build 6 has not
-yet been installed or launched on that device. Build 5 was accepted by Apple's
-upload service but was superseded before device testing by the
-redirect-hardening fix. Build 4 was installed and launched previously, but it
-must not be submitted because its native plan route bypassed the RevenueCat
-paywall. The real photo, purchase, restore,
+distribution-signed, accepted by Apple's upload service for TestFlight
+processing, installed on the paired iPhone 14 Pro Max, and launched
+successfully. Fresh iPhone and iPad simulator builds also install, launch, and
+render the reviewed responsive layouts. Build 5 was accepted by Apple's upload
+service but was superseded before device testing by the redirect-hardening fix.
+Build 4 must not be submitted because its native plan route bypassed the
+RevenueCat paywall. The real photo, purchase, restore,
 notification, and offline device checklist remains mandatory. The three exact
-App Store products exist at the approved prices. RevenueCat accepts in-app-purchase key
-`9Z23GBB5M7`; monthly and yearly are attached to `pro`; all three products are
-in the current/default offering. Native plan links open the RevenueCat
-purchase/restore paywall, while Settings opens Apple's subscription-management
-screen; native builds never open Stripe checkout. App Store production and
-sandbox server notification URLs are set, and APNs key `9R5X23CQQ9` is uploaded
-to Firebase for development and production.
+App Store products exist, but the live U.S. prices still require correction:
+single scan is $9.99 instead of $4.99, monthly is $24.99 instead of $9.99 and
+has a conflicting $14.99 first-month offer, and yearly is $199 instead of
+$79.99. Single-scan availability is not configured. RevenueCat accepts
+in-app-purchase key `9Z23GBB5M7`; monthly and yearly are attached to `pro`; all
+three products are in the current/default offering. Native plan links open the
+RevenueCat purchase/restore paywall, while Settings opens Apple's
+subscription-management screen; native builds never open Stripe checkout.
+APNs key `9R5X23CQQ9` is uploaded to Firebase for development and production.
+RevenueCat reports no App Store server-notification or webhook deliveries yet,
+so both integrations still require a sandbox event.
 
 App Store metadata, age rating, categories, and the App Privacy answers are
 configured. The privacy declaration is not published because the Account
 Holder must personally accept Apple's legal attestation. Content Rights,
 general App Store Connect API access, and Digital Services Act/trader
-attestations are also owner-only gates. Four 1242 × 2688 iPhone screenshots are
-generated under `release-artifacts/app-store-screenshots/`; upload those files
-manually because browser automation is not an acceptable release credential.
-The remaining critical gates are build processing/selection, review contact
-and demo credentials, screenshot upload, the real TestFlight device/purchase/
-push checklist, the owner attestations, and final submission. A successful
-archive or upload does not prove those device and store flows.
+attestations are also owner-only gates. The screenshot generator produces six
+1242 × 2688 iPhone and six 2064 × 2752 iPad candidates that highlight body
+results, training, nutrition, meal planning, four-photo scanning, and coaching
+under
+`release-artifacts/app-store-screenshots/`. The remaining critical gates are
+price and availability correction, build selection, review contact and demo
+credentials, screenshot upload, the real TestFlight device/purchase/push
+checklist, the owner attestations, and final submission. A successful archive
+or upload does not prove those device and store flows.
 
 Purchase restoration is verified only when the customer returns to the same
 Firebase account. Deleting that account and then creating a different Firebase
@@ -402,13 +408,16 @@ After `build:prod`, start the local production preview in a second terminal:
 npm run preview -- --host 127.0.0.1 --port 4173
 ```
 
-Generate the four App Store screenshot candidates from that reviewed preview.
-The script uses a 414 × 896 point viewport at 3× scale and writes exact
-1242 × 2688 PNGs:
+Generate the App Store screenshot candidates from that reviewed preview. The
+default `all` profile writes exact 1242 × 2688 iPhone PNGs and 2064 × 2752 iPad
+PNGs into device-specific subdirectories:
 
 ```bash
 node scripts/capture-app-store-screenshots.mjs http://127.0.0.1:4173
 ```
+
+To regenerate only one size, set `MBS_SCREENSHOT_PROFILE` to `iphone-6.5` or
+`ipad-13`. Every file's PNG dimensions are checked before the command succeeds.
 
 Then run the public/local browser gates from the first terminal. Authenticated
 specs in the broader suite run only when `PLAYWRIGHT_STORAGE_STATE` points to a

--- a/scripts/capture-app-store-screenshots.mjs
+++ b/scripts/capture-app-store-screenshots.mjs
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, readFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import { chromium } from "playwright";
 
@@ -12,76 +12,138 @@ const executablePath =
 const outputDir = resolve(
   process.env.MBS_SCREENSHOT_DIR || "release-artifacts/app-store-screenshots"
 );
+const requestedProfile = (
+  process.env.MBS_SCREENSHOT_PROFILE || "all"
+).toLowerCase();
 
 const screens = [
-  ["01-progress-dashboard.png", "/demo"],
-  ["02-body-scan-results.png", "/results/demo-scan-003?demo=1"],
-  ["03-training-programs.png", "/programs?demo=1"],
-  ["04-nutrition-progress.png", "/meals?demo=1"],
+  ["01-body-scan-results.png", "/results/demo-scan-003?demo=1"],
+  ["02-training-programs.png", "/programs?demo=1"],
+  ["03-nutrition-progress.png", "/meals?demo=1"],
+  ["04-personalized-meal-plan.png", "/meals/plan?demo=1"],
+  ["05-four-photo-scan.png", "/scan/tips?demo=1"],
+  ["06-ai-coach.png", "/coach/chat?demo=1"],
 ];
 
-await mkdir(outputDir, { recursive: true });
+const profiles = {
+  "iphone-6.5": {
+    outputSubdirectory: "iphone-6.5",
+    viewport: { width: 414, height: 896 },
+    deviceScaleFactor: 3,
+    expectedPixels: { width: 1242, height: 2688 },
+  },
+  "ipad-13": {
+    outputSubdirectory: "ipad-13",
+    viewport: { width: 1032, height: 1376 },
+    deviceScaleFactor: 2,
+    expectedPixels: { width: 2064, height: 2752 },
+  },
+};
+
+const selectedProfiles =
+  requestedProfile === "all"
+    ? Object.entries(profiles)
+    : Object.entries(profiles).filter(([name]) => name === requestedProfile);
+
+if (selectedProfiles.length === 0) {
+  throw new Error(
+    `Unknown MBS_SCREENSHOT_PROFILE "${requestedProfile}". Use all, ${Object.keys(
+      profiles
+    ).join(", ")}.`
+  );
+}
+
+function readPngDimensions(buffer) {
+  const pngSignature = "89504e470d0a1a0a";
+  if (buffer.subarray(0, 8).toString("hex") !== pngSignature) {
+    throw new Error("Screenshot output is not a PNG file.");
+  }
+
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
 
 const browser = await chromium.launch({ headless: true, executablePath });
-const context = await browser.newContext({
-  viewport: { width: 414, height: 896 },
-  deviceScaleFactor: 3,
-  hasTouch: true,
-  isMobile: true,
-  colorScheme: "light",
-  reducedMotion: "reduce",
-});
 
-await context.addInitScript(() => {
-  localStorage.setItem("mbs_demo", "1");
-  sessionStorage.setItem("mbs_demo", "1");
-  localStorage.setItem("mbs_policy_ok_v1", "1");
-  localStorage.setItem("mbs-consent", "accepted");
-});
+for (const [profileName, profile] of selectedProfiles) {
+  const profileOutputDir = resolve(outputDir, profile.outputSubdirectory);
+  await mkdir(profileOutputDir, { recursive: true });
 
-for (const [filename, path] of screens) {
-  const page = await context.newPage();
-  await page.goto(`${baseUrl}${path}`, {
-    waitUntil: "domcontentloaded",
-    timeout: 45_000,
+  const context = await browser.newContext({
+    viewport: profile.viewport,
+    deviceScaleFactor: profile.deviceScaleFactor,
+    hasTouch: true,
+    isMobile: profileName.startsWith("iphone"),
+    colorScheme: "light",
+    reducedMotion: "reduce",
   });
-  await page.waitForTimeout(2_000);
-  await page
-    .locator('[aria-label="Demo mode active"]')
-    .evaluateAll((elements) => {
+
+  await context.addInitScript(() => {
+    localStorage.setItem("mbs_demo", "1");
+    sessionStorage.setItem("mbs_demo", "1");
+    localStorage.setItem("mbs_policy_ok_v1", "1");
+    localStorage.setItem("mbs-consent", "accepted");
+  });
+
+  for (const [filename, path] of screens) {
+    const page = await context.newPage();
+    await page.goto(`${baseUrl}${path}`, {
+      waitUntil: "domcontentloaded",
+      timeout: 45_000,
+    });
+    await page.waitForTimeout(2_000);
+    await page
+      .locator(
+        '[aria-label="Demo mode active"], [data-testid="demo-banner"]'
+      )
+      .evaluateAll((elements) => {
+        for (const element of elements) {
+          element.style.display = "none";
+        }
+      });
+    await page.getByText("Demo", { exact: true }).evaluateAll((elements) => {
       for (const element of elements) {
         element.style.display = "none";
       }
     });
-  await page.getByText("Demo", { exact: true }).evaluateAll((elements) => {
-    for (const element of elements) {
-      element.style.display = "none";
+    await page
+      .getByText("Demo preview — read-only experience.", { exact: true })
+      .evaluateAll((elements) => {
+        for (const element of elements) {
+          const container = element.parentElement;
+          if (container) container.style.display = "none";
+        }
+      });
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(250);
+
+    const screenshotPath = resolve(profileOutputDir, filename);
+    await page.screenshot({ path: screenshotPath, fullPage: false });
+    await page.close();
+
+    const dimensions = readPngDimensions(await readFile(screenshotPath));
+    if (
+      dimensions.width !== profile.expectedPixels.width ||
+      dimensions.height !== profile.expectedPixels.height
+    ) {
+      throw new Error(
+        `${profileName}/${filename} is ${dimensions.width}x${dimensions.height}; expected ${profile.expectedPixels.width}x${profile.expectedPixels.height}.`
+      );
     }
-  });
-  await page.locator('[data-testid="demo-banner"]').evaluateAll((elements) => {
-    for (const element of elements) {
-      element.style.display = "none";
-    }
-  });
-  await page
-    .getByText("Demo preview — read-only experience.", { exact: true })
-    .evaluateAll((elements) => {
-      for (const element of elements) {
-        const container = element.parentElement;
-        if (container) container.style.display = "none";
-      }
-  });
-  await page.evaluate(() => window.scrollTo(0, 0));
-  await page.waitForTimeout(250);
-  await page.screenshot({
-    path: resolve(outputDir, filename),
-    fullPage: false,
-  });
-  await page.close();
-  console.log(`[app-store-screenshot] ${filename} <- ${path}`);
+
+    console.log(
+      `[app-store-screenshot] ${profileName}/${filename} (${dimensions.width}x${dimensions.height}) <- ${path}`
+    );
+  }
+
+  await context.close();
 }
 
 await browser.close();
 console.log(
-  `[app-store-screenshot] Wrote ${screens.length} files to ${outputDir}`
+  `[app-store-screenshot] Wrote ${
+    screens.length * selectedProfiles.length
+  } files to ${outputDir}`
 );

--- a/src/pages/ScanTips.test.tsx
+++ b/src/pages/ScanTips.test.tsx
@@ -1,0 +1,22 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/components/Seo", () => ({ Seo: () => null }));
+
+import ScanTips from "@/pages/ScanTips";
+
+describe("ScanTips", () => {
+  it("describes the complete four-photo capture sequence without an accuracy claim", () => {
+    render(<ScanTips />);
+
+    expect(screen.getByText("Front")).toBeTruthy();
+    expect(screen.getByText("Left side")).toBeTruthy();
+    expect(screen.getByText("Back")).toBeTruthy();
+    expect(screen.getByText("Right side")).toBeTruthy();
+    expect(screen.getByText(/more comparable photo estimates/i)).toBeTruthy();
+    expect(screen.queryByText(/more accurate body-fat estimates/i)).toBeNull();
+  });
+});

--- a/src/pages/ScanTips.tsx
+++ b/src/pages/ScanTips.tsx
@@ -18,8 +18,9 @@ const tips = [
 
 const silhouettes = [
   { label: "Front", description: "Feet together, arms out" },
-  { label: "Side", description: "Turn 90°, head forward" },
+  { label: "Left side", description: "Turn 90°, head forward" },
   { label: "Back", description: "Relaxed shoulders" },
+  { label: "Right side", description: "Turn 90°, head forward" },
 ];
 
 export default function ScanTips() {
@@ -30,10 +31,33 @@ export default function ScanTips() {
       <header className="space-y-2">
         <h1 className="text-3xl font-semibold">Photo Tips</h1>
         <p className="text-muted-foreground">
-          Better lighting, distance, and framing lead to more accurate body-fat
-          estimates. Follow this checklist before each scan.
+          Consistent lighting, distance, and framing support more comparable
+          photo estimates. Follow this checklist before each scan.
         </p>
       </header>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Scan className="h-5 w-5 text-primary" /> Four required angles
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="grid grid-cols-2 gap-4 md:grid-cols-4">
+          {silhouettes.map((item) => (
+            <div key={item.label} className="flex flex-col items-center gap-2">
+              <div className="flex h-32 w-24 items-end justify-center rounded-lg border bg-muted">
+                <div className="h-28 w-6 rounded-full bg-gradient-to-t from-primary/70 to-primary/30" />
+              </div>
+              <div className="text-center">
+                <p className="text-sm font-medium">{item.label}</p>
+                <p className="text-xs text-muted-foreground">
+                  {item.description}
+                </p>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader>
@@ -66,29 +90,6 @@ export default function ScanTips() {
             Mark a standing spot with tape so each scan uses the same distance.
             A consistent setup improves comparisons over time.
           </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Scan className="h-5 w-5 text-primary" /> Poses
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="grid gap-4 md:grid-cols-3">
-          {silhouettes.map((item) => (
-            <div key={item.label} className="flex flex-col items-center gap-2">
-              <div className="flex h-32 w-24 items-end justify-center rounded-lg border bg-muted">
-                <div className="h-28 w-6 rounded-full bg-gradient-to-t from-primary/70 to-primary/30" />
-              </div>
-              <div className="text-center">
-                <p className="text-sm font-medium">{item.label}</p>
-                <p className="text-xs text-muted-foreground">
-                  {item.description}
-                </p>
-              </div>
-            </div>
-          ))}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- correct Photo Tips to show all four scan angles and avoid an unsupported accuracy claim
- generate feature-focused App Store screenshot candidates for both iPhone 6.5-inch and iPad 13-inch sizes
- validate every PNG's exact pixel dimensions before the screenshot command succeeds
- update the production runbook with the verified iOS/device state and the actual remaining App Store/RevenueCat blockers

## Verification
- `npm run lint` — passed, 0 errors (1,431 historical warnings)
- `npm run typecheck` — passed
- `npm test -- --reporter=dot` — 102 files, 285 tests passed
- `npm run build:prod` — passed, including program validation, bundle safeguard, and Storage REST guard
- local production screenshot capture — 6 iPhone PNGs at 1242×2688 and 6 iPad PNGs at 2064×2752
- visual review of Results, programs, nutrition, meal plan, four-photo guidance, and Coach layouts

## External state documented
The App Store listing still requires the confirmed price corrections ($4.99 single scan, $9.99 monthly, $79.99 yearly), removal of the conflicting introductory offer, single-scan availability, screenshots/build/review metadata, privacy/owner attestations, and real TestFlight purchase/push/photo validation. This PR does not submit or publish App Store metadata.