### PR TITLE
Make Stripe readiness checks truthful

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,12 @@ The `functions/package.json` scripts keep the runtime on Node 22 and fail fast i
   bound secret is present, handlers return
   `501 { error: "payments_disabled", code: "no_secret" }` and log
   `{ "svc":"checkout", ... , "ok":false }`.
-- Webhook verification uses the bound `STRIPE_WEBHOOK_SECRET`; legacy environment aliases are read only for backwards compatibility.
+- Webhook verification uses the bound `STRIPE_WEBHOOK_SECRET`; legacy
+  environment aliases are read only for backwards compatibility. `/systemHealth`
+  reports `stripeApiKeyPresent`, `stripeWebhookSecretPresent`, and
+  `stripeConfigured` separately so an unrelated Stripe secret cannot produce a
+  false-ready result. A missing webhook secret returns HTTP 501; an unsigned or
+  invalidly signed webhook request returns HTTP 400 and is never processed.
 - Allowlisted price IDs load from committed fail-closed defaults with optional
   environment overrides. The retired `functions.config()` service is not used.
   Canonical launch IDs and explicitly named legacy IDs are the only accepted

--- a/functions/src/stripeWebhook.ts
+++ b/functions/src/stripeWebhook.ts
@@ -15,6 +15,19 @@ import { projectBillingEntitlement } from "./lib/entitlementProjection.js";
 
 const db = getFirestore();
 
+export function getStripeWebhookRequestError(
+  signature: string | undefined,
+  secret: string
+): { status: 400 | 501; message: string } | null {
+  if (!secret) {
+    return { status: 501, message: "unconfigured" };
+  }
+  if (!signature) {
+    return { status: 400, message: "Missing Stripe signature" };
+  }
+  return null;
+}
+
 async function writeStripeProEntitlement(params: {
   uid: string;
   pro: boolean;
@@ -217,7 +230,10 @@ export const stripeWebhook = onRequest(
   async (req, res) => {
     const sig = req.get("stripe-signature");
     const secret = process.env.STRIPE_WEBHOOK_SECRET || "";
-    if (!sig || !secret) return res.status(501).send("unconfigured");
+    const requestError = getStripeWebhookRequestError(sig, secret);
+    if (requestError) {
+      return res.status(requestError.status).send(requestError.message);
+    }
 
     const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
     if (!rawBody) {

--- a/functions/src/systemHealth.ts
+++ b/functions/src/systemHealth.ts
@@ -37,6 +37,21 @@ function envPresent(value: string | undefined): boolean {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+export function resolveStripeHealthStatus(
+  stripeApiKeyPresent: boolean,
+  stripeWebhookSecretPresent: boolean
+) {
+  return {
+    // Backward-compatible field consumed by the client. It represents the API
+    // key needed for checkout and portal sessions, not an unrelated webhook
+    // signing secret.
+    stripeSecretPresent: stripeApiKeyPresent,
+    stripeApiKeyPresent,
+    stripeWebhookSecretPresent,
+    stripeConfigured: stripeApiKeyPresent && stripeWebhookSecretPresent,
+  };
+}
+
 export const systemHealth = onRequest(
   {
     region: "us-central1",
@@ -55,17 +70,24 @@ export const systemHealth = onRequest(
     const openaiConfigured = hasOpenAI();
     const scanEngine = getScanEngineStatus();
 
-    const stripeSecretPresent =
+    const stripeApiKeyPresent =
       !!process.env.STRIPE_SECRET ||
       secretPresent(stripeSecretParam) ||
       secretPresent(stripeSecretKeyParam) ||
-      secretPresent(stripeWebhookSecretParam) ||
       envPresent(process.env.STRIPE_SECRET) ||
       envPresent(process.env.STRIPE_SECRET_KEY) ||
+      envPresent(process.env.STRIPE_API_KEY) ||
+      envPresent(process.env.STRIPE_KEY);
+    const stripeWebhookSecretPresent =
+      secretPresent(stripeWebhookSecretParam) ||
       envPresent(process.env.STRIPE_WEBHOOK_SECRET) ||
       envPresent(process.env.STRIPE_WEBHOOK) ||
       envPresent(process.env.STRIPE_SIGNING_SECRET) ||
       envPresent(process.env.STRIPE_SIGNATURE);
+    const stripeHealth = resolveStripeHealthStatus(
+      stripeApiKeyPresent,
+      stripeWebhookSecretPresent
+    );
 
     const usdaKeyPresent =
       envPresent(process.env.USDA_FDC_API_KEY) ||
@@ -84,7 +106,7 @@ export const systemHealth = onRequest(
 
     const identityToolkitReachable = true;
     const identityToolkitReason =
-      openaiConfigured || stripeSecretPresent ? "ok" : "unknown";
+      openaiConfigured || stripeHealth.stripeSecretPresent ? "ok" : "unknown";
 
     const authProviders = {
       google: getEnvBool("AUTH_GOOGLE_ENABLED", true),
@@ -98,7 +120,7 @@ export const systemHealth = onRequest(
       timestamp: new Date().toISOString(),
       appCheckMode: getAppCheckMode(),
       authProviders,
-      stripeSecretPresent,
+      ...stripeHealth,
       openaiKeyPresent: openaiConfigured,
       nutritionConfigured,
       openaiConfigured,

--- a/functions/test/stripeWebhookGuard.test.js
+++ b/functions/test/stripeWebhookGuard.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getStripeWebhookRequestError } from "../lib/stripeWebhook.js";
+
+test("Stripe webhook reports missing server configuration separately", () => {
+  assert.deepEqual(getStripeWebhookRequestError(undefined, ""), {
+    status: 501,
+    message: "unconfigured",
+  });
+});
+
+test("Stripe webhook rejects a request without a signature", () => {
+  assert.deepEqual(
+    getStripeWebhookRequestError(undefined, "whsec_configured"),
+    {
+      status: 400,
+      message: "Missing Stripe signature",
+    }
+  );
+});
+
+test("Stripe webhook accepts a signed request for verification", () => {
+  assert.equal(
+    getStripeWebhookRequestError(
+      "t=123,v1=invalid-but-present",
+      "whsec_configured"
+    ),
+    null
+  );
+});

--- a/functions/test/systemHealthStripeStatus.test.js
+++ b/functions/test/systemHealthStripeStatus.test.js
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { resolveStripeHealthStatus } from "../lib/systemHealth.js";
+
+test("Stripe health requires both API and webhook secrets for full readiness", () => {
+  assert.deepEqual(resolveStripeHealthStatus(true, true), {
+    stripeSecretPresent: true,
+    stripeApiKeyPresent: true,
+    stripeWebhookSecretPresent: true,
+    stripeConfigured: true,
+  });
+});
+
+test("Stripe health does not confuse a webhook secret with an API key", () => {
+  assert.deepEqual(resolveStripeHealthStatus(false, true), {
+    stripeSecretPresent: false,
+    stripeApiKeyPresent: false,
+    stripeWebhookSecretPresent: true,
+    stripeConfigured: false,
+  });
+});
+
+test("Stripe health reports a missing webhook secret without disabling checkout", () => {
+  assert.deepEqual(resolveStripeHealthStatus(true, false), {
+    stripeSecretPresent: true,
+    stripeApiKeyPresent: true,
+    stripeWebhookSecretPresent: false,
+    stripeConfigured: false,
+  });
+});

--- a/src/hooks/useSystemHealth.ts
+++ b/src/hooks/useSystemHealth.ts
@@ -13,6 +13,9 @@ export interface SystemHealthSnapshot {
   openaiKeyPresent?: boolean;
   openaiConfigured?: boolean;
   stripeSecretPresent?: boolean;
+  stripeApiKeyPresent?: boolean;
+  stripeWebhookSecretPresent?: boolean;
+  stripeConfigured?: boolean;
   usdaKeyPresent?: boolean;
   nutritionConfigured?: boolean;
   coachRpmPresent?: boolean;

--- a/src/lib/envStatus.ts
+++ b/src/lib/envStatus.ts
@@ -55,6 +55,9 @@ export type RemoteHealth = {
   usdaKeyPresent?: boolean;
   coachRpmPresent?: boolean;
   stripeSecretPresent?: boolean;
+  stripeApiKeyPresent?: boolean;
+  stripeWebhookSecretPresent?: boolean;
+  stripeConfigured?: boolean;
   workoutsConfigured?: boolean;
   workoutAdjustConfigured?: boolean;
   scanServicesHealthy?: boolean;


### PR DESCRIPTION
## Summary
- distinguish a missing Stripe webhook secret from an unsigned webhook request
- report Stripe API-key, webhook-secret, and complete readiness states independently
- preserve the existing client compatibility field without false-ready results
- document the health contract and fail-closed behavior

## Verification
- `npm run lint` (0 errors; historical warnings only)
- `npm run typecheck`
- `npm test` (340 passed)
- `npm --prefix functions test` (94 passed)
- `npm run build:prod`
- `npm run rules:check`
- production anonymous smoke and protected-route probes

The production probe exposed the ambiguous HTTP 501 behavior; this PR makes the health and webhook responses independently verifiable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - System health reporting now separately shows Stripe API key status, webhook secret status, and overall configuration readiness.
  - Stripe is marked fully configured only when both required credentials are available.
- **Bug Fixes**
  - Webhooks without server configuration return HTTP 501.
  - Webhooks missing or using invalid signatures return HTTP 400 and are not processed.
  - Stripe secrets are no longer incorrectly treated as interchangeable.
- **Documentation**
  - Expanded troubleshooting guidance explains Stripe readiness checks and webhook response behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->