### PR TITLE
Document Build 15 release state

### DIFF
--- a/docs/AppStoreReleaseChecklist.md
+++ b/docs/AppStoreReleaseChecklist.md
@@ -43,8 +43,9 @@ runbook before shipping.
   at the exact iPhone and iPad dimensions described in the runbook.
 - Select only the freshly uploaded candidate build. Superseded TestFlight
   builds are not release evidence.
-- Current candidate: version 1.0.0 build 14 from main merge `b8a0863`. It is
-  the sole build in `Internal QA` and is saved for App Store version 1.0.
+- Current candidate: version 1.0.0 build 15 from main merge `9e1d4cf`. Its
+  upload succeeded on 2026-07-31 and Apple processing must finish before an
+  operator adds only build 15 to `Internal QA` and selects it for version 1.0.
 - Complete truthful App Review contact details and a dedicated reviewer
   account. An Account Holder/Admin must publish App Privacy, declare Content
   Rights, and complete Digital Services Act/trader status; do not guess those

--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -477,18 +477,21 @@ change app credentials; an Owner/Admin must upload the least-privileged Google
 service-account JSON and complete RTDN after the correct Play account and app
 exist.
 
-Current iOS external state on 2026-07-28: the App Store app record exists;
+Current iOS external state on 2026-07-31: the App Store app record exists;
 Xcode is signed into the ADLR Labs team; the physical iPhone is paired with
 Developer Mode; and the internal tester invitation has been accepted. Version
-1.0.0 build 14 was archived from main merge `b8a0863`, uploaded successfully,
-finished processing, and is **Testing** in the manually managed `Internal QA`
-group. Build 14 is the group's sole build and is saved as the build for App
-Store version 1.0. Builds 2 through 13 are superseded and must not be submitted.
+1.0.0 build 15 was archived from main merge `9e1d4cf`, validated, exported, and
+uploaded successfully on 2026-07-31. Apple reported the package as processing;
+do not treat it as available to testers until App Store Connect reports that
+processing has completed and it has been manually added to `Internal QA`.
+Builds 2 through 14 are superseded and must not be submitted.
 
-Build 14 includes the native request-routing and CORS fixes, four-photo upload
+Build 15 includes the native request-routing and CORS fixes, four-photo upload
 normalization, safe-area layout, user-facing Coach/nutrition error handling,
 the final customer terminology cleanup, and the reviewed Food Diary typography
-and responsive layout. It must still be installed fresh from TestFlight and
+and responsive layout. It also corrects goal-preview orientation, strengthens
+the realistic goal-direction prompt, and removes nutrition-search horizontal
+overflow. It must still be installed fresh from TestFlight and
 pass physical-device acceptance before submission. An archive, successful
 upload, simulator launch, or older TestFlight install is not acceptance
 evidence. The real-photo, purchase, restore, notification, authentication,
@@ -496,7 +499,7 @@ cold-launch, offline, nutrition, Coach-adjustment, and account-deletion
 checklist remains mandatory.
 
 The matching production web and backend are deployed from main merge
-`c1c1d6b`. Guarded deployment run `30411264094` completed successfully after
+`9e1d4cf`. Guarded deployment run `30656127887` completed successfully after
 the web and Functions builds, rules emulator checks, scan/credit/refund/account
 deletion pipeline, and dependency audits passed. Post-deploy verification
 confirmed the public and direct regional health endpoints, production CORS,

--- a/ios/RELEASE_IOS.md
+++ b/ios/RELEASE_IOS.md
@@ -107,25 +107,19 @@ enabled on the device.
 5. Distribute first through internal TestFlight. Do not submit for review
    until the device and purchase checklist below passes.
 
-Current release snapshot (2026-07-28):
+Current release snapshot (2026-07-31):
 
-- Build 12 (`1.0.0`) is the current TestFlight/device acceptance candidate. It
-  contains the merged adaptive coaching, allergy-aware nutrition, custom-food
-  and recipe, workout-session, billing, legal, production release, and
-  customer-facing terminology changes. The archive contains build tag
-  `a2e0cf2`.
-- Xcode archive validation, distribution export, upload, and Apple processing
-  completed successfully. App Store Connect reports build 12 as **Ready to
-  Submit**.
-- Build 12 is the sole build in the `Internal QA` TestFlight group. Distribution
-  is manual so later unverified uploads cannot reach testers automatically.
-  The build-level `What to Test` checklist and the app-level beta description,
-  feedback email, marketing URL, and privacy URL are saved.
-- Build 12 is selected and saved for App Store version 1.0. It has not been
-  installed on the paired iPhone or submitted for review. App Store Connect
-  currently has no eligible internal testers, so no invitation has been sent.
-- Builds 2 through 11 are superseded and build 11 is no longer selected for App
-  Store version 1.0; do not submit any of them.
+- Build 15 (`1.0.0`) from main merge `9e1d4cf` is the current device-acceptance
+  candidate. It includes the goal-preview orientation/visibility and mobile
+  nutrition-search fixes in addition to the previously merged release work.
+- Archive validation, distribution export, and upload completed successfully
+  on 2026-07-31. Apple reported that the uploaded package is processing.
+- Distribution is manual so an upload cannot reach testers automatically. Once
+  processing completes, add only build 15 to `Internal QA`, retain the saved
+  beta metadata, and select build 15 for App Store version 1.0.
+- Build 15 has not yet passed the clean-install physical-device checklist and
+  has not been submitted for review. Builds 2 through 14 are superseded; do not
+  submit any of them.
 - The monthly, yearly, and single-scan App Store products exist at the approved
   prices. RevenueCat's `pro` entitlement and current/default offering are
   wired to the exact products described above.


### PR DESCRIPTION
## Summary
- record the successful production deployment from merge `9e1d4cf`
- record Build 15 archive validation and successful App Store Connect upload
- explicitly retain Apple processing, Internal QA assignment, and clean-device acceptance as pending gates
- mark builds 2–14 superseded

Documentation-only follow-up to #786. No App Store review submission or public release is performed.