### PR TITLE
Streamline nutrition search and scan handoff

### DIFF
--- a/functions/src/nutritionSearch.ts
+++ b/functions/src/nutritionSearch.ts
@@ -994,7 +994,7 @@ async function runNutritionSearchCore(
   if (!items.length || input.sourcePreference !== "usda-first") {
     if (offResult.items.length) {
       if (input.sourcePreference === "combined" && items.length) {
-        items = [...items, ...offResult.items].slice(0, 40);
+        items = [...items, ...offResult.items];
         source = "USDA";
       } else {
         items = offResult.items;
@@ -1024,7 +1024,10 @@ async function runNutritionSearchCore(
       seen.add(key);
       return true;
     })
-    .slice(0, 40)
+    // A food logger needs a short, useful choice set—not an upstream database
+    // dump. Ranking happens first, so this keeps the strongest authoritative,
+    // branded, and serving-complete matches while reducing decision fatigue.
+    .slice(0, 16)
     .map(({ raw: _raw, ...item }) => item);
   return {
     status: "ok",

--- a/src/features/meals/NutritionSearch.tsx
+++ b/src/features/meals/NutritionSearch.tsx
@@ -37,6 +37,8 @@ type NutritionSearchProps = {
   onMealAdded?: (payload: { meal: MealEntry; totals: any }) => void;
 };
 
+const INITIAL_RESULT_COUNT = 8;
+
 export default function NutritionSearch({
   onMealLogged,
   defaultMealType,
@@ -56,6 +58,9 @@ export default function NutritionSearch({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [results, setResults] = useState<FoodItem[] | null>(null);
+  const [visibleResultCount, setVisibleResultCount] = useState(
+    INITIAL_RESULT_COUNT
+  );
   const [hasSearched, setHasSearched] = useState(false);
   const [scanOpen, setScanOpen] = useState(false);
   const [scannerCapability, setScannerCapability] = useState<{
@@ -74,6 +79,7 @@ export default function NutritionSearch({
     e?.preventDefault();
     setError(null);
     setResults(null);
+    setVisibleResultCount(INITIAL_RESULT_COUNT);
     if (!q.trim()) {
       setHasSearched(false);
       return;
@@ -316,7 +322,7 @@ export default function NutritionSearch({
           className="min-w-0 divide-y overflow-hidden rounded-xl border bg-background"
           data-testid="nutrition-results"
         >
-          {results.map((it) => (
+          {results.slice(0, visibleResultCount).map((it) => (
             <li
               key={it.id ?? it.name}
               className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-3.5 sm:px-4"
@@ -362,6 +368,21 @@ export default function NutritionSearch({
               </button>
             </li>
           ))}
+          {results.length > visibleResultCount ? (
+            <li className="p-3">
+              <button
+                type="button"
+                className="min-h-11 w-full rounded-lg border bg-background px-4 text-sm font-semibold transition-colors hover:bg-secondary"
+                onClick={() =>
+                  setVisibleResultCount((count) =>
+                    Math.min(results.length, count + INITIAL_RESULT_COUNT)
+                  )
+                }
+              >
+                Show {Math.min(INITIAL_RESULT_COUNT, results.length - visibleResultCount)} more
+              </button>
+            </li>
+          ) : null}
         </ul>
       )}
 

--- a/src/pages/MealsSearch.tsx
+++ b/src/pages/MealsSearch.tsx
@@ -47,6 +47,7 @@ import { reportError } from "@/lib/telemetry";
 
 const RECENTS_KEY = "mbs_nutrition_recents_v3";
 const MAX_RECENTS = 50;
+const INITIAL_RESULT_COUNT = 8;
 
 function currentLocalDate(): string {
   const now = new Date();
@@ -352,6 +353,9 @@ export default function MealsSearch() {
   const [query, setQuery] = useState("");
   const [loading, setLoading] = useState(false);
   const [results, setResults] = useState<FoodItem[]>([]);
+  const [visibleResultCount, setVisibleResultCount] = useState(
+    INITIAL_RESULT_COUNT
+  );
   const [primarySource, setPrimarySource] = useState<
     "USDA" | "Open Food Facts" | null
   >(null);
@@ -410,6 +414,7 @@ export default function MealsSearch() {
     }
 
     const term = sanitizeNutritionQuery(debouncedQuery);
+    setVisibleResultCount(INITIAL_RESULT_COUNT);
     if (!term) {
       setResults([]);
       setPrimarySource(null);
@@ -834,7 +839,7 @@ export default function MealsSearch() {
             {!loading && searchWarning && (
               <p className="text-sm text-muted-foreground">{searchWarning}</p>
             )}
-            {results.map((item) => {
+            {results.slice(0, visibleResultCount).map((item) => {
               const favorite = favoritesMap.get(item.id);
               const subtitle = item.brand || item.source;
               const base = item.basePer100g;
@@ -881,6 +886,20 @@ export default function MealsSearch() {
                 </Card>
               );
             })}
+            {results.length > visibleResultCount ? (
+              <Button
+                type="button"
+                variant="outline"
+                className="w-full"
+                onClick={() =>
+                  setVisibleResultCount((count) =>
+                    Math.min(results.length, count + INITIAL_RESULT_COUNT)
+                  )
+                }
+              >
+                Show {Math.min(INITIAL_RESULT_COUNT, results.length - visibleResultCount)} more
+              </Button>
+            ) : null}
           </CardContent>
         </Card>
       </main>

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -918,6 +918,10 @@ export default function Onboarding() {
           <p className="mt-1 text-sm text-muted-foreground">
             Step {step + 1} of {STEP_TITLES.length}: {STEP_TITLES[step]}
           </p>
+          <p className="mx-auto mt-2 max-w-sm text-sm leading-5 text-muted-foreground">
+            About two minutes. More detail helps tailor your training and meals;
+            optional questions can be left blank and updated later.
+          </p>
         </div>
 
         {loadError && (

--- a/src/pages/Scan.tsx
+++ b/src/pages/Scan.tsx
@@ -27,7 +27,7 @@ import { apiFetch } from "@/lib/http";
 import { db, getFirebaseApp, getFirebaseConfig } from "@/lib/firebase";
 import { getIdToken } from "@/auth/mbs-auth";
 import { useClaims } from "@/lib/claims";
-import { doc, getDoc, onSnapshot, serverTimestamp, setDoc } from "firebase/firestore";
+import { doc, getDoc, serverTimestamp, setDoc } from "firebase/firestore";
 import { useAppCheckStatus } from "@/hooks/useAppCheckStatus";
 import { getScanPhotoPath } from "@/lib/uploads/storagePaths";
 import {
@@ -773,77 +773,11 @@ export default function ScanPage() {
       setActiveScanId(null);
       setScanSession(null);
 
-      const scanDocRef = doc(db, "users", user.uid, "scans", startedScanId);
-      let settled = false;
-      const finalizeNavigation = () => {
-        if (settled) return;
-        settled = true;
-        cleanupWatchers();
-        nav(`/scans/${startedScanId}`);
-      };
-      const handleFailureStatus = (message: string) => {
-        if (settled) return;
-        const customerMessage =
-          "Scan is temporarily unavailable. Please try again in a few minutes or contact support.";
-        const visibleMessage = showDebug ? message : customerMessage;
-        setStatus("error");
-        setError(visibleMessage);
-        setStatusDetail(null);
-        updatePipeline(startedScanId, {
-          stage: "failed",
-          lastError: {
-            message: visibleMessage,
-            pose: undefined,
-            stage: "failed",
-            requestId: requestIdRef.current ?? undefined,
-            occurredAt: Date.now(),
-          },
-        });
-        settled = true;
-        cleanupWatchers();
-      };
-
-      let unsubscribe: (() => void) | null = null;
-      const fallbackTimer = window.setTimeout(async () => {
-        if (settled) return;
-        const snap = await getDoc(scanDocRef);
-        const data = snap.data() as any;
-        const statusValue = typeof data?.status === "string" ? data.status : null;
-        if (statusValue === "complete" || statusValue === "completed") {
-          finalizeNavigation();
-          return;
-        }
-        if (statusValue === "failed" || statusValue === "error") {
-          handleFailureStatus(data?.errorMessage || "Scan failed during processing.");
-          return;
-        }
-        finalizeNavigation();
-      }, 45_000);
-
-      const cleanupWatchers = () => {
-        if (unsubscribe) {
-          try {
-            unsubscribe();
-          } catch {
-            // ignore
-          }
-          unsubscribe = null;
-        }
-        window.clearTimeout(fallbackTimer);
-      };
-
-      unsubscribe = onSnapshot(scanDocRef, (snap) => {
-        if (!snap.exists()) return;
-        const data = snap.data() as any;
-        const statusValue = typeof data?.status === "string" ? data.status : null;
-        if (statusValue === "complete" || statusValue === "completed") {
-          finalizeNavigation();
-          return;
-        }
-        if (statusValue === "failed" || statusValue === "error") {
-          handleFailureStatus(data?.errorMessage || "Scan failed during processing.");
-        }
-      });
+      // Submission is already accepted and durable at this point. Move straight
+      // to the scan detail screen, which owns the live processing subscription.
+      // Waiting here duplicated that listener and made a healthy scan appear
+      // frozen for up to 45 seconds on mobile.
+      nav(`/scans/${startedScanId}`);
     } catch (err) {
       console.error("scan.submit.unexpected", err);
       const pose = (err as any)?.pose as string | undefined;

--- a/tests/nutrition-search-layout.test.ts
+++ b/tests/nutrition-search-layout.test.ts
@@ -25,4 +25,10 @@ describe("nutrition search mobile layout", () => {
     expect(mealsSource).toContain("max-w-[calc(100vw-1rem)]");
     expect(mealsSource).toContain("overflow-x-hidden");
   });
+
+  it("reveals ranked results in a short, progressive list", () => {
+    expect(searchSource).toContain("const INITIAL_RESULT_COUNT = 8");
+    expect(searchSource).toContain("slice(0, visibleResultCount)");
+    expect(searchSource).toContain("Show {");
+  });
 });

--- a/tests/scan-submission-navigation.test.ts
+++ b/tests/scan-submission-navigation.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const scanSource = readFileSync("src/pages/Scan.tsx", "utf8");
+
+describe("scan submission navigation", () => {
+  it("opens the live result tracker immediately after an accepted submission", () => {
+    const accepted = scanSource.indexOf('stage: "queued"');
+    const navigation = scanSource.indexOf('nav(`/scans/${startedScanId}`)', accepted);
+
+    expect(accepted).toBeGreaterThan(-1);
+    expect(navigation).toBeGreaterThan(accepted);
+    expect(scanSource).not.toContain("}, 45_000)");
+  });
+});


### PR DESCRIPTION
## What changed

- cap ranked nutrition responses at 16 useful matches
- show the best 8 results first with an explicit **Show more** control
- move accepted scans immediately to the live processing tracker instead of waiting up to 45 seconds on the upload screen
- clarify onboarding time, personalization value, and optional answers
- add regression coverage for progressive nutrition results and immediate scan handoff

## Why

Generic food searches were visually overwhelming, and a successful scan could look frozen even though processing had already started. These changes reduce decision fatigue and remove the duplicated client-side waiting period.

## Verification

- typecheck passed
- web tests: 344/344 passed
- Functions tests: 98/98 passed
- production web build passed
- bundle and Storage REST safeguards passed
- Firestore rule consistency passed
- production and iOS release configuration passed
- native iOS build and native-auth bundle verification passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nutrition searches now show eight results initially, with a “Show more” option to load additional results.
  * Search results refresh their visible count when starting a new search.
  * Onboarding now explains setup time, personalization benefits, and optional questions.
  * Scan submissions now take you directly to the scan tracking view once accepted.

* **Bug Fixes**
  * Improved nutrition search ranking by considering more combined results before selecting the final set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->