### PR TITLE
Fix production rate-limit Firestore path

### DIFF
--- a/functions/src/middleware/rateLimit.ts
+++ b/functions/src/middleware/rateLimit.ts
@@ -10,9 +10,22 @@ interface RateLimitConfig {
   windowMs: number;
 }
 
+export function rateLimitDocumentPath(uid: string, key: string): string {
+  const safeKey = String(key || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]/g, "_");
+  if (!uid || uid.includes("/") || !safeKey) {
+    throw new HttpsError("internal", "rate_limit_key_invalid");
+  }
+  // Firestore document paths must have an even number of segments. Keep rate
+  // limit state in a server-only document under the existing `private`
+  // collection instead of the invalid `private/rateLimits/{key}` shape.
+  return `users/${uid}/private/rateLimits_${safeKey}`;
+}
+
 export async function enforceRateLimit(config: RateLimitConfig): Promise<void> {
   const { uid, key, limit, windowMs } = config;
-  const ref = db.doc(`users/${uid}/private/rateLimits/${key}`);
+  const ref = db.doc(rateLimitDocumentPath(uid, key));
   const now = Timestamp.now();
   const windowStart = now.toMillis() - windowMs;
 

--- a/functions/test/rateLimitPath.test.js
+++ b/functions/test/rateLimitPath.test.js
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rateLimitDocumentPath } from "../lib/middleware/rateLimit.js";
+
+test("rate limiter uses a valid server-private Firestore document path", () => {
+  const path = rateLimitDocumentPath("user_123", "coachChat");
+  assert.equal(path, "users/user_123/private/rateLimits_coachChat");
+  assert.equal(path.split("/").length % 2, 0);
+});
+
+test("rate limiter sanitizes internal keys and rejects invalid user ids", () => {
+  assert.equal(
+    rateLimitDocumentPath("user_123", "workouts/generate"),
+    "users/user_123/private/rateLimits_workouts_generate"
+  );
+  assert.throws(() => rateLimitDocumentPath("users/bad", "coachChat"));
+  assert.throws(() => rateLimitDocumentPath("user_123", ""));
+});


### PR DESCRIPTION
## What changed

- replace the invalid `users/{uid}/private/rateLimits/{key}` Firestore document path with a valid server-private document path
- sanitize internal rate-limit keys before constructing the document ID
- add regression coverage that asserts the path has a valid even segment count and rejects invalid IDs

## Root cause and impact

The shared rate limiter called `db.doc()` with an odd number of Firestore path segments. Production Coach requests failed before reaching OpenAI, and the same helper could also affect workout generation and paid-scan entry paths.

## Validation

- web tests: 316 passed
- Functions tests: 81 passed
- web and Functions type-checks passed
- production build, bundle safeguard, Storage REST safeguard passed
- Firestore rule consistency passed
- lint: 0 errors (historical warnings unchanged)
- live production QA reproduced the failure before this fix; post-deploy subscriber probe will verify USDA, Open Food Facts, Coach/OpenAI, Stripe Checkout, and account deletion

The Java-backed scan emulator gate will be required to pass in CI before merge because this Mac does not currently have a Java runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rate-limit path handling by sanitizing internal keys and rejecting invalid inputs.
  - Prevented malformed or unsafe Firestore paths from being generated.

- **Tests**
  - Added coverage for valid paths, key normalization, path structure, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->