### PR TITLE
Improve mobile header touch targets

### DIFF
--- a/src/layouts/AuthedLayout.tsx
+++ b/src/layouts/AuthedLayout.tsx
@@ -175,7 +175,7 @@ export default function AuthedLayout({ children }: AuthedLayoutProps) {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 p-0"
+                    className="h-11 w-11 p-0"
                     aria-label="Open account menu"
                   >
                     <Avatar className="h-8 w-8">
@@ -206,7 +206,7 @@ export default function AuthedLayout({ children }: AuthedLayoutProps) {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="h-8 w-8 p-0"
+                    className="h-11 w-11 p-0"
                     aria-label="Open navigation menu"
                   >
                     <Menu className="h-4 w-4" />

--- a/tests/mobile-touch-targets.test.ts
+++ b/tests/mobile-touch-targets.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const layout = fs.readFileSync(
+  path.resolve(__dirname, "../src/layouts/AuthedLayout.tsx"),
+  "utf8"
+);
+
+describe("authenticated header touch targets", () => {
+  it.each(["Open account menu", "Open navigation menu"])(
+    "keeps %s at least 44px square",
+    (label) => {
+      const labelIndex = layout.indexOf(`aria-label="${label}"`);
+      expect(labelIndex).toBeGreaterThan(0);
+
+      const buttonSource = layout.slice(labelIndex - 220, labelIndex);
+      expect(buttonSource).toContain('className="h-11 w-11 p-0"');
+      expect(buttonSource).not.toContain('className="h-8 w-8 p-0"');
+    }
+  );
+});


### PR DESCRIPTION
## What changed
- increases the authenticated account and mobile navigation menu controls from 32×32px to 44×44px
- adds a regression test that protects both header touch targets

## Why
A live iPhone-width production audit found the hamburger control rendered at 32×32px. The layout was otherwise clean, but the target was smaller than the recommended phone accessibility size.

## User impact
The controls are easier and more reliable to tap without changing the visual hierarchy, icon size, navigation behavior, or responsive layout.

## Validation
- `npx eslint src/layouts/AuthedLayout.tsx`
- `npm run typecheck`
- `npm test -- --reporter=dot --silent` — 316/316 existing tests passed
- `npx vitest run tests/mobile-touch-targets.test.ts --maxWorkers=1 --minWorkers=1` — 2/2 passed
- `npm run build:prod` — build, bundle guard, and Storage REST guard passed
- local production preview at 390×844 confirmed a 44×44px menu control with no horizontal overflow
- live production audit before the change found no browser errors and intentional subscriber gating

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Increased the size of desktop account-menu and mobile navigation buttons for easier tapping on touch devices.
* **Tests**
  * Added coverage to verify authenticated header controls meet the required mobile touch-target size.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->