### PR TITLE
Fix production checkout and account deletion

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -249,21 +249,28 @@ the current-state notes below say it was configured:
    - subscribed events include `checkout.session.completed`,
      `invoice.payment_succeeded`, `customer.subscription.updated`, and
      `customer.subscription.deleted`.
-     As of 2026-07-22 the current destination is active and listens to all four
-     required events; its Function has a webhook secret bound and rejects an
-     intentionally invalid signature with HTTP 400. On 2026-07-23 the product
+     As of 2026-07-26 the current `inspiring-dream` destination is active and
+     listens to all four required events. A locally generated, harmless Stripe
+     event signed with the deployed secret returned HTTP 200 from the direct
+     Cloud Run Function URL, proving the live secret and handler are aligned.
+     The dead legacy `memorable-radiance` / `stripeWebhook2` destination
+     returned HTTP 404 and was disabled. On 2026-07-23 the product
      owner approved the launch catalog: $4.99 for one scan, $9.99/month, and
      $79.99/year. New immutable live prices were created on the existing
      MyBodyScan products, made the product defaults, and installed in the web
      and Functions allowlists. Verify all three live Checkouts before archiving
      superseded prices. Old price IDs remain recognized temporarily for delayed
-     pre-cutover webhook events. A stale zero-activity
-     `stripeWebhook2` destination also remains; disable it
-     only after a successful signed delivery to the current destination.
+     pre-cutover webhook events. The Hosting `/api/billing/*` router and direct
+     callable handlers share the same price allowlist and customer-cache
+     implementation; do not reintroduce a second set of price environment
+     variables.
      Customer Portal subscription cancellation, payment-method updates, and
      invoice history are enabled. Its account-wide legal links are blank;
      because this Stripe account is branded ADLR LABS, do not replace those
      links with MyBodyScan URLs without an account-owner/legal decision.
+     Stripe still reports incomplete account onboarding (email/business
+     verification and tax-monitoring setup); the account owner must resolve
+     those dashboard items before accepting live customer payments.
 6. Firebase Hosting → Custom domains: `mybodyscanapp.com` is the canonical
    Firebase custom domain. On 2026-07-22, the `www` custom domain was explicitly
    configured in Firebase as a redirect to `mybodyscanapp.com`, and Firebase
@@ -399,17 +406,33 @@ release guard. RevenueCat still has no Google service-account credentials or
 Real-Time Developer Notifications connection, so Play purchases cannot be
 accepted as release-verified.
 
+A new ignored upload keystore was generated at
+`android/mybodyscan-upload.jks`, with its ignored configuration at
+`android/keystore.properties`. Its password is stored in the macOS Keychain
+under service `MyBodyScan Android Upload Keystore` and account
+`mybodyscan-upload`; an identical keystore backup is stored outside Git at
+`/Users/adlr/Documents/MyBodyScan Release Keys/mybodyscan-upload.jks`.
+The upload certificate SHA-1 is
+`6F:FF:1F:AF:9A:98:E1:7D:37:60:92:42:55:57:C7:1E:3A:2F:AB:AB` and SHA-256 is
+`FE:0F:86:19:89:5B:D8:39:3F:3F:C1:01:6C:30:C6:A4:59:F0:A5:38:62:98:6C:C0:FD:9C:C0:4D:0A:5D:21:4D`.
+The backup hash matches the working keystore. A release AAB was built through
+the production credential guard, unit tests, Android lint, and Gradle release
+signing, and `jarsigner -verify` accepted it. Rebuild it from the final reviewed
+commit before upload; never upload an AAB produced from a different commit.
+
 Play Integrity registration is prepared but not saved because the account
 owner must accept the Google APIs and Play Integrity terms. The currently
 signed-in Google account still shows Play Console account creation and asks
 whether the owner is an organization or individual; ownership cannot be
 changed later. Do not complete that flow unless it is the intended ADLR Labs
 organization account. Otherwise switch to the already-paid developer account.
-No recoverable upload/app-signing key, Play product catalog, internal test
-build, or Android device acceptance test exists yet. The current RevenueCat
-role can inspect but cannot change app credentials; an Owner/Admin must upload
-the least-privileged Google service-account JSON and complete RTDN after the
-correct Play account and app exist.
+No Play product catalog, internal-test upload, Play App Signing certificate, or
+Android device acceptance test exists yet. Register both the upload certificate
+above and the Play-generated app-signing certificate in Firebase after the
+correct Play app exists. The current RevenueCat role can inspect but cannot
+change app credentials; an Owner/Admin must upload the least-privileged Google
+service-account JSON and complete RTDN after the correct Play account and app
+exist.
 
 Current iOS external state on 2026-07-26: the App Store app record exists;
 Xcode is signed into the ADLR Labs team; the physical iPhone is paired with
@@ -736,7 +759,11 @@ providers and does not replace the subscribed real-account checks below.
 - Account deletion removes the Auth user, the complete Firestore user subtree,
   `scans/{uid}/`, `user_uploads/{uid}/`, and
   `transformation-previews/{uid}/`, plus that user's global hashed push-token
-  ownership records.
+  ownership records. It also deletes every Stripe customer found by the cached
+  customer ID or the user's Stripe metadata before deleting Firebase data,
+  canceling linked Stripe subscriptions without relying on a later webhook.
+  Apple App Store and Google Play subscriptions remain store-managed and the
+  deletion UI must continue to tell users how to cancel them.
 - `/legal/privacy`, `/legal/terms`, `/legal/refund`, `/legal/disclaimer`, and
   the compatibility `/medical` route work on the custom and Firebase domains;
   SPA deep links refresh successfully.

--- a/functions/src/account.ts
+++ b/functions/src/account.ts
@@ -6,6 +6,11 @@ import { getAuth, getFirestore, getStorage } from "./firebase.js";
 import { buildScanPhotoPath, isScanPose } from "./scan/paths.js";
 import { onCallWithOptionalAppCheck } from "./util/callable.js";
 import { deletePushTokenOwnershipForUser } from "./pushTokenOwnership.js";
+import { deleteStripeCustomerForUser } from "./accountDeletion.js";
+import {
+  stripeSecretKeyParam,
+  stripeSecretParam,
+} from "./stripe/keys.js";
 
 const auth = getAuth();
 const db = getFirestore();
@@ -153,6 +158,7 @@ export const deleteMyAccount = onCallWithOptionalAppCheck(
     }
 
     try {
+      await deleteStripeCustomerForUser(uid, requestId);
       await deleteStorageUser(uid, requestId);
       await deleteFirestoreUser(uid, requestId);
       await auth.revokeRefreshTokens(uid);
@@ -168,7 +174,10 @@ export const deleteMyAccount = onCallWithOptionalAppCheck(
       throw new HttpsError("internal", "Unable to delete account right now.");
     }
   },
-  { region: "us-central1" }
+  {
+    region: "us-central1",
+    secrets: [stripeSecretParam, stripeSecretKeyParam],
+  }
 );
 
 export const exportMyData = onCallWithOptionalAppCheck(

--- a/functions/src/accountDeletion.ts
+++ b/functions/src/accountDeletion.ts
@@ -56,6 +56,20 @@ export async function deleteStripeCustomerForUser(
   requestId: string,
   deps: StripeCustomerDeletionDeps = {}
 ): Promise<{ customerIds: string[]; deletedCount: number }> {
+  const usingProductionStripe =
+    deps.findCustomerIds === undefined && deps.deleteCustomer === undefined;
+  if (
+    process.env.FUNCTIONS_EMULATOR === "true" &&
+    usingProductionStripe
+  ) {
+    console.log("account_delete_stripe_skipped", {
+      uid,
+      requestId,
+      reason: "functions_emulator",
+    });
+    return { customerIds: [], deletedCount: 0 };
+  }
+
   const readCustomerId = deps.readCustomerId ?? readCachedStripeCustomerId;
   const findCustomerIds = deps.findCustomerIds ?? findStripeCustomerIds;
   const removeCustomer = deps.deleteCustomer ?? deleteStripeCustomer;

--- a/functions/src/accountDeletion.ts
+++ b/functions/src/accountDeletion.ts
@@ -1,0 +1,125 @@
+import Stripe from "stripe";
+
+import { getFirestore } from "./firebase.js";
+import { getStripeKey } from "./stripe/keys.js";
+
+type StripeCustomerDeletionDeps = {
+  readCustomerId?: (uid: string) => Promise<string | null>;
+  findCustomerIds?: (uid: string) => Promise<string[]>;
+  deleteCustomer?: (customerId: string) => Promise<void>;
+};
+
+type StripeDeletionError = {
+  code?: string;
+  statusCode?: number;
+};
+
+async function readCachedStripeCustomerId(uid: string): Promise<string | null> {
+  const snapshot = await getFirestore()
+    .doc(`users/${uid}/private/stripe`)
+    .get();
+  if (!snapshot.exists) return null;
+
+  const value = snapshot.data()?.customerId;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function getStripeClient(): Stripe {
+  return new Stripe(getStripeKey(), { apiVersion: "2024-06-20" });
+}
+
+function escapeStripeSearchValue(value: string): string {
+  return value.replaceAll("\\", "\\\\").replaceAll("'", "\\'");
+}
+
+async function findStripeCustomerIds(uid: string): Promise<string[]> {
+  const result = await getStripeClient().customers.search({
+    query: `metadata['uid']:'${escapeStripeSearchValue(uid)}'`,
+    limit: 100,
+  });
+  return result.data.map((customer) => customer.id);
+}
+
+async function deleteStripeCustomer(customerId: string): Promise<void> {
+  await getStripeClient().customers.del(customerId);
+}
+
+function isMissingStripeCustomer(error: unknown): boolean {
+  const stripeError = error as StripeDeletionError | undefined;
+  return (
+    stripeError?.code === "resource_missing" || stripeError?.statusCode === 404
+  );
+}
+
+export async function deleteStripeCustomerForUser(
+  uid: string,
+  requestId: string,
+  deps: StripeCustomerDeletionDeps = {}
+): Promise<{ customerIds: string[]; deletedCount: number }> {
+  const readCustomerId = deps.readCustomerId ?? readCachedStripeCustomerId;
+  const findCustomerIds = deps.findCustomerIds ?? findStripeCustomerIds;
+  const removeCustomer = deps.deleteCustomer ?? deleteStripeCustomer;
+  const [cachedCustomerId, discoveredCustomerIds] = await Promise.all([
+    readCustomerId(uid),
+    findCustomerIds(uid),
+  ]);
+  const customerIds = [
+    ...new Set(
+      [cachedCustomerId, ...discoveredCustomerIds].filter(
+        (customerId): customerId is string => Boolean(customerId)
+      )
+    ),
+  ];
+
+  if (customerIds.length === 0) {
+    console.log("account_delete_stripe_skipped", {
+      uid,
+      requestId,
+      reason: "no_customer",
+    });
+    return { customerIds: [], deletedCount: 0 };
+  }
+
+  console.log("account_delete_stripe_begin", {
+    uid,
+    requestId,
+    customerIds,
+  });
+
+  let deletedCount = 0;
+  for (const customerId of customerIds) {
+    try {
+      await removeCustomer(customerId);
+      deletedCount += 1;
+      console.log("account_delete_stripe_customer_complete", {
+        uid,
+        requestId,
+        customerId,
+      });
+    } catch (error) {
+      if (isMissingStripeCustomer(error)) {
+        console.warn("account_delete_stripe_already_missing", {
+          uid,
+          requestId,
+          customerId,
+        });
+        continue;
+      }
+      console.error("account_delete_stripe_failed", {
+        uid,
+        requestId,
+        customerId,
+        message: (error as Error)?.message,
+      });
+      throw error;
+    }
+  }
+
+  console.log("account_delete_stripe_complete", {
+    uid,
+    requestId,
+    customerIds,
+    deletedCount,
+  });
+  return { customerIds, deletedCount };
+}

--- a/functions/src/billing.ts
+++ b/functions/src/billing.ts
@@ -1,246 +1,27 @@
 import expressModule from "express";
 import type { Request, Response } from "express";
-import type Stripe from "stripe";
-import { getAuth } from "./firebase.js";
+
 import {
-  allowCorsAndOptionalAppCheck,
-  publicBaseUrl,
-  requireAuthWithClaims,
-} from "./http.js";
-import { getStripe } from "./stripe/common.js";
-
-const stripeConfigured = Boolean(
-  process.env.STRIPE_SECRET_KEY || process.env.STRIPE_SECRET
-);
-
-function resolveStripe(): Stripe | null {
-  try {
-    return getStripe();
-  } catch {
-    return null;
-  }
-}
+  handleCreateCheckout,
+  handleCustomerPortal,
+} from "./http/checkout.js";
 
 const express = expressModule as any;
 
-export const hasStripe = stripeConfigured;
-
-const PRICE_ONE = process.env.PRICE_ONE || process.env.VITE_PRICE_ONE || "";
-const PRICE_MONTHLY =
-  process.env.PRICE_MONTHLY || process.env.VITE_PRICE_MONTHLY || "";
-const PRICE_YEARLY =
-  process.env.PRICE_YEARLY || process.env.VITE_PRICE_YEARLY || "";
-const PRICE_EXTRA =
-  process.env.PRICE_EXTRA || process.env.VITE_PRICE_EXTRA || "";
-const PROMO_CODE = process.env.STRIPE_MONTHLY_PROMO_CODE || "";
-const BASE_URL =
-  process.env.BASE_URL ||
-  process.env.APP_BASE_URL ||
-  process.env.VITE_APP_BASE_URL ||
-  "https://mybodyscanapp.com";
-
-type PriceConfig = {
-  id: string;
-  plan: "one" | "monthly" | "yearly" | "extra";
-  mode: "payment" | "subscription";
-};
-
-const priceConfigs: PriceConfig[] = [
-  PRICE_ONE ? { id: PRICE_ONE, plan: "one", mode: "payment" } : null,
-  PRICE_MONTHLY
-    ? { id: PRICE_MONTHLY, plan: "monthly", mode: "subscription" }
-    : null,
-  PRICE_YEARLY
-    ? { id: PRICE_YEARLY, plan: "yearly", mode: "subscription" }
-    : null,
-  PRICE_EXTRA ? { id: PRICE_EXTRA, plan: "extra", mode: "payment" } : null,
-].filter((config): config is PriceConfig => Boolean(config?.id));
-
-const allowedPrices = new Set(priceConfigs.map((config) => config.id));
-
-function resolvePriceConfig(priceId: string): PriceConfig | null {
-  return priceConfigs.find((config) => config.id === priceId) ?? null;
-}
-
-async function ensureCustomer(
-  stripe: Stripe,
-  uid: string,
-  email?: string | null
-) {
-  const query = `metadata['uid']:'${uid}'`;
-  const existing = await stripe.customers.search({ query, limit: 1 });
-  let customer = existing.data[0];
-  if (!customer) {
-    customer = await stripe.customers.create({
-      metadata: { uid },
-      email: email || undefined,
-    });
-  } else {
-    const metadata = customer.metadata || {};
-    if (metadata.uid !== uid) {
-      metadata.uid = uid;
-    }
-    const needsEmail = email && customer.email !== email;
-    if (needsEmail || metadata.uid !== customer.metadata?.uid) {
-      await stripe.customers.update(customer.id, {
-        metadata,
-        email: needsEmail ? email : customer.email || undefined,
-      });
-    }
-  }
-  return customer;
-}
-
-function resolvePriceMode(priceId: string): "payment" | "subscription" {
-  if (priceId === PRICE_ONE) return "payment";
-  if (priceId === PRICE_MONTHLY || priceId === PRICE_YEARLY)
-    return "subscription";
-  return "payment";
-}
-
-function formatError(error: any) {
-  const status =
-    typeof error?.statusCode === "number" ? error.statusCode : undefined;
-  const type = error?.type || error?.raw?.type;
-  const code = error?.code || error?.raw?.code;
-  return { status, type, code, message: error?.message || "checkout_failed" };
-}
-
-async function hasActiveSubscription(
-  stripe: Stripe,
-  customerId: string
-): Promise<boolean> {
-  const subs = await stripe.subscriptions.list({
-    customer: customerId,
-    status: "active",
-    limit: 1,
-  });
-  return subs.data.length > 0;
-}
-
+// Keep the aggregate `/api/billing/*` routes on the same implementation as the
+// standalone Hosting rewrites. A previous duplicate router depended on
+// unpopulated PRICE_* environment variables and rejected valid live prices.
 export const billingRouter = express.Router();
-
-billingRouter.use(allowCorsAndOptionalAppCheck);
 billingRouter.use(express.json());
-
 billingRouter.post(
   "/create-checkout-session",
-  async (req: Request, res: Response) => {
-    const stripe = resolveStripe();
-    if (!stripe) {
-      res.status(501).json({ error: "payments_disabled" });
-      return;
-    }
-    try {
-      const { priceId, mode } = req.body ?? {};
-      const normalizedPrice = typeof priceId === "string" ? priceId.trim() : "";
-      if (!normalizedPrice || !allowedPrices.has(normalizedPrice)) {
-        res.status(400).json({ error: "invalid_price" });
-        return;
-      }
-
-      const priceConfig = resolvePriceConfig(normalizedPrice);
-      if (!priceConfig) {
-        res.status(400).json({ error: "unconfigured_price" });
-        return;
-      }
-
-      const { uid, claims } = await requireAuthWithClaims(req);
-      const emailClaim =
-        typeof claims?.email === "string" ? claims.email : undefined;
-      const auth = getAuth();
-      let email = emailClaim;
-      if (!email) {
-        try {
-          const record = await auth.getUser(uid);
-          email = record.email || undefined;
-        } catch {
-          email = undefined;
-        }
-      }
-
-      const customer = await ensureCustomer(stripe, uid, email);
-
-      const inferredMode =
-        mode === "subscription" || mode === "payment"
-          ? mode
-          : (priceConfig.mode ?? resolvePriceMode(normalizedPrice));
-      const params: Stripe.Checkout.SessionCreateParams = {
-        mode: inferredMode,
-        success_url: `${BASE_URL.replace(/\/$/, "")}/plans?success=1`,
-        cancel_url: `${BASE_URL.replace(/\/$/, "")}/plans?canceled=1`,
-        line_items: [{ price: normalizedPrice, quantity: 1 }],
-        customer: customer.id,
-        allow_promotion_codes: false,
-        metadata: {
-          uid,
-          email: email || "",
-          priceId: normalizedPrice,
-          plan: priceConfig.plan,
-        },
-      };
-
-      if (
-        inferredMode === "subscription" &&
-        normalizedPrice === PRICE_MONTHLY &&
-        PROMO_CODE
-      ) {
-        const active = await hasActiveSubscription(stripe, customer.id);
-        if (!active) {
-          params.discounts = [{ promotion_code: PROMO_CODE }];
-        }
-      }
-
-      const session = await stripe.checkout.sessions.create(params);
-      res.json({ sessionId: session.id });
-    } catch (error) {
-      const info = formatError(error);
-      console.error("create_checkout_session_error", info);
-      const status =
-        info.status && info.status >= 400 && info.status < 600
-          ? info.status
-          : 400;
-      res.status(status).json({ error: info.message, code: info.code || null });
-    }
+  (req: Request, res: Response) => {
+    void handleCreateCheckout(req, res);
   }
 );
-
-async function handlePortal(req: Request, res: Response) {
-  const stripe = resolveStripe();
-  if (!stripe) {
-    res.status(501).json({ error: "payments_disabled" });
-    return;
-  }
-  try {
-    const { uid, claims } = await requireAuthWithClaims(req);
-    const emailClaim =
-      typeof claims?.email === "string" ? claims.email : undefined;
-    const auth = getAuth();
-    let email = emailClaim;
-    if (!email) {
-      try {
-        const record = await auth.getUser(uid);
-        email = record.email || undefined;
-      } catch {
-        email = undefined;
-      }
-    }
-    const customer = await ensureCustomer(stripe, uid, email);
-    const portal = await stripe.billingPortal.sessions.create({
-      customer: customer.id,
-      return_url: `${publicBaseUrl(req)}/plans`,
-    });
-    res.json({ url: portal.url });
-  } catch (error) {
-    const info = formatError(error);
-    console.error("billing_portal_error", info);
-    const status =
-      info.status && info.status >= 400 && info.status < 600
-        ? info.status
-        : 400;
-    res.status(status).json({ error: info.message, code: info.code || null });
-  }
-}
-
-billingRouter.post("/portal", handlePortal);
-billingRouter.post("/customer-portal", handlePortal);
+billingRouter.post("/portal", (req: Request, res: Response) => {
+  void handleCustomerPortal(req, res);
+});
+billingRouter.post("/customer-portal", (req: Request, res: Response) => {
+  void handleCustomerPortal(req, res);
+});

--- a/functions/src/http/checkout.ts
+++ b/functions/src/http/checkout.ts
@@ -513,7 +513,7 @@ function sendPaymentsDisabled(
   );
 }
 
-async function handleCreateCheckout(req: Request, res: Response) {
+export async function handleCreateCheckout(req: Request, res: Response) {
   if (cors(req, res)) return;
   await appCheckSoft(req);
   const { allowedOrigin, ended } = applyCors(req, res);
@@ -717,7 +717,7 @@ async function handleCreateCheckout(req: Request, res: Response) {
   }
 }
 
-async function handleCustomerPortal(req: Request, res: Response) {
+export async function handleCustomerPortal(req: Request, res: Response) {
   if (cors(req, res)) return;
   await appCheckSoft(req);
   const { allowedOrigin, ended } = applyCors(req, res);

--- a/functions/src/http/deleteAccount.ts
+++ b/functions/src/http/deleteAccount.ts
@@ -5,6 +5,11 @@ import { getFirestore } from "firebase-admin/firestore";
 import { getStorage } from "firebase-admin/storage";
 import { verifyAppCheck } from "../http.js";
 import { deletePushTokenOwnershipForUser } from "../pushTokenOwnership.js";
+import { deleteStripeCustomerForUser } from "../accountDeletion.js";
+import {
+  stripeSecretKeyParam,
+  stripeSecretParam,
+} from "../stripe/keys.js";
 
 export const deleteAccount = onRequest(
   {
@@ -12,6 +17,7 @@ export const deleteAccount = onRequest(
     region: "us-central1",
     timeoutSeconds: 540,
     memory: "1GiB",
+    secrets: [stripeSecretParam, stripeSecretKeyParam],
   },
   async (req, res) => {
     if (req.method !== "POST")
@@ -32,8 +38,11 @@ export const deleteAccount = onRequest(
       }
 
       const uid = decoded.uid;
+      const requestId =
+        String(req.headers["x-request-id"] || "").trim() || "unknown";
       logger.info("deleteAccount_start", { uid });
 
+      await deleteStripeCustomerForUser(uid, requestId);
       await deleteUserData(uid);
 
       await getAuth().deleteUser(uid);

--- a/functions/test/accountDeletion.test.js
+++ b/functions/test/accountDeletion.test.js
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { deleteStripeCustomerForUser } from "../lib/accountDeletion.js";
+
+test("skips Stripe deletion when the user has no Stripe customer", async () => {
+  let deleteCalls = 0;
+  const result = await deleteStripeCustomerForUser("user-no-stripe", "req-1", {
+    readCustomerId: async () => null,
+    findCustomerIds: async () => [],
+    deleteCustomer: async () => {
+      deleteCalls += 1;
+    },
+  });
+
+  assert.deepEqual(result, { customerIds: [], deletedCount: 0 });
+  assert.equal(deleteCalls, 0);
+});
+
+test("deletes cached and legacy Stripe customers before account data removal", async () => {
+  const deleted = [];
+  const result = await deleteStripeCustomerForUser("user-paid", "req-2", {
+    readCustomerId: async () => "cus_release_test",
+    findCustomerIds: async () => [
+      "cus_release_test",
+      "cus_legacy_without_cache",
+    ],
+    deleteCustomer: async (customerId) => {
+      deleted.push(customerId);
+    },
+  });
+
+  assert.deepEqual(result, {
+    customerIds: ["cus_release_test", "cus_legacy_without_cache"],
+    deletedCount: 2,
+  });
+  assert.deepEqual(deleted, [
+    "cus_release_test",
+    "cus_legacy_without_cache",
+  ]);
+});
+
+test("treats an already-missing Stripe customer as idempotent", async () => {
+  const result = await deleteStripeCustomerForUser("user-retry", "req-3", {
+    readCustomerId: async () => "cus_already_deleted",
+    findCustomerIds: async () => [],
+    deleteCustomer: async () => {
+      const error = new Error("No such customer");
+      error.code = "resource_missing";
+      throw error;
+    },
+  });
+
+  assert.deepEqual(result, {
+    customerIds: ["cus_already_deleted"],
+    deletedCount: 0,
+  });
+});
+
+test("surfaces Stripe failures so deletion can be retried safely", async () => {
+  await assert.rejects(
+    deleteStripeCustomerForUser("user-error", "req-4", {
+      readCustomerId: async () => "cus_unavailable",
+      findCustomerIds: async () => [],
+      deleteCustomer: async () => {
+        throw new Error("Stripe unavailable");
+      },
+    }),
+    /Stripe unavailable/
+  );
+});

--- a/functions/test/accountDeletion.test.js
+++ b/functions/test/accountDeletion.test.js
@@ -3,6 +3,24 @@ import test from "node:test";
 
 import { deleteStripeCustomerForUser } from "../lib/accountDeletion.js";
 
+test("does not access production Stripe from the Functions emulator", async () => {
+  const priorEmulatorValue = process.env.FUNCTIONS_EMULATOR;
+  process.env.FUNCTIONS_EMULATOR = "true";
+  try {
+    const result = await deleteStripeCustomerForUser(
+      "emulator-user",
+      "req-emulator"
+    );
+    assert.deepEqual(result, { customerIds: [], deletedCount: 0 });
+  } finally {
+    if (priorEmulatorValue === undefined) {
+      delete process.env.FUNCTIONS_EMULATOR;
+    } else {
+      process.env.FUNCTIONS_EMULATOR = priorEmulatorValue;
+    }
+  }
+});
+
 test("skips Stripe deletion when the user has no Stripe customer", async () => {
   let deleteCalls = 0;
   const result = await deleteStripeCustomerForUser("user-no-stripe", "req-1", {

--- a/functions/test/apiRoutes.test.js
+++ b/functions/test/apiRoutes.test.js
@@ -4,11 +4,11 @@ import http from 'node:http';
 
 const { apiAppForTest } = await import('../lib/index.js');
 
-function postJson(base, path) {
+function postJson(base, path, body = {}) {
   return fetch(`${base}${path}`, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({})
+    body: JSON.stringify(body)
   });
 }
 
@@ -47,6 +47,17 @@ test('api router returns json for legacy workout endpoints on / and /api aliases
       assert.equal(payload.ok, true);
       assert.ok(payload.data);
     }
+
+    const billing = await postJson(
+      base,
+      '/api/billing/create-checkout-session',
+      { priceId: 'price_1TwQ1OQQU5vuhlNj5peGUJbZ', plan: 'one' },
+    );
+    assert.equal(billing.status, 401);
+    assert.deepEqual(await billing.json(), {
+      error: 'auth_required',
+      code: 'auth_required',
+    });
   } finally {
     global.fetch = originalFetch;
     await new Promise((resolve) => server.close(resolve));

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1360,8 +1360,9 @@ const Settings = () => {
                   <DialogDescription>
                     This will revoke access, delete scans, and erase uploads
                     immediately. You cannot undo this action. It does not cancel
-                    an Apple App Store or Stripe subscription; cancel the
-                    subscription first if you do not want it to renew.
+                    an Apple App Store or Google Play subscription. Cancel store
+                    subscriptions first if you do not want them to renew. A
+                    linked Stripe subscription is canceled during deletion.
                   </DialogDescription>
                 </DialogHeader>
                 <DialogFooter>

--- a/src/pages/SettingsAccountPrivacy.tsx
+++ b/src/pages/SettingsAccountPrivacy.tsx
@@ -69,9 +69,10 @@ export default function SettingsAccountPrivacyPage() {
           Deleting your account will permanently remove your scans, notes, and
           settings. This cannot be undone. For security, sign in again first if
           your last authentication was more than five minutes ago. Deleting
-          your MyBodyScan account does not cancel an Apple App Store or Stripe
-          subscription; cancel it in Apple Subscriptions or the billing portal
-          first if you do not want it to renew.
+          your MyBodyScan account cancels its linked Stripe customer and
+          subscription, but it cannot cancel an Apple App Store or Google Play
+          subscription. Cancel store subscriptions in the applicable store
+          settings first if you do not want them to renew.
         </p>
 
         <label className="text-xs block">


### PR DESCRIPTION
## What changed

- Consolidated `/api/billing/*` onto the production Stripe checkout and Customer Portal handlers and removed the stale duplicate router that depended on empty `PRICE_*` environment variables.
- Added regression coverage proving a configured live price reaches authentication instead of failing as `invalid_price`.
- Made both account-deletion entry points delete cached and legacy metadata-linked Stripe customers before removing Firebase data, so linked Stripe subscriptions are canceled and retriable failures fail safely.
- Updated account-deletion copy to distinguish Stripe cancellation from Apple App Store and Google Play store-managed subscriptions.
- Updated the production runbook with verified webhook state, Stripe onboarding gates, Android upload-key recovery details, and the expanded deletion smoke test.

## Root cause

The Hosting web client called the aggregate `/api/billing/create-checkout-session` route, but that router was a legacy copy whose allowlist came from unset runtime `PRICE_*` variables. The newer standalone Stripe handlers had the correct committed production allowlist, so direct-function checks could pass while the real web route rejected every price. Account deletion also removed Firebase state without first canceling an associated Stripe customer.

## Impact

Web checkout and Customer Portal now use the same tested production implementation as direct function routes. Account deletion cancels Stripe-backed subscriptions while preserving clear instructions for App Store and Play subscriptions.

## Verification

- `npm run lint` — pass, 0 errors (historical warnings only)
- `npm run typecheck` — pass
- `npm test` — 304/304 pass
- `npm --prefix functions test` — 78/78 pass
- `npm run build:prod` — pass, bundle and Storage REST safeguards pass
- `npm run rules:check` — pass
- Firestore rules emulator — 7/7 pass
- `npm run verify:scan` — pass, including success, idempotency, failure refund, credit ledger, and deletion
- Production Storage CORS matches committed policy
- Root and Functions clean-install dry runs pass
- Production dependency audit has no high-severity findings; Functions has 0 findings
- `npm run android:bundle:release` — pass, Gradle tests/lint/signing pass; AAB signature verified
- Live Stripe webhook signed probe — HTTP 200; dead legacy webhook disabled


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Deleting an account now cancels linked Stripe subscriptions and removes the associated Stripe customer record.
  - Updated account-deletion messaging clarifies that Apple App Store and Google Play subscriptions must be canceled through their respective store settings.

- **Bug Fixes**
  - Improved account deletion handling to safely process linked billing records and support retrying failed deletions.

- **Documentation**
  - Updated production and Android release checklists with current billing verification, signing, credential, and post-deployment guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->