### PR TITLE
Pin vetted React Router release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.61.1",
         "react-resizable-panels": "^2.1.9",
-        "react-router-dom": "^6.30.1",
+        "react-router-dom": "6.30.4",
         "recharts": "^2.15.4",
         "sonner": "^1.7.4",
         "stripe": "^16.12.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.61.1",
     "react-resizable-panels": "^2.1.9",
-    "react-router-dom": "^6.30.1",
+    "react-router-dom": "6.30.4",
     "recharts": "^2.15.4",
     "sonner": "^1.7.4",
     "stripe": "^16.12.0",

--- a/src/lib/returnTo.test.ts
+++ b/src/lib/returnTo.test.ts
@@ -12,6 +12,7 @@ describe("sanitizeReturnTo", () => {
     "https://example.com",
     "//example.com/path",
     "/\\example.com/path",
+    "/%2F%2Fexample.com/path",
     "/%5Cexample.com/path",
     "\\\\example.com/path",
     "javascript:alert(1)",


### PR DESCRIPTION
## What changed
- pin `react-router-dom` to the audited 6.30.4 release so a future install cannot silently drift across the 6.x range
- add a regression case proving encoded protocol-relative redirects are rejected

## Why
The currently available forced npm audit upgrade is a breaking React Router 7 migration and its current release line also carries a high-severity advisory. MyBodyScan is a client-only Vite SPA, so the SSR hydration advisory does not apply, and all user-controlled return paths already pass through the centralized sanitizer. Pinning the reviewed release preserves that known behavior and the regression test locks in the redirect defense.

## Validation
- clean `npm ci --ignore-scripts --no-audit --no-fund`
- `npm audit --omit=dev --audit-level=high` (exit 0; two moderate advisories, mitigated/not applicable as described above)
- lint: 0 errors (1,415 historical warnings)
- type-check: pass
- web tests: 342/342
- Functions tests: 94/94
- production build: pass
- bundle safeguard: pass
- Storage REST safeguard: pass
- Firestore rules consistency: pass