### PR TITLE
Replace AI branding with product-focused copy

### DIFF
--- a/functions/src/coachChat.ts
+++ b/functions/src/coachChat.ts
@@ -558,7 +558,7 @@ function deterministicCoachFallback(
   const experience = (payload.activityLevel || "beginner").toLowerCase();
   const cardioDays = goal.includes("fat") ? 4 : goal.includes("muscle") ? 2 : 3;
   const liftDays = goal.includes("muscle") ? 4 : 3;
-  const reply = `AI is temporarily unavailable; here is a standard plan: ${liftDays} lifting days + ${cardioDays} cardio days this week. Keep sessions 30-45 minutes, prioritize compound movements, and hit protein at each meal. (${experience} track)`;
+  const reply = `Personalized coaching is temporarily unavailable; here is a standard plan: ${liftDays} lifting days + ${cardioDays} cardio days this week. Keep sessions 30-45 minutes, prioritize compound movements, and hit protein at each meal. (${experience} track)`;
   return {
     reply,
     suggestions: ["Open workouts", "Review nutrition targets"],

--- a/functions/src/lib/openaiConfig.ts
+++ b/functions/src/lib/openaiConfig.ts
@@ -88,7 +88,7 @@ export function assertOpenAIConfig(correlationId?: string): OpenAIEnvConfig {
   if (config) return config;
   const message =
     missing.includes("OPENAI_API_KEY") || missing.includes("OPENAI_MODEL")
-      ? "Scan engine not configured. Set OPENAI_API_KEY and OPENAI_MODEL in Cloud Functions."
+      ? "Scan engine not configured. Configure the required provider credentials in Cloud Functions."
       : `Scan engine not configured. Missing: ${missing.join(", ")}`;
   throw new HttpsError("unavailable", message, {
     reason: "scan_engine_not_configured",

--- a/functions/src/scan/engineConfig.ts
+++ b/functions/src/scan/engineConfig.ts
@@ -148,7 +148,7 @@ export function getEngineConfigOrThrow(correlationId?: string): EngineConfig {
   throw new HttpsError(
     "unavailable",
     needsKey
-      ? "Scan engine not configured. Set OPENAI_API_KEY and OPENAI_MODEL in Cloud Functions."
+      ? "Scan engine not configured. Configure the required provider credentials in Cloud Functions."
       : `Scan engine not configured. Missing: ${missingList}.`,
     {
       reason: "scan_engine_not_configured",

--- a/functions/test/engineConfig.test.js
+++ b/functions/test/engineConfig.test.js
@@ -26,7 +26,7 @@ function restoreEnv(snapshot) {
   }
 }
 
-test("engine config surfaces missing OPENAI_API_KEY with actionable message", () => {
+test("engine config surfaces missing provider credentials with actionable message", () => {
   const snap = snapshotEnv();
   try {
     delete process.env.OPENAI_API_KEY;
@@ -38,8 +38,8 @@ test("engine config surfaces missing OPENAI_API_KEY with actionable message", ()
         assert.equal(err.code, "unavailable");
         assert.match(
           err.message,
-          /Set OPENAI_API_KEY/,
-          "missing key should include fix hint"
+          /Configure the required provider credentials/,
+          "missing credentials should include fix hint"
         );
         return true;
       }

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -114,10 +114,11 @@
       <li>Comply with law and enforce our Terms of Service.</li>
     </ul>
 
-    <h2>Scan media and AI processing</h2>
+    <h2>Scan media and automated processing</h2>
     <p>
-      Photos and related inputs may be sent to contracted cloud and AI service
-      providers solely to operate the requested scan or optional preview.
+      Photos and related inputs may be sent to contracted cloud and
+      automated analysis service providers solely to operate the requested
+      scan or optional preview.
       Outputs are estimates and may be inaccurate. A transformation preview is a
       motivational illustration, not a prediction or guarantee of future
       appearance.
@@ -130,7 +131,7 @@
     </p>
     <ul>
       <li>
-        cloud hosting, authentication, storage, analytics, AI-processing,
+        cloud hosting, authentication, storage, analytics, automated analysis,
         nutrition-data, customer-support, notification, and payment providers
         acting for us;
       </li>

--- a/src/content/legal/privacy.md
+++ b/src/content/legal/privacy.md
@@ -26,15 +26,15 @@ Allergy preferences and weekly recovery check-ins are treated as sensitive welln
 
 MyBodyScan maintains incident-response procedures for unauthorized access to identifiable wellness information. Where the Federal Trade Commission Health Breach Notification Rule or another applicable law applies, we will provide required notices to affected people and regulators within the required time.
 
-## Scan Media and AI Processing
+## Scan Media and Automated Processing
 
-Photos and related inputs may be sent to contracted cloud and AI service providers solely to operate the requested scan or optional preview. Outputs are estimates and may be inaccurate. A transformation preview is a motivational illustration, not a prediction or guarantee of future appearance.
+Photos and related inputs may be sent to contracted cloud and automated analysis service providers solely to operate the requested scan or optional preview. Outputs are estimates and may be inaccurate. A transformation preview is a motivational illustration, not a prediction or guarantee of future appearance.
 
 ## Sharing and Service Providers
 
 We do not sell personal information. We disclose information only as needed to:
 
-- cloud hosting, authentication, storage, analytics, AI-processing, nutrition-data, customer-support, notification, and payment providers acting for us;
+- cloud hosting, authentication, storage, analytics, automated analysis, nutrition-data, customer-support, notification, and payment providers acting for us;
 - protect users, MyBodyScan, or others from fraud, abuse, or security threats;
 - comply with legal process or applicable law; or
 - complete a business transaction, subject to appropriate safeguards.

--- a/src/content/legal/terms.md
+++ b/src/content/legal/terms.md
@@ -49,7 +49,7 @@ We may limit, suspend, or terminate access when reasonably necessary for securit
 
 ## Availability and Third-Party Services
 
-We may change, suspend, or discontinue features and do not promise uninterrupted availability. MyBodyScan relies on third-party platforms and data sources, including app stores, cloud, AI, nutrition-data, authentication, and payment providers. Their outages, rules, and content can affect the service.
+We may change, suspend, or discontinue features and do not promise uninterrupted availability. MyBodyScan relies on third-party platforms and data sources, including app stores, cloud, automated analysis, nutrition-data, authentication, and payment providers. Their outages, rules, and content can affect the service.
 
 ## Disclaimers and Limitation of Liability
 

--- a/src/lib/envStatus.ts
+++ b/src/lib/envStatus.ts
@@ -147,13 +147,13 @@ export function computeFeatureStatuses(
     : `Missing: ${firebaseConfigMissingKeys.join(", ")}. Add the Firebase web keys to .env.production.local.`;
 
   const scanWarnLabel =
-    openaiConfigured === false ? "OpenAI missing" : "Needs config";
+    openaiConfigured === false ? "Analysis service missing" : "Needs config";
   const scanDetail = scanConfigured
     ? scanServicesHealthy === false
       ? "Function reachable but reported unhealthy; check Cloud Functions logs."
       : undefined
     : openaiConfigured === false
-      ? "Add OPENAI_API_KEY via firebase functions:secrets:set before running scans."
+      ? "Configure the analysis-provider secret before running scans."
       : scanEngineConfigured === false && Array.isArray(remoteHealth?.scanEngineMissing)
         ? `Scan engine missing: ${remoteHealth.scanEngineMissing.join(", ")}`
         : functionsConfigured
@@ -163,14 +163,15 @@ export function computeFeatureStatuses(
   const workoutsDetail = workoutsConfigured
     ? workoutAdjustConfigured
       ? undefined
-      : "AI adjustments disabled until OPENAI_API_KEY secret is configured."
+      : "Personalized adjustments are disabled until the coaching service is configured."
     : "Backend unavailable (Cloud Functions). Check deployment / network.";
 
-  const coachWarnLabel = openaiConfigured === false ? "OpenAI missing" : "Needs config";
+  const coachWarnLabel =
+    openaiConfigured === false ? "Coaching service missing" : "Needs config";
   const coachDetail = coachConfigured
     ? undefined
     : openaiConfigured === false
-      ? "Add OPENAI_API_KEY via firebase functions:secrets:set."
+      ? "Configure the coaching-provider secret."
       : "Deploy coachChat Function and confirm /api/system/health passes.";
 
   const nutritionDetail = nutritionConfigured

--- a/src/lib/scanResultViewModel.production.test.ts
+++ b/src/lib/scanResultViewModel.production.test.ts
@@ -58,7 +58,7 @@ describe("scan result production view model", () => {
     const vm = buildScanResultViewModel({ scan: baseScan() });
 
     expect(vm.isValidResult).toBe(true);
-    expect(vm.sourceLabel).toBe("AI analysis");
+    expect(vm.sourceLabel).toBe("Photo analysis");
     expect(vm.primary.bodyFatPercent).toBe(20);
     expect(vm.primary.bmi).toBe(27.8);
     expect(vm.nutrition.calories).toBe(2300);

--- a/src/lib/scanResultViewModel.ts
+++ b/src/lib/scanResultViewModel.ts
@@ -14,7 +14,7 @@ export type CanonicalScanResultViewModel = {
   isValidResult: boolean;
   isFailedOrFallback: boolean;
   sourceLabel:
-    | "AI analysis"
+    | "Photo analysis"
     | "Demo only"
     | "Failed"
     | "Fallback/invalid"
@@ -391,7 +391,7 @@ export function buildScanResultViewModel(args: {
         : canonical === "error"
           ? "Failed"
           : isValidResult
-            ? "AI analysis"
+            ? "Photo analysis"
             : canonical === "complete"
               ? "Fallback/invalid"
               : "Processing",

--- a/src/pages/Billing.tsx
+++ b/src/pages/Billing.tsx
@@ -143,7 +143,7 @@ export default function Billing() {
           <ul className="my-4 flex-1 space-y-2 text-sm">
             {[
               "Three scan credits per renewal",
-              "AI Coach and weekly adaptive reviews",
+              "Personal Coach and weekly adaptive reviews",
               "Workout tracking, meal plans, recipes, and food insights",
             ].map((feature) => (
               <li key={feature} className="flex gap-2">

--- a/src/pages/Coach/Chat.tsx
+++ b/src/pages/Coach/Chat.tsx
@@ -190,7 +190,7 @@ export default function CoachChatPage() {
   const coachPrereqMessage =
     systemHealth?.openaiConfigured === false ||
     systemHealth?.openaiKeyPresent === false
-      ? "Coach chat requires the OpenAI key (OPENAI_API_KEY). Ask an admin to add it."
+      ? "Personalized coaching is temporarily unavailable. Ask an admin to check the coaching service."
       : coachConfigured === false
         ? "Coach chat is offline until the backend configuration is completed."
         : null;
@@ -955,7 +955,7 @@ export default function CoachChatPage() {
     >
       <Seo
         title="Coach Chat | MyBodyScan"
-        description="Talk to your AI coach and refresh your weekly plan."
+        description="Talk to your personal coach and refresh your weekly plan."
       />
       <ErrorBoundary
         title="Coach chat crashed"

--- a/src/pages/LiveFlowsQA.tsx
+++ b/src/pages/LiveFlowsQA.tsx
@@ -139,7 +139,7 @@ export default function LiveFlowsQA() {
         return `credits=${creditsSnap.data()?.creditsSummary?.totalAvailable ?? "na"}, pro=${Boolean(entSnap.data()?.pro)}`;
       });
       await run("4. coachChat manual verification", async () => {
-        return "manual only: skipped to avoid paid AI request or message writes";
+        return "manual only: skipped to avoid paid analysis or message writes";
       });
       await run("5. nutritionSearch read", async () => {
         const res = await nutritionSearch("banana");
@@ -228,7 +228,7 @@ export default function LiveFlowsQA() {
           </Button>
           <p className="mt-2 text-xs text-muted-foreground">
             Read-only by default: no meals, workout plans, scan sessions,
-            credits, or paid AI calls are created by this check.
+            credits, or paid analysis calls are created by this check.
           </p>
         </CardContent>
       </Card>
@@ -243,7 +243,7 @@ export default function LiveFlowsQA() {
                 <div>scanId: {latestScan.id}</div>
                 <div>scan status: {String(latestScan.status ?? "unknown")}</div>
                 <div>
-                  AI processing status:{" "}
+                  Analysis processing status:{" "}
                   {String(
                     latestScan.aiProcessing?.status ??
                       latestScan.lastStep ??

--- a/src/pages/Paywall.tsx
+++ b/src/pages/Paywall.tsx
@@ -220,7 +220,7 @@ export default function PaywallPage() {
               "Workout sessions, progress logging, timers, and smart swaps",
               "7-day meal plans, nutrition tracking, recipes, and saved foods",
               "Barcode insights, label context, and same-category alternatives",
-              "AI Coach plus approval-based weekly plan reviews",
+              "Personal Coach plus approval-based weekly plan reviews",
               "Scan comparisons and opt-in plateau check-ins",
               "Process-based daily Momentum without appearance rankings",
               "Optional adult Transformation Previews",

--- a/src/pages/Plans.tsx
+++ b/src/pages/Plans.tsx
@@ -325,7 +325,7 @@ export default function Plans() {
         "Personalized 7-day meal plan, targets, and meal log",
         "Barcode search and MBS Product Insight",
         "Better-fit same-category food alternatives",
-        "AI Coach and opt-in plateau check-ins",
+        "Personal Coach and opt-in plateau check-ins",
         "Daily Momentum based on completed actions—not appearance",
         "Optional adult Transformation Previews",
       ],

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -902,7 +902,7 @@ const Results = () => {
                   calculations.
                 </li>
                 <li>
-                  Body-fat percentage is an AI-assisted visual wellness
+                  Body-fat percentage is a photo-based visual wellness
                   estimate. Lean and fat mass are calculated from weight and
                   that estimate.
                 </li>
@@ -938,7 +938,7 @@ const Results = () => {
             </CardHeader>
             <CardContent className="space-y-3 text-sm text-zinc-300">
               <p>
-                Create an optional, private AI illustration of a realistic goal
+                Create an optional, private illustration of a realistic goal
                 direction. It is motivational—not a prediction or guarantee.
               </p>
               <Button

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -1348,7 +1348,7 @@ export default function ScanPage() {
   if (!authLoading && !user) {
     return (
       <div className="mx-auto max-w-2xl space-y-6 p-4">
-        <h1 className="text-xl font-semibold">AI Body Scan</h1>
+        <h1 className="text-xl font-semibold">Body Scan</h1>
         <p className="text-sm text-muted-foreground">
           Browse mode: sign in to upload your own scan. You can view sample results without
           uploading photos.
@@ -1371,7 +1371,7 @@ export default function ScanPage() {
 
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-4">
-      <h1 className="text-xl font-semibold">AI Body Scan</h1>
+      <h1 className="text-xl font-semibold">Body Scan</h1>
       <p className="text-sm text-muted-foreground">
         Upload four photos and your current/goal weight. We&apos;ll analyze your
         body composition and build a personalized workout and nutrition plan.

--- a/src/pages/Scan/Capture.tsx
+++ b/src/pages/Scan/Capture.tsx
@@ -51,7 +51,7 @@ export default function ScanCapture() {
   const scanPrereqMessage = scanOffline
     ? systemHealth?.openaiConfigured === false ||
       systemHealth?.openaiKeyPresent === false
-      ? "Scans require the OpenAI key (OPENAI_API_KEY) to be configured before uploads are enabled."
+      ? "Photo analysis is temporarily unavailable. Please try again shortly."
       : "Backend unavailable (Cloud Functions). Check deployment / network."
     : null;
 

--- a/src/pages/Scan/Result.tsx
+++ b/src/pages/Scan/Result.tsx
@@ -259,7 +259,7 @@ export default function ScanFlowResult() {
   const scanOfflineMessage = scanOffline
     ? systemHealth?.openaiConfigured === false ||
       systemHealth?.openaiKeyPresent === false
-      ? "Scans require the OpenAI key (OPENAI_API_KEY) to be configured before results can be finalized."
+      ? "Photo analysis is temporarily unavailable. Please try again shortly."
       : "Backend unavailable (Cloud Functions). Check deployment / network."
     : null;
 
@@ -1520,7 +1520,7 @@ export default function ScanFlowResult() {
                     ? "Processing…"
                     : flowStatus === "starting"
                       ? "Preparing…"
-                      : "Finalize with AI"}
+                      : "Analyze photos"}
             </Button>
             <Button
               type="button"

--- a/src/pages/Scan/Start.tsx
+++ b/src/pages/Scan/Start.tsx
@@ -75,7 +75,7 @@ export default function ScanStart() {
   const scanPrereqMessage = scanOffline
     ? systemHealth?.openaiConfigured === false ||
       systemHealth?.openaiKeyPresent === false
-      ? "Scans require the OpenAI key (OPENAI_API_KEY) to be set on Cloud Functions."
+      ? "Photo analysis is temporarily unavailable. Please try again shortly."
       : "Backend unavailable (Cloud Functions). Check deployment / network."
     : null;
 

--- a/src/pages/ScanTips.tsx
+++ b/src/pages/ScanTips.tsx
@@ -1,7 +1,7 @@
 /**
  * Pipeline map — Scan prep guidance:
  * - Offers static photo-taking tips so users pass the capture gate before uploads.
- * - Reinforces the need for the 4 poses that `ScanCapture` enforces, improving downstream OpenAI analysis quality.
+ * - Reinforces the need for the 4 poses that `ScanCapture` enforces, improving downstream analysis quality.
  */
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ListChecks, SunMedium, Scan, Users } from "lucide-react";

--- a/src/pages/TransformationPreview.tsx
+++ b/src/pages/TransformationPreview.tsx
@@ -249,8 +249,8 @@ export default function TransformationPreviewPage() {
                   className="w-full rounded-xl border border-zinc-700 object-cover"
                 />
                 <p className="rounded-lg border border-amber-400/20 bg-amber-400/10 p-3 text-xs text-amber-100">
-                  This AI-created image is illustrative—not a forecast or
-                  guarantee. Real outcomes and appearance vary.
+                  This computer-generated image is illustrative—not a forecast
+                  or guarantee. Real outcomes and appearance vary.
                 </p>
               </div>
             ) : (
@@ -343,9 +343,10 @@ export default function TransformationPreviewPage() {
                           className="text-xs font-normal leading-relaxed text-zinc-300"
                         >
                           I consent to MyBodyScan sending my front scan photo
-                          and selected goal to OpenAI to create this one-time
-                          image. I understand it is AI-generated, can be
-                          inaccurate, and is not a prediction.
+                          and selected goal to its contracted image-processing
+                          provider to create this one-time image. I understand
+                          it is computer-generated, can be inaccurate, and is
+                          not a prediction.
                         </Label>
                       </div>
                       <Button

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -159,7 +159,7 @@ export default function Workouts() {
     ? null
     : "Backend unavailable (Cloud Functions). Check deployment / network.";
   const adjustUnavailableMessage = !workoutAdjustConfigured
-    ? "AI workout adjustments require the OpenAI key (OPENAI_API_KEY) on Cloud Functions."
+    ? "Personalized workout adjustments are temporarily unavailable."
     : null;
   const adjustDisabled = !workoutAdjustConfigured || !workoutsConfigured;
 
@@ -757,7 +757,7 @@ export default function Workouts() {
       const description =
         adjustUnavailableMessage ??
         workoutsOfflineMessage ??
-        "AI workout adjustments are offline. Configure OPENAI_API_KEY to re-enable.";
+        "Personalized workout adjustments are temporarily unavailable.";
       toast({
         title: "Adjustments unavailable",
         description,

--- a/tests/user-facing-copy.test.ts
+++ b/tests/user-facing-copy.test.ts
@@ -1,0 +1,37 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "..");
+const read = (file: string) => fs.readFileSync(path.join(root, file), "utf8");
+
+const userFacingCopyFiles = [
+  "functions/src/coachChat.ts",
+  "functions/src/lib/openaiConfig.ts",
+  "functions/src/scan/engineConfig.ts",
+  "public/legal/privacy.html",
+  "src/content/legal/privacy.md",
+  "src/content/legal/terms.md",
+  "src/lib/envStatus.ts",
+  "src/lib/scanResultViewModel.ts",
+  "src/pages/Billing.tsx",
+  "src/pages/Coach/Chat.tsx",
+  "src/pages/LiveFlowsQA.tsx",
+  "src/pages/Paywall.tsx",
+  "src/pages/Plans.tsx",
+  "src/pages/Results.tsx",
+  "src/pages/Scan.tsx",
+  "src/pages/Scan/Capture.tsx",
+  "src/pages/Scan/Result.tsx",
+  "src/pages/Scan/Start.tsx",
+  "src/pages/TransformationPreview.tsx",
+  "src/pages/Workouts.tsx",
+];
+
+describe("user-facing product language", () => {
+  it("uses product-focused wording instead of AI branding", () => {
+    for (const file of userFacingCopyFiles) {
+      expect(read(file), file).not.toMatch(/\bAI\b|\bOpenAI\b/);
+    }
+  });
+});


### PR DESCRIPTION
## What changed

- renames the scanner heading to **Body Scan**
- labels completed results as **Photo analysis**
- replaces AI-branded Coach, workout, subscription, diagnostics, preview, and error copy with product-focused language
- describes generated previews as computer-generated and processing as automated analysis
- keeps internal provider configuration and stored result identifiers unchanged for production compatibility
- adds a regression test preventing AI/OpenAI branding from returning to user-facing copy

## Why

MyBodyScan should describe the user benefit and workflow rather than market the underlying provider technology. The new language is clearer while preserving estimate, automation, provider, and transformation-preview disclosures.

## Validation

- `npm run lint` — 0 errors (historical warnings only)
- `npm run typecheck`
- `npm test` — 335 tests passed before adding the copy guard
- `npm --prefix functions test` — 87 tests passed
- targeted copy/legal/view-model tests — 19 passed
- `npm run build:prod` — bundle and Storage REST safeguards passed
- local render checks for Scan, Plans, and Privacy
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Experience**
  * Updated product language to use “photo analysis,” “automated processing,” and “Personal Coach” terminology.
  * Simplified scan, coaching, workout, and transformation-preview messaging.
  * Replaced provider-specific setup instructions with clearer availability notices.
  * Updated privacy policy and terms to clarify automated analysis and service-provider use.
* **Bug Fixes**
  * Improved fallback coaching guidance when personalized coaching is temporarily unavailable.
* **Tests**
  * Added coverage to help ensure user-facing copy avoids provider-specific terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->