### PR TITLE
Enforce subscriber scan credit metering

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -109,7 +109,10 @@ surface.
 The fail-closed iOS product IDs are committed in both client and Functions
 configuration: `com.mybodyscan.pro.monthly` (3 credits per renewal),
 `com.mybodyscan.pro.yearly` (36 credits per annual renewal), and
-`com.mybodyscan.scan.single` (one consumable credit). RevenueCat events for any
+`com.mybodyscan.scan.single` (one consumable credit). Subscription events grant
+Pro feature access and the documented credit bucket; Pro by itself must never
+bypass scan metering. Only staff or accounts explicitly marked with unlimited
+credits bypass the credit bucket and debit ledger. RevenueCat events for any
 other product are recorded as ignored and cannot grant Pro or credits.
 
 ### Product access boundary

--- a/functions/src/lib/scanCreditAccess.ts
+++ b/functions/src/lib/scanCreditAccess.ts
@@ -1,0 +1,21 @@
+export type ScanCreditAccessSignals = {
+  staff: boolean;
+  unlimitedClaim: boolean;
+  unlimitedMirror: boolean;
+  proEntitled?: boolean;
+};
+
+/**
+ * Paid subscriptions unlock Pro features and grant metered scan credits.
+ * They do not make scans unlimited. Only staff and explicitly unlimited
+ * accounts bypass the credit bucket + ledger path.
+ */
+export function shouldBypassScanCredits(
+  signals: ScanCreditAccessSignals
+): boolean {
+  return (
+    signals.staff === true ||
+    signals.unlimitedClaim === true ||
+    signals.unlimitedMirror === true
+  );
+}

--- a/functions/src/scan/beginPaidScan.ts
+++ b/functions/src/scan/beginPaidScan.ts
@@ -22,7 +22,7 @@ import { validateBeginPaidScanPayload } from "../validation/beginPaidScan.js";
 import { isStaff } from "../claims.js";
 import { errorCode, statusFromCode } from "../lib/errors.js";
 import { hasUnlimitedCreditsMirror } from "../lib/unlimitedCredits.js";
-import { hasProEntitlement } from "../lib/proEntitlements.js";
+import { shouldBypassScanCredits } from "../lib/scanCreditAccess.js";
 
 const db = getFirestore();
 const MAX_DAILY_FAILS = 3;
@@ -37,13 +37,11 @@ async function handler(req: ExpressRequest, res: ExpressResponse) {
   await verifyAppCheckStrict(req);
   const { uid, claims } = await requireAuthWithClaims(req);
   const staffBypass = await isStaff(uid);
-  const tokenEmail = (claims as any)?.email;
-  const email = typeof tokenEmail === "string" ? tokenEmail : null;
-  const proEntitled = await hasProEntitlement(uid, email);
-  const unlimitedCredits =
-    claims?.unlimitedCredits === true ||
-    (await hasUnlimitedCreditsMirror(uid)) ||
-    proEntitled;
+  const unlimitedCredits = shouldBypassScanCredits({
+    staff: staffBypass,
+    unlimitedClaim: claims?.unlimitedCredits === true,
+    unlimitedMirror: await hasUnlimitedCreditsMirror(uid),
+  });
 
   if (staffBypass) {
     console.info("beginPaidScan_staff_bypass", { uid });

--- a/functions/src/scan/creditAuthorization.ts
+++ b/functions/src/scan/creditAuthorization.ts
@@ -2,7 +2,7 @@ import type { Transaction } from "firebase-admin/firestore";
 import { Timestamp, getFirestore } from "../firebase.js";
 import { isStaff } from "../claims.js";
 import { hasUnlimitedCreditsMirror } from "../lib/unlimitedCredits.js";
-import { hasProEntitlement } from "../lib/proEntitlements.js";
+import { shouldBypassScanCredits } from "../lib/scanCreditAccess.js";
 import { consumeCreditBuckets } from "./creditUtils.js";
 import { HttpsError } from "firebase-functions/v2/https";
 
@@ -14,13 +14,15 @@ export async function resolveScanCreditAccess(
   uid: string,
   claims: any
 ): Promise<ScanCreditAccess> {
-  const tokenEmail = claims?.email;
-  const email = typeof tokenEmail === "string" ? tokenEmail : null;
-  const bypass =
-    (await isStaff(uid)) ||
-    claims?.unlimitedCredits === true ||
-    (await hasUnlimitedCreditsMirror(uid)) ||
-    (await hasProEntitlement(uid, email));
+  const [staff, unlimitedMirror] = await Promise.all([
+    isStaff(uid),
+    hasUnlimitedCreditsMirror(uid),
+  ]);
+  const bypass = shouldBypassScanCredits({
+    staff,
+    unlimitedClaim: claims?.unlimitedCredits === true,
+    unlimitedMirror,
+  });
   return { bypass };
 }
 

--- a/functions/src/useCredit.ts
+++ b/functions/src/useCredit.ts
@@ -4,7 +4,7 @@ import type { Request } from "express";
 import { verifyAppCheckStrict } from "./http.js";
 import { consumeCredit } from "./credits.js";
 import { hasUnlimitedCreditsMirror } from "./lib/unlimitedCredits.js";
-import { hasProEntitlement } from "./lib/proEntitlements.js";
+import { shouldBypassScanCredits } from "./lib/scanCreditAccess.js";
 
 type UseCreditContext = Pick<CallableRequest<unknown>, "auth" | "rawRequest">;
 
@@ -22,18 +22,16 @@ export async function useCreditHandler(
   if (!uid) {
     throw new HttpsError("unauthenticated", "Authentication required");
   }
-  const tokenEmail = context.auth?.token?.email;
-  const email = typeof tokenEmail === "string" ? tokenEmail : null;
-
   const rawRequest = context.rawRequest as Request | undefined;
   if (rawRequest) {
     await verifyAppCheckStrict(rawRequest);
   }
 
-  const unlimitedCredits =
-    hasUnlimited(context) ||
-    (await hasUnlimitedCreditsMirror(uid)) ||
-    (await hasProEntitlement(uid, email));
+  const unlimitedCredits = shouldBypassScanCredits({
+    staff: false,
+    unlimitedClaim: hasUnlimited(context),
+    unlimitedMirror: await hasUnlimitedCreditsMirror(uid),
+  });
   if (unlimitedCredits) {
     // Bypass credit consumption for whitelisted users
     return { ok: true, remaining: Infinity };

--- a/functions/test/scanCreditMetering.test.js
+++ b/functions/test/scanCreditMetering.test.js
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { shouldBypassScanCredits } from "../lib/lib/scanCreditAccess.js";
+
+test("a Pro subscription remains metered for granted scan credits", () => {
+  assert.equal(
+    shouldBypassScanCredits({
+      staff: false,
+      unlimitedClaim: false,
+      unlimitedMirror: false,
+      proEntitled: true,
+    }),
+    false
+  );
+});
+
+test("only staff or explicitly unlimited accounts bypass scan credits", () => {
+  assert.equal(
+    shouldBypassScanCredits({
+      staff: true,
+      unlimitedClaim: false,
+      unlimitedMirror: false,
+    }),
+    true
+  );
+  assert.equal(
+    shouldBypassScanCredits({
+      staff: false,
+      unlimitedClaim: true,
+      unlimitedMirror: false,
+    }),
+    true
+  );
+  assert.equal(
+    shouldBypassScanCredits({
+      staff: false,
+      unlimitedClaim: false,
+      unlimitedMirror: true,
+    }),
+    true
+  );
+});


### PR DESCRIPTION
## Summary
- keep Monthly and Yearly subscriptions metered against their granted scan-credit buckets
- reserve scan bypasses for staff and explicitly unlimited QA accounts
- apply one shared access rule to scan upload, paid-scan gating, and generic credit consumption
- document the product boundary and add direct regression coverage

## Why
The public plans promise 3 monthly or 36 yearly scan credits. Treating every active Pro entitlement as unlimited bypassed both the bucket balance and debit ledger, contradicting the product and release checklist.

## Verification
- focused scan-credit tests: 2/2
- complete Functions suite: 83/83
- Functions type-check: pass
- diff check: pass