### PR TITLE
Handle expected headless App Check console noise

### DIFF
--- a/e2e/utils/consoleGuard.ts
+++ b/e2e/utils/consoleGuard.ts
@@ -8,9 +8,10 @@ const benignConsolePatterns: Array<RegExp> = [
   /chrome-error\:\/\//,
 ];
 
-function isBenign(message: ConsoleMessage): boolean {
-  const text = message.text();
-  const sourceUrl = message.location().url;
+export function isBenignConsoleError(
+  text: string,
+  sourceUrl: string
+): boolean {
   const isLocalPreview = /^https?:\/\/(127\.0\.0\.1|localhost)(?::\d+)?\//.test(
     sourceUrl
   );
@@ -25,7 +26,44 @@ function isBenign(message: ConsoleMessage): boolean {
     return true;
   }
 
+  let source: URL | undefined;
+  try {
+    source = new URL(sourceUrl);
+  } catch {
+    source = undefined;
+  }
+
+  // Invisible reCAPTCHA Enterprise frames request unpartitioned storage, which
+  // Chromium denies in headless mode. This message comes from Google's frame,
+  // not from application code.
+  if (
+    text === "requestStorageAccess: Permission denied." &&
+    source?.hostname === "www.google.com" &&
+    source.pathname === "/recaptcha/enterprise/anchor"
+  ) {
+    return true;
+  }
+
+  // reCAPTCHA Enterprise intentionally refuses headless automation, so the
+  // App Check exchange returns 403 in live E2E. Production App Check remains in
+  // soft mode until real-browser attestation metrics are proven safe. Restrict
+  // this exception to this project's token-exchange endpoint so other 403s fail.
+  if (
+    /Failed to load resource.*403/.test(text) &&
+    source?.hostname === "content-firebaseappcheck.googleapis.com" &&
+    source.pathname.startsWith(
+      "/v1/projects/mybodyscan-f3daf/apps/"
+    ) &&
+    source.pathname.endsWith(":exchangeRecaptchaEnterpriseToken")
+  ) {
+    return true;
+  }
+
   return benignConsolePatterns.some((pattern) => pattern.test(text));
+}
+
+function isBenign(message: ConsoleMessage): boolean {
+  return isBenignConsoleError(message.text(), message.location().url);
 }
 
 export async function acceptPoliciesIfShown(page: Page): Promise<void> {

--- a/tests/e2e-console-guard.test.ts
+++ b/tests/e2e-console-guard.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { isBenignConsoleError } from "../e2e/utils/consoleGuard";
+
+describe("live E2E console guard", () => {
+  it("allows the headless reCAPTCHA Enterprise storage warning", () => {
+    expect(
+      isBenignConsoleError(
+        "requestStorageAccess: Permission denied.",
+        "https://www.google.com/recaptcha/enterprise/anchor?ar=1"
+      )
+    ).toBe(true);
+  });
+
+  it("does not hide the same storage error from application code", () => {
+    expect(
+      isBenignConsoleError(
+        "requestStorageAccess: Permission denied.",
+        "https://mybodyscanapp.com/assets/app.js"
+      )
+    ).toBe(false);
+  });
+
+  it("allows only this project's headless App Check exchange 403", () => {
+    expect(
+      isBenignConsoleError(
+        "Failed to load resource: the server responded with a status of 403 ()",
+        "https://content-firebaseappcheck.googleapis.com/v1/projects/mybodyscan-f3daf/apps/1:157018993008:web:test:exchangeRecaptchaEnterpriseToken?key=redacted"
+      )
+    ).toBe(true);
+  });
+
+  it("does not hide unrelated 403 responses", () => {
+    expect(
+      isBenignConsoleError(
+        "Failed to load resource: the server responded with a status of 403 ()",
+        "https://mybodyscanapp.com/api/coach"
+      )
+    ).toBe(false);
+  });
+
+  it("does not hide another project's App Check exchange", () => {
+    expect(
+      isBenignConsoleError(
+        "Failed to load resource: the server responded with a status of 403 ()",
+        "https://content-firebaseappcheck.googleapis.com/v1/projects/other-project/apps/1:2:web:test:exchangeRecaptchaEnterpriseToken"
+      )
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- classify only Google's headless reCAPTCHA Enterprise storage warning as benign
- classify only this Firebase project's App Check token-exchange 403 as expected in headless live E2E
- keep all application, unrelated 403, and cross-project errors fatal
- add focused regression tests for allowed and rejected cases

## Verification
- `npm run typecheck`
- `npm run typecheck:functions`
- `npm run lint` (0 errors; historical warnings only)
- `npm test` (304 passed)
- `npm --prefix functions test` (74 passed)
- `npm run build:prod` (bundle and Storage REST safeguards passed)
- `npm run rules:check`
- `E2E_BASE_URL=https://mybodyscanapp.com npx playwright test --config e2e/playwright.config.ts` (4 passed, 4 authenticated-only skipped)