### PR TITLE
Normalize the configured OpenAI API base URL

### DIFF
--- a/functions/src/openai/client.ts
+++ b/functions/src/openai/client.ts
@@ -111,10 +111,13 @@ function resolveEndpoint(customBaseUrl?: string): string {
   const base =
     (customBaseUrl || process.env.OPENAI_BASE_URL || "").trim() ||
     OPENAI_ENDPOINT;
-  if (base.includes("/v1/chat/completions")) {
-    return base;
-  }
   const trimmed = base.replace(/\/+$/, "");
+  if (trimmed.endsWith("/v1/chat/completions")) {
+    return trimmed;
+  }
+  if (trimmed.endsWith("/v1")) {
+    return `${trimmed}/chat/completions`;
+  }
   return `${trimmed}/v1/chat/completions`;
 }
 

--- a/functions/test/openaiClientReliability.test.js
+++ b/functions/test/openaiClientReliability.test.js
@@ -52,10 +52,12 @@ test("falls back from a retired override to the current image-capable model", as
   const originalModel = process.env.OPENAI_MODEL;
   const requestedModels = [];
   const requestBodies = [];
+  const requestedUrls = [];
 
   process.env.OPENAI_MODEL = "gpt-4o-mini";
-  globalThis.fetch = async (_url, init) => {
+  globalThis.fetch = async (url, init) => {
     const body = JSON.parse(init.body);
+    requestedUrls.push(String(url));
     requestBodies.push(body);
     requestedModels.push(body.model);
     if (body.model === "gpt-4o-mini") {
@@ -85,6 +87,7 @@ test("falls back from a retired override to the current image-capable model", as
       apiKey: "test-key",
       model: "gpt-4o-mini",
       userId: "firebase-user-123",
+      baseUrl: "https://api.openai.com/v1/",
       validate(payload) {
         assert.deepEqual(payload, { estimate: "ok" });
         return payload;
@@ -99,6 +102,10 @@ test("falls back from a retired override to the current image-capable model", as
     assert.equal(requestBodies[1].temperature, undefined);
     assert.equal(requestBodies[1].safety_identifier, "firebase-user-123");
     assert.equal(requestBodies[1].user, undefined);
+    assert.deepEqual(requestedUrls, [
+      "https://api.openai.com/v1/chat/completions",
+      "https://api.openai.com/v1/chat/completions",
+    ]);
   } finally {
     globalThis.fetch = originalFetch;
     if (originalModel == null) delete process.env.OPENAI_MODEL;


### PR DESCRIPTION
## Summary
- normalize an OpenAI base URL that already ends in `/v1`
- prevent production from calling the invalid `/v1/v1/chat/completions` path
- add a regression assertion covering the exact production URL shape

## Root cause
The committed Functions environment correctly used `OPENAI_BASE_URL=https://api.openai.com/v1`, but the shared client always appended `/v1/chat/completions`. OpenAI returned a 404, which the model fallback layer surfaced as unavailable models.

## Verification
- focused OpenAI reliability tests: 2/2
- complete Functions suite: 81/81
- Functions type-check: pass
- production configuration check: pass
- direct production-key access for Luna, Terra, image input, and structured JSON was already verified in #770