### PR TITLE
Handle Hosting rollback channel capacity

### DIFF
--- a/.github/workflows/deploy-functions-on-main.yml
+++ b/.github/workflows/deploy-functions-on-main.yml
@@ -99,7 +99,14 @@ jobs:
 
       - name: Deploy production in dependency order
         run: |
-          npx firebase hosting:clone mybodyscan-f3daf:live "mybodyscan-f3daf:rollback-${GITHUB_SHA:0:7}" --project mybodyscan-f3daf
+          rollback_channel="rollback-${GITHUB_SHA:0:7}"
+          fallback_rollback_channel="rollback-c1c1d6b"
+          if ! npx firebase hosting:clone mybodyscan-f3daf:live "mybodyscan-f3daf:${rollback_channel}" --project mybodyscan-f3daf; then
+            echo "::warning::Firebase Hosting preview-channel capacity prevented a commit-specific rollback snapshot; reusing the recorded rollback slot."
+            rollback_channel="${fallback_rollback_channel}"
+            npx firebase hosting:clone mybodyscan-f3daf:live "mybodyscan-f3daf:${rollback_channel}" --project mybodyscan-f3daf
+          fi
+          echo "Hosting rollback channel: ${rollback_channel}" >> "${GITHUB_STEP_SUMMARY}"
           npm run storage:cors:apply
           npx firebase deploy --only firestore:indexes --project mybodyscan-f3daf --non-interactive
           npx firebase deploy --only functions --project mybodyscan-f3daf --non-interactive

--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -508,6 +508,14 @@ Stripe webhook request returns HTTP 400 instead of being misreported as an
 unconfigured server. The pre-deployment Hosting rollback channel preserved by
 this deployment is `rollback-c1c1d6b`.
 
+Firebase Hosting limits the number of active preview channels. The guarded
+workflow first tries a commit-specific `rollback-SHORT_SHA` channel. If channel
+capacity prevents that snapshot, it reuses `rollback-c1c1d6b`, clones the
+current live release into that slot before any deployment, and records the
+actual channel in the GitHub Actions job summary. This fallback is
+non-destructive to the live channel and avoids deleting recovery points by
+guess.
+
 Five ordered 1242 × 2688 iPhone screenshots and five ordered 2064 × 2752 iPad
 screenshots are uploaded: body results, training, nutrition progress, meal
 planning, and four-photo scanning. The nutrition screenshots were regenerated
@@ -748,6 +756,10 @@ npx firebase-tools deploy --only functions --project mybodyscan-f3daf --non-inte
 npx firebase-tools deploy --only firestore:rules,storage --project mybodyscan-f3daf --non-interactive
 npx firebase-tools deploy --only hosting --project mybodyscan-f3daf --non-interactive
 ```
+
+For the automated workflow, use the rollback channel printed in the deployment
+job summary. At preview-channel capacity, the current reusable slot is
+`rollback-c1c1d6b`; do not delete channels manually just to make room.
 
 Indexes are submitted first because they may build asynchronously. Backend code
 is deployed before the web bundle. Rules and Storage policy are updated before

--- a/tests/deploy-workflow.test.ts
+++ b/tests/deploy-workflow.test.ts
@@ -76,6 +76,20 @@ describe("production deployment authentication", () => {
     expect(deployIndex).toBeGreaterThan(authIndex);
   });
 
+  it("preserves a rollback release even when preview-channel capacity is full", () => {
+    expect(WORKFLOW).toContain('rollback_channel="rollback-${GITHUB_SHA:0:7}"');
+    expect(WORKFLOW).toContain('fallback_rollback_channel="rollback-c1c1d6b"');
+    expect(WORKFLOW).toContain(
+      "if ! npx firebase hosting:clone mybodyscan-f3daf:live"
+    );
+    expect(WORKFLOW).toContain(
+      'rollback_channel="${fallback_rollback_channel}"'
+    );
+    expect(WORKFLOW).toContain(
+      'echo "Hosting rollback channel: ${rollback_channel}" >> "${GITHUB_STEP_SUMMARY}"'
+    );
+  });
+
   it("commits only safe non-secret Functions parameters for CI", () => {
     const keys = FUNCTIONS_ENV.split(/\r?\n/)
       .map((line) => line.trim())
@@ -208,7 +222,9 @@ describe("production deployment authentication", () => {
     expect(WORKFLOW).toContain(
       "VITE_FIREBASE_VAPID_KEY: ${{ secrets.VITE_FIREBASE_VAPID_KEY }}"
     );
-    expect(WORKFLOW).not.toMatch(/VITE_FIREBASE_VAPID_KEY:\s+[A-Za-z0-9_-]{40}/);
+    expect(WORKFLOW).not.toMatch(
+      /VITE_FIREBASE_VAPID_KEY:\s+[A-Za-z0-9_-]{40}/
+    );
   });
 
   it("deletes the temporary production probe account after scan cleanup", () => {


### PR DESCRIPTION
## Root cause
Firebase Hosting reached its active preview-channel capacity, so the guarded `main` deployment stopped while trying to create `rollback-814da0f`. Production was not modified.

## Fix
- continue preferring a commit-specific rollback snapshot
- if capacity blocks creation, clone current live Hosting into the already-recorded `rollback-c1c1d6b` slot before deployment
- record the actual rollback channel in the Actions job summary
- document the fallback and test the workflow contract

No channels are deleted and live Hosting is not changed by the fallback snapshot itself.

## Verification
- `npx vitest run tests/deploy-workflow.test.ts` — 17 passed
- Prettier checks — passed
- `git diff --check` — passed