### PR TITLE
Document iOS build 8 release state

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -434,23 +434,25 @@ change app credentials; an Owner/Admin must upload the least-privileged Google
 service-account JSON and complete RTDN after the correct Play account and app
 exist.
 
-Current iOS external state on 2026-07-26: the App Store app record exists;
+Current iOS external state on 2026-07-27: the App Store app record exists;
 Xcode is signed into the ADLR Labs team; the physical iPhone is paired with
-Developer Mode. Build 7 was archived from commit `4b5d4bcc`, passed Apple's
-remote App Store validation, and was accepted by Apple's upload service for
-TestFlight processing. That exact archive was installed on the paired iPhone
-14 Pro Max, launched successfully, and remained running with bundle
-`com.mybodyscan.app`, version `1.0.0`, build `7`. App Store Connect processing
-and build selection have not yet been confirmed because the browser session
-expired after upload. Fresh iPhone and iPad simulator builds also install,
-launch, and render the reviewed responsive layouts. Builds 4 through 6 are
+Developer Mode. Build 8 was archived from merged `main` commit `21dda06`,
+exported with App Store distribution signing, and uploaded successfully.
+App Store Connect completed processing without an upload rejection and reports
+version `1.0.0`, build `8` as **Ready to Submit**. Build 8 is selected and saved
+for App Store version 1.0; the final **Add for Review** action was intentionally
+not taken. The exact archive was installed on the paired iPhone 14 Pro Max,
+reports bundle `com.mybodyscan.app`, version `1.0.0`, build `8`, launched
+successfully, and remained running. The exported signature passed
+`codesign --verify --deep --strict`; its provisioning entitlements include
+production APNs, Sign in with Apple, TestFlight beta reporting, and
+`get-task-allow=false`. Fresh iPhone and iPad simulator builds also install,
+launch, and render the reviewed responsive layouts. Builds 2 through 7 are
 superseded and must not be submitted. The real photo, purchase, restore,
 notification, authentication, cold-launch, and offline device checklist
 remains mandatory.
 
-Build 6 is still selected for App Store version 1.0 only as the prior metadata
-placeholder; replace it with processed build 7 before submission. Six
-ordered 1242 × 2688 iPhone
+Six ordered 1242 × 2688 iPhone
 screenshots and six ordered 2064 × 2752 iPad screenshots are uploaded: body
 results, training, nutrition progress, meal planning, four-photo scanning, and
 AI coaching. The app download price is $0.00 and the app is scheduled to be


### PR DESCRIPTION
## What changed
- records build 8’s archive, App Store export/signature checks, upload, processing, and draft selection
- records installation and launch on the paired iPhone
- marks builds 2–7 as superseded
- preserves the mandatory real-photo, auth, purchase, restore, notification, cold-launch, and offline checklist

## Why
The production release source of truth still described build 7 as processing and build 6 as selected. App Store Connect now has build 8 ready and selected.

## Validation
- `git diff --check`
- App Store Connect build 8: Complete / Ready to Submit
- App Store version 1.0: build 8 selected and saved
- connected iPhone: `com.mybodyscan.app` version `1.0.0` build `8`, installed and launched
- exported IPA: App Store distribution signature verified