### PR TITLE
Document final TestFlight build 10 setup

### DIFF
--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -485,16 +485,20 @@ Connect completed processing without an upload rejection and reports version
 `1.0.0`, build `10` as **Ready to Submit**. The archive contains Weekly Review,
 private foods and recipes, the three exact App Store products, and build tag
 `becc143`. Build 10 is the only current TestFlight/device acceptance candidate.
-It has not been added to an internal testing group, selected for App Store
-version 1.0, installed on the paired iPhone, or submitted for review.
+It is the sole build in the `Internal QA` TestFlight group, whose distribution
+is intentionally manual, and it is selected and saved for App Store version
+1.0. Its build-level `What to Test` checklist and app-level beta description,
+feedback email, marketing URL, and privacy URL are saved. App Store Connect
+currently has no eligible internal testers, so no invitation has been sent.
+Build 10 has not been installed on the paired iPhone or submitted for review.
 
-Build 9 remains selected and saved for App Store version 1.0, but it predates
-the final adaptive coaching and custom-food bundle and is now superseded. Do
-not submit build 9. It was previously installed on the paired iPhone 14 Pro
-Max, reported bundle `com.mybodyscan.app`, version `1.0.0`, build `9`, launched
-successfully, and remained running. Fresh iPhone and iPad simulator builds also
-install, launch, and render the reviewed responsive layouts. Builds 2 through
-9 are superseded and must not be submitted. The real photo, purchase, restore,
+Build 9 is no longer selected for App Store version 1.0. It predates the final
+adaptive coaching and custom-food bundle and is now superseded; do not submit
+it. It was previously installed on the paired iPhone 14 Pro Max, reported
+bundle `com.mybodyscan.app`, version `1.0.0`, build `9`, launched successfully,
+and remained running. Fresh iPhone and iPad simulator builds also install,
+launch, and render the reviewed responsive layouts. Builds 2 through 9 are
+superseded and must not be submitted. The real photo, purchase, restore,
 notification, authentication, cold-launch, and offline device checklist
 remains mandatory for build 10.
 

--- a/ios/RELEASE_IOS.md
+++ b/ios/RELEASE_IOS.md
@@ -116,11 +116,15 @@ Current release snapshot (2026-07-28):
 - Xcode archive validation, distribution export, upload, and Apple processing
   completed successfully. App Store Connect reports build 10 as **Ready to
   Submit**.
-- Build 10 has not been added to an internal testing group, installed on the
-  paired iPhone, selected for App Store version 1.0, or submitted for review.
-- Builds 2 through 9 are superseded. Build 9 remains selected for App Store
-  version 1.0 but predates the final adaptive coaching and custom-food bundle;
-  do not submit it.
+- Build 10 is the sole build in the `Internal QA` TestFlight group. Distribution
+  is manual so later unverified uploads cannot reach testers automatically.
+  The build-level `What to Test` checklist and the app-level beta description,
+  feedback email, marketing URL, and privacy URL are saved.
+- Build 10 is selected and saved for App Store version 1.0. It has not been
+  installed on the paired iPhone or submitted for review. App Store Connect
+  currently has no eligible internal testers, so no invitation has been sent.
+- Builds 2 through 9 are superseded and build 9 is no longer selected for App
+  Store version 1.0; do not submit any of them.
 - The monthly, yearly, and single-scan App Store products exist at the approved
   prices. RevenueCat's `pro` entitlement and current/default offering are
   wired to the exact products described above.


### PR DESCRIPTION
## What changed

- records build 10 as the sole build in the manual `Internal QA` TestFlight group
- records the saved TestFlight testing instructions and beta metadata
- records build 10 as the selected App Store version 1.0 build
- marks builds 2–9 as superseded and documents that no eligible internal tester is currently available

## Why

The release guides still described the earlier build 9 state. This brings the repository source of truth in line with the verified App Store Connect configuration without submitting the app, publishing privacy changes, or inviting testers.

## Validation

- `git diff --check`
- GitHub compare: one commit, two documentation files, no code changes
- App Store Connect audit: build 10 metadata saved, manual Internal QA distribution, build 10 selected for version 1.0