### PR TITLE
Add physique, voice logging, and WHOOP foundations

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -334,6 +334,12 @@ service cloud.firestore {
         allow write: if !isDemoUser() && hasActivePro(uid);
       }
 
+      // OAuth access and refresh tokens are server-only. Connection status is
+      // exposed through an authenticated API that strips token material.
+      match /serverHealth/{provider} {
+        allow read, write: if false;
+      }
+
       match /nutrition/{docId} {
         allow read: if hasActivePro(uid);
         allow write: if !isDemoUser() && hasActivePro(uid);
@@ -386,6 +392,11 @@ service cloud.firestore {
     match /stripeEvents/{eventId} {
       allow read: if isStaff();
       allow write: if false;
+    }
+
+    // Short-lived, one-time OAuth CSRF state. Never client-readable.
+    match /oauthStates/{stateHash} {
+      allow read, write: if false;
     }
 
     match /telemetryEvents/{eventId} {

--- a/docs/PHYSIQUE_VOICE_WHOOP_FOUNDATIONS.md
+++ b/docs/PHYSIQUE_VOICE_WHOOP_FOUNDATIONS.md
@@ -31,11 +31,11 @@ It matches the spoken exercise to today's existing workout exercises instead of 
 
 The logger is mounted in the existing workout session and saves through the same `saveExerciseLog` / `logWorkoutExercise` path as manual entries. Multi-set phrases are stored in the existing completed-reps field as `sets×reps`, preserving one workout log model.
 
-## WHOOP
+## WHOOP (deferred from the initial production release)
 
-WHOOP stays gated until all server-side OAuth configuration exists. The implementation uses the standard authorization-code flow with one-time expiring CSRF state, server-only access and refresh tokens, refresh handling, recovery sync, provider revocation, and account-deletion cleanup. The UI cannot display WHOOP as connected until a token exchange succeeds.
+The WHOOP foundation is retained for a later provider-approved release, but its routes, UI, Firebase secret bindings, and callback exception are not deployed in the initial production release. The implementation uses the standard authorization-code flow with one-time expiring CSRF state, server-only access and refresh tokens, refresh handling, recovery sync, provider revocation, and account-deletion cleanup.
 
-Required operator configuration before enabling:
+Required operator configuration before enabling in a future release:
 
 - `WHOOP_CLIENT_ID`
 - `WHOOP_CLIENT_SECRET`

--- a/docs/PHYSIQUE_VOICE_WHOOP_FOUNDATIONS.md
+++ b/docs/PHYSIQUE_VOICE_WHOOP_FOUNDATIONS.md
@@ -1,0 +1,56 @@
+# Physique, Voice Logging, and WHOOP Foundations
+
+This branch intentionally isolates the next fitness-product improvements from the current Android/Google Play release path.
+
+## Product principles
+
+- Keep the UI simple and consistent with the existing MyBodyScan design.
+- Extend existing scan, workout, and health systems rather than creating parallel data models.
+- Do not copy competitor terminology, score presentation, proprietary copy, or branded methodology.
+- Treat all photo-derived development scores as wellness/progress estimates, never medical or strength measurements.
+- Never display a provider as connected until authorization succeeds.
+
+## Physique development scores
+
+First-party regions: chest, back, shoulders, arms, core, legs.
+
+The shared client/server helpers accept explicit numeric 0–100 development scores only. They do not convert qualitative observations into numbers. Sparse scores may be shown by region, but an overall score requires at least four valid regions.
+
+The reusable UI presents relative development, strengths, and training priorities with a disclosure. The next integration step is to extend the existing four-photo scan analysis contract so it may return these optional scores using a stable conservative rubric, sanitize them server-side, persist them with the scan, render the component in the full Results report, and pass the weakest supported regions into workout-plan prioritization.
+
+## Voice workout logging
+
+The parser is deterministic and local. It handles common gym phrases without an additional model call, including:
+
+- `bench press 225 for 8`
+- `bench press 225 pounds for 8 reps`
+- `squat 3 sets of 5 at 315 pounds`
+- `deadlift 180 kg x 5`
+
+It matches the spoken exercise to today's existing workout exercises instead of creating duplicate movements. The reusable logger requires a confirmation tap before saving. Unsupported or ambiguous speech fails closed and remains editable as text.
+
+The next integration step is to mount the component in the existing workout-session card and call the existing `saveExerciseLog` / `logWorkoutExercise` path so voice and manual logs remain identical data.
+
+## WHOOP
+
+WHOOP stays gated until all server-side OAuth configuration exists. The foundation defines the standard OAuth authorization/token endpoints, minimum read-only recovery scopes, readiness checks, token-storage contract, and normalization for recovery score, resting heart rate, and HRV.
+
+Required operator configuration before enabling:
+
+- `WHOOP_CLIENT_ID`
+- `WHOOP_CLIENT_SECRET`
+- `WHOOP_REDIRECT_URI`
+- a registered WHOOP developer app and matching redirect URI
+- privacy review and production approval as required by WHOOP
+
+Tokens must remain server-side. The app should request the least data necessary and should revoke access/delete provider tokens when a user disconnects the integration or deletes their MyBodyScan account.
+
+## Explicitly out of scope for this branch
+
+- Garmin
+- creator marketplace
+- social feed
+- leaderboards
+- Android release/build-number changes
+- Google Play submission changes
+- turning on Apple Health / Health Connect before native connector and privacy acceptance

--- a/docs/PHYSIQUE_VOICE_WHOOP_FOUNDATIONS.md
+++ b/docs/PHYSIQUE_VOICE_WHOOP_FOUNDATIONS.md
@@ -16,7 +16,7 @@ First-party regions: chest, back, shoulders, arms, core, legs.
 
 The shared client/server helpers accept explicit numeric 0–100 development scores only. They do not convert qualitative observations into numbers. Sparse scores may be shown by region, but an overall score requires at least four valid regions.
 
-The reusable UI presents relative development, strengths, and training priorities with a disclosure. The next integration step is to extend the existing four-photo scan analysis contract so it may return these optional scores using a stable conservative rubric, sanitize them server-side, persist them with the scan, render the component in the full Results report, and pass the weakest supported regions into workout-plan prioritization.
+The production scan contract now requests these optional scores using a stable conservative rubric, sanitizes them server-side, persists them with the scan, and renders them in the full Results report. A balanced scan with at least four supported regions may add modest training volume to the two lowest-scoring areas; sparse scores never adapt the plan.
 
 ## Voice workout logging
 
@@ -29,21 +29,20 @@ The parser is deterministic and local. It handles common gym phrases without an 
 
 It matches the spoken exercise to today's existing workout exercises instead of creating duplicate movements. The reusable logger requires a confirmation tap before saving. Unsupported or ambiguous speech fails closed and remains editable as text.
 
-The next integration step is to mount the component in the existing workout-session card and call the existing `saveExerciseLog` / `logWorkoutExercise` path so voice and manual logs remain identical data.
+The logger is mounted in the existing workout session and saves through the same `saveExerciseLog` / `logWorkoutExercise` path as manual entries. Multi-set phrases are stored in the existing completed-reps field as `sets×reps`, preserving one workout log model.
 
 ## WHOOP
 
-WHOOP stays gated until all server-side OAuth configuration exists. The foundation defines the standard OAuth authorization/token endpoints, minimum read-only recovery scopes, readiness checks, token-storage contract, and normalization for recovery score, resting heart rate, and HRV.
+WHOOP stays gated until all server-side OAuth configuration exists. The implementation uses the standard authorization-code flow with one-time expiring CSRF state, server-only access and refresh tokens, refresh handling, recovery sync, provider revocation, and account-deletion cleanup. The UI cannot display WHOOP as connected until a token exchange succeeds.
 
 Required operator configuration before enabling:
 
 - `WHOOP_CLIENT_ID`
 - `WHOOP_CLIENT_SECRET`
-- `WHOOP_REDIRECT_URI`
-- a registered WHOOP developer app and matching redirect URI
+- a registered WHOOP developer app with the exact redirect URI `https://mybodyscanapp.com/api/health/whoop/callback`
 - privacy review and production approval as required by WHOOP
 
-Tokens must remain server-side. The app should request the least data necessary and should revoke access/delete provider tokens when a user disconnects the integration or deletes their MyBodyScan account.
+Tokens remain in a server-owned Firestore path denied by client rules. MyBodyScan requests read-only recovery, sleep, cycle, and workout scopes plus `offline` refresh access. Disconnect calls WHOOP's v2 revocation endpoint before deleting the local token record.
 
 ## Explicitly out of scope for this branch
 

--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -77,8 +77,6 @@ npx firebase-tools functions:secrets:get STRIPE_SECRET --project mybodyscan-f3da
 npx firebase-tools functions:secrets:get STRIPE_SECRET_KEY --project mybodyscan-f3daf
 npx firebase-tools functions:secrets:get STRIPE_WEBHOOK_SECRET --project mybodyscan-f3daf
 npx firebase-tools functions:secrets:get USDA_FDC_API_KEY --project mybodyscan-f3daf
-npx firebase-tools functions:secrets:get WHOOP_CLIENT_ID --project mybodyscan-f3daf
-npx firebase-tools functions:secrets:get WHOOP_CLIENT_SECRET --project mybodyscan-f3daf
 ```
 
 Set or rotate a missing value interactively, one at a time:
@@ -94,21 +92,12 @@ exist before Functions deployment. RevenueCat is required when mobile purchase
 events are enabled. `ADMIN_EMAIL_ALLOWLIST` is a fail-closed binding for the
 admin credit-grant function and must exist before Functions deployment.
 
-WHOOP remains unavailable until both WHOOP secrets have enabled versions and
-the WHOOP developer app has the exact redirect URI
-`https://mybodyscanapp.com/api/health/whoop/callback`. Set the secrets
-interactively without printing their values:
-
-```bash
-npx firebase-tools functions:secrets:set WHOOP_CLIENT_ID --project mybodyscan-f3daf
-npx firebase-tools functions:secrets:set WHOOP_CLIENT_SECRET --project mybodyscan-f3daf
-```
-
-The integration requests read-only recovery, sleep, cycle, and workout scopes
-plus offline refresh access. Access and refresh tokens stay in server-owned
-Firestore documents denied by client rules. Keep the feature labeled
-unavailable until connect, refresh, recovery sync, disconnect/revocation, and
-account-deletion cleanup pass with a non-admin Pro production test account.
+WHOOP is intentionally deferred from the initial production release. Its UI,
+API routes, public callback exception, and Firebase secret bindings must remain
+absent until a company-owned WHOOP developer membership, an approved OAuth
+client, and an end-to-end member test are available. The preserved foundation
+documents the future redirect URI as
+`https://mybodyscanapp.com/api/health/whoop/callback`.
 
 Non-secret runtime configuration is committed in
 `functions/.env.mybodyscan-f3daf`, the Firebase-supported project-specific
@@ -888,7 +877,7 @@ providers and does not replace the subscribed real-account checks below.
   support path for a customer who later returns with a different account.
 - On the physical iPhone, opt into plateau alerts, accept the system prompt,
   receive one visible APNs notification, and confirm tapping it opens History.
-- With WHOOP configured, a Pro test user can connect through the provider
+- In a future WHOOP-enabled release, a Pro test user can connect through the provider
   consent screen, return to Settings, sync the latest recovery, and disconnect.
   Confirm the UI never exposes tokens, the provider access grant is revoked,
   the server token document is removed, and account deletion performs the same

--- a/docs/PRODUCTION_RELEASE.md
+++ b/docs/PRODUCTION_RELEASE.md
@@ -77,6 +77,8 @@ npx firebase-tools functions:secrets:get STRIPE_SECRET --project mybodyscan-f3da
 npx firebase-tools functions:secrets:get STRIPE_SECRET_KEY --project mybodyscan-f3daf
 npx firebase-tools functions:secrets:get STRIPE_WEBHOOK_SECRET --project mybodyscan-f3daf
 npx firebase-tools functions:secrets:get USDA_FDC_API_KEY --project mybodyscan-f3daf
+npx firebase-tools functions:secrets:get WHOOP_CLIENT_ID --project mybodyscan-f3daf
+npx firebase-tools functions:secrets:get WHOOP_CLIENT_SECRET --project mybodyscan-f3daf
 ```
 
 Set or rotate a missing value interactively, one at a time:
@@ -91,6 +93,22 @@ API-key aliases are currently bound for compatibility and therefore both must
 exist before Functions deployment. RevenueCat is required when mobile purchase
 events are enabled. `ADMIN_EMAIL_ALLOWLIST` is a fail-closed binding for the
 admin credit-grant function and must exist before Functions deployment.
+
+WHOOP remains unavailable until both WHOOP secrets have enabled versions and
+the WHOOP developer app has the exact redirect URI
+`https://mybodyscanapp.com/api/health/whoop/callback`. Set the secrets
+interactively without printing their values:
+
+```bash
+npx firebase-tools functions:secrets:set WHOOP_CLIENT_ID --project mybodyscan-f3daf
+npx firebase-tools functions:secrets:set WHOOP_CLIENT_SECRET --project mybodyscan-f3daf
+```
+
+The integration requests read-only recovery, sleep, cycle, and workout scopes
+plus offline refresh access. Access and refresh tokens stay in server-owned
+Firestore documents denied by client rules. Keep the feature labeled
+unavailable until connect, refresh, recovery sync, disconnect/revocation, and
+account-deletion cleanup pass with a non-admin Pro production test account.
 
 Non-secret runtime configuration is committed in
 `functions/.env.mybodyscan-f3daf`, the Firebase-supported project-specific
@@ -870,6 +888,13 @@ providers and does not replace the subscribed real-account checks below.
   support path for a customer who later returns with a different account.
 - On the physical iPhone, opt into plateau alerts, accept the system prompt,
   receive one visible APNs notification, and confirm tapping it opens History.
+- With WHOOP configured, a Pro test user can connect through the provider
+  consent screen, return to Settings, sync the latest recovery, and disconnect.
+  Confirm the UI never exposes tokens, the provider access grant is revoked,
+  the server token document is removed, and account deletion performs the same
+  cleanup. Repeat once after forcing an access-token refresh. A non-Pro user
+  must be denied connect and sync but must still be able to disconnect an
+  existing connection.
 - From a Google Play internal-test install, verify email, Google, and Apple
   authentication only where the provider is intentionally offered; complete a
   real four-photo scan; test notification opt-in; and purchase monthly, yearly,

--- a/firebase.json
+++ b/firebase.json
@@ -232,7 +232,9 @@
         "STRIPE_SECRET",
         "STRIPE_SECRET_KEY",
         "STRIPE_WEBHOOK_SECRET",
-        "USDA_FDC_API_KEY"
+        "USDA_FDC_API_KEY",
+        "WHOOP_CLIENT_ID",
+        "WHOOP_CLIENT_SECRET"
       ]
     }
   ],

--- a/firebase.json
+++ b/firebase.json
@@ -232,9 +232,7 @@
         "STRIPE_SECRET",
         "STRIPE_SECRET_KEY",
         "STRIPE_WEBHOOK_SECRET",
-        "USDA_FDC_API_KEY",
-        "WHOOP_CLIENT_ID",
-        "WHOOP_CLIENT_SECRET"
+        "USDA_FDC_API_KEY"
       ]
     }
   ],

--- a/firestore.rules
+++ b/firestore.rules
@@ -334,6 +334,12 @@ service cloud.firestore {
         allow write: if !isDemoUser() && hasActivePro(uid);
       }
 
+      // OAuth access and refresh tokens are server-only. Connection status is
+      // exposed through an authenticated API that strips token material.
+      match /serverHealth/{provider} {
+        allow read, write: if false;
+      }
+
       match /nutrition/{docId} {
         allow read: if hasActivePro(uid);
         allow write: if !isDemoUser() && hasActivePro(uid);
@@ -386,6 +392,11 @@ service cloud.firestore {
     match /stripeEvents/{eventId} {
       allow read: if isStaff();
       allow write: if false;
+    }
+
+    // Short-lived, one-time OAuth CSRF state. Never client-readable.
+    match /oauthStates/{stateHash} {
+      allow read, write: if false;
     }
 
     match /telemetryEvents/{eventId} {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -765,9 +765,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -33,6 +33,7 @@
     "typescript": "^5.4.0"
   },
   "overrides": {
+    "brace-expansion": "5.0.9",
     "rimraf": "$rimraf",
     "uuid": "11.1.1"
   }

--- a/functions/src/account.ts
+++ b/functions/src/account.ts
@@ -8,7 +8,6 @@ import { onCallWithOptionalAppCheck } from "./util/callable.js";
 import { deletePushTokenOwnershipForUser } from "./pushTokenOwnership.js";
 import { deleteStripeCustomerForUser } from "./accountDeletion.js";
 import { stripeSecretKeyParam, stripeSecretParam } from "./stripe/keys.js";
-import { whoopClientIdParam, whoopClientSecretParam } from "./health/whoop.js";
 import { deleteWhoopDataForAccount } from "./health/whoopRouter.js";
 
 const auth = getAuth();
@@ -176,12 +175,7 @@ export const deleteMyAccount = onCallWithOptionalAppCheck(
   },
   {
     region: "us-central1",
-    secrets: [
-      stripeSecretParam,
-      stripeSecretKeyParam,
-      whoopClientIdParam,
-      whoopClientSecretParam,
-    ],
+    secrets: [stripeSecretParam, stripeSecretKeyParam],
   }
 );
 

--- a/functions/src/account.ts
+++ b/functions/src/account.ts
@@ -7,10 +7,9 @@ import { buildScanPhotoPath, isScanPose } from "./scan/paths.js";
 import { onCallWithOptionalAppCheck } from "./util/callable.js";
 import { deletePushTokenOwnershipForUser } from "./pushTokenOwnership.js";
 import { deleteStripeCustomerForUser } from "./accountDeletion.js";
-import {
-  stripeSecretKeyParam,
-  stripeSecretParam,
-} from "./stripe/keys.js";
+import { stripeSecretKeyParam, stripeSecretParam } from "./stripe/keys.js";
+import { whoopClientIdParam, whoopClientSecretParam } from "./health/whoop.js";
+import { deleteWhoopDataForAccount } from "./health/whoopRouter.js";
 
 const auth = getAuth();
 const db = getFirestore();
@@ -43,6 +42,7 @@ async function deleteFirestoreUser(
   const ref = db.doc(`users/${uid}`);
   console.log("account_delete_firestore_begin", { uid, requestId });
   await deletePushTokenOwnershipForUser(db, uid);
+  await deleteWhoopDataForAccount(uid);
   await db.recursiveDelete(ref);
   console.log("account_delete_firestore_complete", { uid, requestId });
 }
@@ -176,7 +176,12 @@ export const deleteMyAccount = onCallWithOptionalAppCheck(
   },
   {
     region: "us-central1",
-    secrets: [stripeSecretParam, stripeSecretKeyParam],
+    secrets: [
+      stripeSecretParam,
+      stripeSecretKeyParam,
+      whoopClientIdParam,
+      whoopClientSecretParam,
+    ],
   }
 );
 

--- a/functions/src/health/whoop.ts
+++ b/functions/src/health/whoop.ts
@@ -1,0 +1,92 @@
+export const WHOOP_AUTHORIZATION_URL =
+  "https://api.prod.whoop.com/oauth/oauth2/auth";
+export const WHOOP_TOKEN_URL =
+  "https://api.prod.whoop.com/oauth/oauth2/token";
+export const WHOOP_API_BASE_URL = "https://api.prod.whoop.com/developer/v2";
+
+/** Minimum read-only data needed for recovery-aware coaching. */
+export const WHOOP_DEFAULT_SCOPES = [
+  "offline",
+  "read:recovery",
+  "read:sleep",
+  "read:cycles",
+  "read:workout",
+] as const;
+
+export type WhoopReadiness = {
+  configured: boolean;
+  reason: "ready" | "missing_client_id" | "missing_client_secret" | "missing_redirect_uri";
+};
+
+export function getWhoopReadiness(
+  env: NodeJS.ProcessEnv = process.env
+): WhoopReadiness {
+  if (!env.WHOOP_CLIENT_ID?.trim()) {
+    return { configured: false, reason: "missing_client_id" };
+  }
+  if (!env.WHOOP_CLIENT_SECRET?.trim()) {
+    return { configured: false, reason: "missing_client_secret" };
+  }
+  if (!env.WHOOP_REDIRECT_URI?.trim()) {
+    return { configured: false, reason: "missing_redirect_uri" };
+  }
+  return { configured: true, reason: "ready" };
+}
+
+export function buildWhoopAuthorizationUrl(args: {
+  clientId: string;
+  redirectUri: string;
+  state: string;
+  scopes?: readonly string[];
+}): string {
+  if (args.state.trim().length < 8) {
+    throw new Error("whoop_state_too_short");
+  }
+  const url = new URL(WHOOP_AUTHORIZATION_URL);
+  url.searchParams.set("client_id", args.clientId);
+  url.searchParams.set("redirect_uri", args.redirectUri);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", (args.scopes ?? WHOOP_DEFAULT_SCOPES).join(" "));
+  url.searchParams.set("state", args.state);
+  return url.toString();
+}
+
+/**
+ * Keep provider tokens server-side. Callers should store encrypted/sealed token
+ * material in a server-owned document and never expose a client secret or
+ * refresh token to the browser bundle.
+ */
+export type WhoopTokenRecord = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAtMs: number;
+  scope: string;
+  updatedAtMs: number;
+};
+
+export type WhoopDailyRecovery = {
+  date: string;
+  recoveryScore: number | null;
+  restingHeartRate: number | null;
+  hrvRmssdMs: number | null;
+  source: "whoop";
+};
+
+export function normalizeWhoopRecovery(
+  value: unknown,
+  date: string
+): WhoopDailyRecovery {
+  const source = value && typeof value === "object" ? (value as any) : {};
+  const score = source?.score && typeof source.score === "object" ? source.score : {};
+  const finite = (raw: unknown): number | null => {
+    const n = Number(raw);
+    return Number.isFinite(n) ? n : null;
+  };
+  return {
+    date,
+    recoveryScore: finite(score.recovery_score),
+    restingHeartRate: finite(score.resting_heart_rate),
+    hrvRmssdMs: finite(score.hrv_rmssd_milli),
+    source: "whoop",
+  };
+}

--- a/functions/src/health/whoop.ts
+++ b/functions/src/health/whoop.ts
@@ -1,8 +1,14 @@
+import { defineSecret } from "firebase-functions/params";
+
 export const WHOOP_AUTHORIZATION_URL =
   "https://api.prod.whoop.com/oauth/oauth2/auth";
-export const WHOOP_TOKEN_URL =
-  "https://api.prod.whoop.com/oauth/oauth2/token";
+export const WHOOP_TOKEN_URL = "https://api.prod.whoop.com/oauth/oauth2/token";
 export const WHOOP_API_BASE_URL = "https://api.prod.whoop.com/developer/v2";
+export const WHOOP_REDIRECT_URI =
+  "https://mybodyscanapp.com/api/health/whoop/callback";
+
+export const whoopClientIdParam = defineSecret("WHOOP_CLIENT_ID");
+export const whoopClientSecretParam = defineSecret("WHOOP_CLIENT_SECRET");
 
 /** Minimum read-only data needed for recovery-aware coaching. */
 export const WHOOP_DEFAULT_SCOPES = [
@@ -15,7 +21,7 @@ export const WHOOP_DEFAULT_SCOPES = [
 
 export type WhoopReadiness = {
   configured: boolean;
-  reason: "ready" | "missing_client_id" | "missing_client_secret" | "missing_redirect_uri";
+  reason: "ready" | "missing_client_id" | "missing_client_secret";
 };
 
 export function getWhoopReadiness(
@@ -27,10 +33,28 @@ export function getWhoopReadiness(
   if (!env.WHOOP_CLIENT_SECRET?.trim()) {
     return { configured: false, reason: "missing_client_secret" };
   }
-  if (!env.WHOOP_REDIRECT_URI?.trim()) {
-    return { configured: false, reason: "missing_redirect_uri" };
-  }
   return { configured: true, reason: "ready" };
+}
+
+export function readWhoopServerConfig(): {
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+} | null {
+  const read = (
+    param: ReturnType<typeof defineSecret>,
+    envName: string
+  ): string => {
+    try {
+      return String(param.value() || process.env[envName] || "").trim();
+    } catch {
+      return String(process.env[envName] || "").trim();
+    }
+  };
+  const clientId = read(whoopClientIdParam, "WHOOP_CLIENT_ID");
+  const clientSecret = read(whoopClientSecretParam, "WHOOP_CLIENT_SECRET");
+  if (!clientId || !clientSecret) return null;
+  return { clientId, clientSecret, redirectUri: WHOOP_REDIRECT_URI };
 }
 
 export function buildWhoopAuthorizationUrl(args: {
@@ -46,15 +70,17 @@ export function buildWhoopAuthorizationUrl(args: {
   url.searchParams.set("client_id", args.clientId);
   url.searchParams.set("redirect_uri", args.redirectUri);
   url.searchParams.set("response_type", "code");
-  url.searchParams.set("scope", (args.scopes ?? WHOOP_DEFAULT_SCOPES).join(" "));
+  url.searchParams.set(
+    "scope",
+    (args.scopes ?? WHOOP_DEFAULT_SCOPES).join(" ")
+  );
   url.searchParams.set("state", args.state);
   return url.toString();
 }
 
 /**
- * Keep provider tokens server-side. Callers should store encrypted/sealed token
- * material in a server-owned document and never expose a client secret or
- * refresh token to the browser bundle.
+ * Keep provider tokens server-side in a document denied by client rules. Never
+ * expose a client secret or refresh token to the browser bundle.
  */
 export type WhoopTokenRecord = {
   accessToken: string;
@@ -76,8 +102,14 @@ export function normalizeWhoopRecovery(
   value: unknown,
   date: string
 ): WhoopDailyRecovery {
-  const source = value && typeof value === "object" ? (value as any) : {};
-  const score = source?.score && typeof source.score === "object" ? source.score : {};
+  const source =
+    value && typeof value === "object"
+      ? (value as Record<string, unknown>)
+      : {};
+  const score =
+    source.score && typeof source.score === "object"
+      ? (source.score as Record<string, unknown>)
+      : {};
   const finite = (raw: unknown): number | null => {
     const n = Number(raw);
     return Number.isFinite(n) ? n : null;

--- a/functions/src/health/whoopRouter.ts
+++ b/functions/src/health/whoopRouter.ts
@@ -1,0 +1,354 @@
+import { createHash, randomBytes } from "node:crypto";
+import type { Request, Response, Router } from "express";
+import { Timestamp, getFirestore } from "../firebase.js";
+import { requireAuth } from "../http.js";
+import { requireProEntitlement } from "../lib/proEntitlements.js";
+import {
+  WHOOP_API_BASE_URL,
+  WHOOP_DEFAULT_SCOPES,
+  WHOOP_TOKEN_URL,
+  buildWhoopAuthorizationUrl,
+  normalizeWhoopRecovery,
+  readWhoopServerConfig,
+  type WhoopTokenRecord,
+} from "./whoop.js";
+
+const db = getFirestore();
+const STATE_TTL_MS = 10 * 60 * 1000;
+const TOKEN_REFRESH_SKEW_MS = 60 * 1000;
+const WEB_RETURN_URL = "https://mybodyscanapp.com/settings/health";
+
+type StoredWhoopToken = WhoopTokenRecord & {
+  connectedAtMs: number;
+  lastSyncedAtMs?: number;
+};
+
+type WhoopRecoveryCollection = {
+  records?: Array<Record<string, unknown>>;
+};
+
+function stateHash(state: string): string {
+  return createHash("sha256").update(state).digest("hex");
+}
+
+function tokenRef(uid: string) {
+  return db.doc(`users/${uid}/serverHealth/whoop`);
+}
+
+function statusCode(error: unknown): number {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String((error as { code?: unknown }).code || "")
+      : "";
+  if (code.includes("unauthenticated")) return 401;
+  if (code.includes("permission-denied")) return 403;
+  return 500;
+}
+
+function sendError(res: Response, error: unknown, fallback: string): void {
+  const status = statusCode(error);
+  res.status(status).json({
+    ok: false,
+    code:
+      status === 401
+        ? "auth_required"
+        : status === 403
+          ? "subscription_required"
+          : fallback,
+    message:
+      status === 401
+        ? "Sign in to manage health connections."
+        : status === 403
+          ? "An active monthly or yearly plan is required."
+          : "The health connection is temporarily unavailable.",
+  });
+}
+
+function redirectResult(
+  res: Response,
+  result: "connected" | "error",
+  code?: string
+) {
+  const target = new URL(WEB_RETURN_URL);
+  target.searchParams.set("whoop", result);
+  if (code) target.searchParams.set("reason", code);
+  res.setHeader("Location", target.toString());
+  res.status(302).end();
+}
+
+async function requestTokens(body: URLSearchParams): Promise<StoredWhoopToken> {
+  const response = await fetch(WHOOP_TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  const payload = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >;
+  const accessToken =
+    typeof payload.access_token === "string" ? payload.access_token : "";
+  const refreshToken =
+    typeof payload.refresh_token === "string" ? payload.refresh_token : "";
+  const expiresIn = Number(payload.expires_in);
+  if (
+    !response.ok ||
+    !accessToken ||
+    !refreshToken ||
+    !Number.isFinite(expiresIn)
+  ) {
+    console.warn("whoop_token_exchange_failed", { status: response.status });
+    throw new Error("whoop_token_exchange_failed");
+  }
+  const now = Date.now();
+  return {
+    accessToken,
+    refreshToken,
+    expiresAtMs: now + Math.max(60, expiresIn) * 1000,
+    scope: typeof payload.scope === "string" ? payload.scope : "",
+    updatedAtMs: now,
+    connectedAtMs: now,
+  };
+}
+
+async function getFreshToken(uid: string): Promise<StoredWhoopToken | null> {
+  const snap = await tokenRef(uid).get();
+  if (!snap.exists) return null;
+  const stored = snap.data() as StoredWhoopToken;
+  if (
+    typeof stored.accessToken !== "string" ||
+    typeof stored.refreshToken !== "string"
+  ) {
+    return null;
+  }
+  if (Number(stored.expiresAtMs) > Date.now() + TOKEN_REFRESH_SKEW_MS) {
+    return stored;
+  }
+  const config = readWhoopServerConfig();
+  if (!config) throw new Error("whoop_not_configured");
+  const refreshed = await requestTokens(
+    new URLSearchParams({
+      grant_type: "refresh_token",
+      refresh_token: stored.refreshToken,
+      client_id: config.clientId,
+      client_secret: config.clientSecret,
+      scope: "offline",
+    })
+  );
+  refreshed.connectedAtMs = Number(stored.connectedAtMs) || Date.now();
+  await tokenRef(uid).set(refreshed);
+  return refreshed;
+}
+
+async function start(req: Request, res: Response) {
+  try {
+    const uid = await requireAuth(req);
+    await requireProEntitlement(uid);
+    const config = readWhoopServerConfig();
+    if (!config) {
+      res.status(503).json({
+        ok: false,
+        code: "whoop_not_configured",
+        message: "WHOOP connection is not available yet.",
+      });
+      return;
+    }
+    const state = randomBytes(32).toString("base64url");
+    const now = Date.now();
+    await db.doc(`oauthStates/${stateHash(state)}`).set({
+      provider: "whoop",
+      uid,
+      createdAt: Timestamp.now(),
+      expiresAtMs: now + STATE_TTL_MS,
+    });
+    res.status(200).json({
+      ok: true,
+      authorizationUrl: buildWhoopAuthorizationUrl({
+        clientId: config.clientId,
+        redirectUri: config.redirectUri,
+        state,
+      }),
+    });
+  } catch (error) {
+    sendError(res, error, "whoop_start_failed");
+  }
+}
+
+async function callback(req: Request, res: Response) {
+  const code = typeof req.query.code === "string" ? req.query.code : "";
+  const state = typeof req.query.state === "string" ? req.query.state : "";
+  const providerError =
+    typeof req.query.error === "string" ? req.query.error : "";
+  if (providerError || !code || state.length < 8) {
+    redirectResult(res, "error", providerError || "invalid_callback");
+    return;
+  }
+  try {
+    const config = readWhoopServerConfig();
+    if (!config) throw new Error("whoop_not_configured");
+    const ref = db.doc(`oauthStates/${stateHash(state)}`);
+    const uid = await db.runTransaction(async (transaction) => {
+      const snap = await transaction.get(ref);
+      const data = snap.data();
+      transaction.delete(ref);
+      if (
+        !snap.exists ||
+        data?.provider !== "whoop" ||
+        typeof data?.uid !== "string" ||
+        Number(data?.expiresAtMs) < Date.now()
+      ) {
+        throw new Error("invalid_or_expired_state");
+      }
+      return data.uid as string;
+    });
+    const tokens = await requestTokens(
+      new URLSearchParams({
+        grant_type: "authorization_code",
+        code,
+        client_id: config.clientId,
+        client_secret: config.clientSecret,
+        redirect_uri: config.redirectUri,
+      })
+    );
+    await tokenRef(uid).set(tokens);
+    redirectResult(res, "connected");
+  } catch (error) {
+    console.warn("whoop_callback_failed", {
+      message: error instanceof Error ? error.message : "unknown",
+    });
+    redirectResult(res, "error", "connection_failed");
+  }
+}
+
+async function status(req: Request, res: Response) {
+  try {
+    const uid = await requireAuth(req);
+    const configured = Boolean(readWhoopServerConfig());
+    const snap = configured ? await tokenRef(uid).get() : null;
+    const data = snap?.data() as StoredWhoopToken | undefined;
+    res.status(200).json({
+      ok: true,
+      configured,
+      connected: Boolean(configured && snap?.exists && data?.refreshToken),
+      connectedAtMs: Number(data?.connectedAtMs) || null,
+      lastSyncedAtMs: Number(data?.lastSyncedAtMs) || null,
+    });
+  } catch (error) {
+    sendError(res, error, "whoop_status_failed");
+  }
+}
+
+async function sync(req: Request, res: Response) {
+  try {
+    const uid = await requireAuth(req);
+    await requireProEntitlement(uid);
+    const token = await getFreshToken(uid);
+    if (!token) {
+      res.status(409).json({
+        ok: false,
+        code: "whoop_not_connected",
+        message: "Connect WHOOP before syncing recovery data.",
+      });
+      return;
+    }
+    const response = await fetch(`${WHOOP_API_BASE_URL}/recovery?limit=1`, {
+      headers: { authorization: `Bearer ${token.accessToken}` },
+    });
+    const payload = (await response
+      .json()
+      .catch(() => ({}))) as WhoopRecoveryCollection;
+    if (!response.ok) {
+      console.warn("whoop_recovery_sync_failed", { status: response.status });
+      throw new Error("whoop_recovery_sync_failed");
+    }
+    const record = Array.isArray(payload.records) ? payload.records[0] : null;
+    const rawDate = String(record?.updated_at || record?.created_at || "");
+    const date = /^\d{4}-\d{2}-\d{2}/.test(rawDate)
+      ? rawDate.slice(0, 10)
+      : new Date().toISOString().slice(0, 10);
+    const recovery = record ? normalizeWhoopRecovery(record, date) : null;
+    const now = Date.now();
+    if (recovery) {
+      await db.doc(`users/${uid}/healthDaily/${date}`).set(
+        {
+          whoop: recovery,
+          whoopSyncedAt: Timestamp.now(),
+        },
+        { merge: true }
+      );
+    }
+    await tokenRef(uid).set({ lastSyncedAtMs: now }, { merge: true });
+    res.status(200).json({ ok: true, recovery, lastSyncedAtMs: now });
+  } catch (error) {
+    sendError(res, error, "whoop_sync_failed");
+  }
+}
+
+async function disconnect(req: Request, res: Response) {
+  try {
+    const uid = await requireAuth(req);
+    const token = await getFreshToken(uid);
+    if (token?.accessToken) {
+      const revoke = await fetch(`${WHOOP_API_BASE_URL}/user/access`, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      });
+      if (!revoke.ok && revoke.status !== 401) {
+        res.status(502).json({
+          ok: false,
+          code: "whoop_revoke_failed",
+          message: "WHOOP could not be disconnected. Please try again.",
+        });
+        return;
+      }
+    }
+    await tokenRef(uid).delete();
+    res.status(200).json({ ok: true, connected: false });
+  } catch (error) {
+    sendError(res, error, "whoop_disconnect_failed");
+  }
+}
+
+/** Best-effort provider revocation followed by unconditional local deletion. */
+export async function deleteWhoopDataForAccount(uid: string): Promise<void> {
+  try {
+    const token = await getFreshToken(uid);
+    if (token?.accessToken) {
+      const revoke = await fetch(`${WHOOP_API_BASE_URL}/user/access`, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      });
+      if (!revoke.ok && revoke.status !== 401) {
+        console.warn("whoop_account_delete_revoke_failed", {
+          uid,
+          status: revoke.status,
+        });
+      }
+    }
+  } catch (error) {
+    console.warn("whoop_account_delete_revoke_failed", {
+      uid,
+      message: error instanceof Error ? error.message : "unknown",
+    });
+  }
+  await tokenRef(uid)
+    .delete()
+    .catch(() => undefined);
+  const states = await db
+    .collection("oauthStates")
+    .where("uid", "==", uid)
+    .get();
+  await Promise.all(states.docs.map((state) => state.ref.delete()));
+}
+
+export function registerWhoopRoutes(router: Router): void {
+  router.post("/health/whoop/start", start);
+  router.get("/health/whoop/callback", callback);
+  router.get("/health/whoop/status", status);
+  router.post("/health/whoop/sync", sync);
+  router.post("/health/whoop/disconnect", disconnect);
+}
+
+export const whoopRouterInternals = {
+  stateHash,
+};

--- a/functions/src/http.ts
+++ b/functions/src/http.ts
@@ -49,8 +49,19 @@ export const allowCorsAndOptionalAppCheck: RequestHandler = async (
   res.set("Access-Control-Allow-Methods", "GET,POST,OPTIONS");
   if (req.method === "OPTIONS") return res.status(204).end();
   try {
-    const publicHealth = /^\/(?:api\/)?health\/?$/.test(req.url || req.path);
-    await verifyAppCheck(req, publicHealth ? "soft" : getAppCheckMode());
+    const requestPath = req.path || req.url || "";
+    const publicHealth = /^\/(?:api\/)?health\/?$/.test(requestPath);
+    // OAuth providers cannot send a Firebase App Check token when redirecting
+    // the browser back to our server. The signed, one-time state is the callback
+    // gate; authenticated start/status/sync/disconnect routes remain covered by
+    // the configured App Check mode.
+    const publicOAuthCallback = /^\/(?:api\/)?health\/whoop\/callback\/?$/.test(
+      requestPath
+    );
+    await verifyAppCheck(
+      req,
+      publicHealth || publicOAuthCallback ? "soft" : getAppCheckMode()
+    );
     next();
   } catch {
     res.status(403).json({ error: "app_check_required" });

--- a/functions/src/http.ts
+++ b/functions/src/http.ts
@@ -51,17 +51,7 @@ export const allowCorsAndOptionalAppCheck: RequestHandler = async (
   try {
     const requestPath = req.path || req.url || "";
     const publicHealth = /^\/(?:api\/)?health\/?$/.test(requestPath);
-    // OAuth providers cannot send a Firebase App Check token when redirecting
-    // the browser back to our server. The signed, one-time state is the callback
-    // gate; authenticated start/status/sync/disconnect routes remain covered by
-    // the configured App Check mode.
-    const publicOAuthCallback = /^\/(?:api\/)?health\/whoop\/callback\/?$/.test(
-      requestPath
-    );
-    await verifyAppCheck(
-      req,
-      publicHealth || publicOAuthCallback ? "soft" : getAppCheckMode()
-    );
+    await verifyAppCheck(req, publicHealth ? "soft" : getAppCheckMode());
     next();
   } catch {
     res.status(403).json({ error: "app_check_required" });

--- a/functions/src/http/deleteAccount.ts
+++ b/functions/src/http/deleteAccount.ts
@@ -6,10 +6,9 @@ import { getStorage } from "firebase-admin/storage";
 import { verifyAppCheck } from "../http.js";
 import { deletePushTokenOwnershipForUser } from "../pushTokenOwnership.js";
 import { deleteStripeCustomerForUser } from "../accountDeletion.js";
-import {
-  stripeSecretKeyParam,
-  stripeSecretParam,
-} from "../stripe/keys.js";
+import { stripeSecretKeyParam, stripeSecretParam } from "../stripe/keys.js";
+import { whoopClientIdParam, whoopClientSecretParam } from "../health/whoop.js";
+import { deleteWhoopDataForAccount } from "../health/whoopRouter.js";
 
 export const deleteAccount = onRequest(
   {
@@ -17,7 +16,12 @@ export const deleteAccount = onRequest(
     region: "us-central1",
     timeoutSeconds: 540,
     memory: "1GiB",
-    secrets: [stripeSecretParam, stripeSecretKeyParam],
+    secrets: [
+      stripeSecretParam,
+      stripeSecretKeyParam,
+      whoopClientIdParam,
+      whoopClientSecretParam,
+    ],
   },
   async (req, res) => {
     if (req.method !== "POST")
@@ -71,5 +75,6 @@ async function deleteUserData(uid: string) {
   await bucket.deleteFiles({ prefix: `user_uploads/${uid}/` });
   await bucket.deleteFiles({ prefix: `transformation-previews/${uid}/` });
   await deletePushTokenOwnershipForUser(db, uid);
+  await deleteWhoopDataForAccount(uid);
   await db.recursiveDelete(db.doc(`users/${uid}`));
 }

--- a/functions/src/http/deleteAccount.ts
+++ b/functions/src/http/deleteAccount.ts
@@ -7,7 +7,6 @@ import { verifyAppCheck } from "../http.js";
 import { deletePushTokenOwnershipForUser } from "../pushTokenOwnership.js";
 import { deleteStripeCustomerForUser } from "../accountDeletion.js";
 import { stripeSecretKeyParam, stripeSecretParam } from "../stripe/keys.js";
-import { whoopClientIdParam, whoopClientSecretParam } from "../health/whoop.js";
 import { deleteWhoopDataForAccount } from "../health/whoopRouter.js";
 
 export const deleteAccount = onRequest(
@@ -16,12 +15,7 @@ export const deleteAccount = onRequest(
     region: "us-central1",
     timeoutSeconds: 540,
     memory: "1GiB",
-    secrets: [
-      stripeSecretParam,
-      stripeSecretKeyParam,
-      whoopClientIdParam,
-      whoopClientSecretParam,
-    ],
+    secrets: [stripeSecretParam, stripeSecretKeyParam],
   },
   async (req, res) => {
     if (req.method !== "POST")

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,6 +13,8 @@ import { nutritionRouter } from "./nutrition.js";
 import { openAiSecretParam } from "./openai/keys.js";
 import { stripeSecretKeyParam, stripeSecretParam } from "./stripe/keys.js";
 import { systemRouter } from "./systemRouter.js";
+import { registerWhoopRoutes } from "./health/whoopRouter.js";
+import { whoopClientIdParam, whoopClientSecretParam } from "./health/whoop.js";
 
 export { health } from "./health.js";
 export { systemHealth } from "./systemHealth.js";
@@ -237,6 +239,7 @@ apiRouter.use("/billing", billingRouter);
 apiRouter.use("/coach", coachRouter);
 apiRouter.use("/nutrition", nutritionRouter);
 apiRouter.use("/system", systemRouter);
+registerWhoopRoutes(apiRouter);
 
 app.use("/", apiRouter);
 app.use("/api", apiRouter);
@@ -279,6 +282,8 @@ export const api = onRequest(
       stripeSecretParam,
       stripeSecretKeyParam,
       usdaFdcApiKeyParam,
+      whoopClientIdParam,
+      whoopClientSecretParam,
     ],
   },
   app

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -13,8 +13,6 @@ import { nutritionRouter } from "./nutrition.js";
 import { openAiSecretParam } from "./openai/keys.js";
 import { stripeSecretKeyParam, stripeSecretParam } from "./stripe/keys.js";
 import { systemRouter } from "./systemRouter.js";
-import { registerWhoopRoutes } from "./health/whoopRouter.js";
-import { whoopClientIdParam, whoopClientSecretParam } from "./health/whoop.js";
 
 export { health } from "./health.js";
 export { systemHealth } from "./systemHealth.js";
@@ -239,7 +237,6 @@ apiRouter.use("/billing", billingRouter);
 apiRouter.use("/coach", coachRouter);
 apiRouter.use("/nutrition", nutritionRouter);
 apiRouter.use("/system", systemRouter);
-registerWhoopRoutes(apiRouter);
 
 app.use("/", apiRouter);
 app.use("/api", apiRouter);
@@ -282,8 +279,6 @@ export const api = onRequest(
       stripeSecretParam,
       stripeSecretKeyParam,
       usdaFdcApiKeyParam,
-      whoopClientIdParam,
-      whoopClientSecretParam,
     ],
   },
   app

--- a/functions/src/scan/analysis.ts
+++ b/functions/src/scan/analysis.ts
@@ -15,6 +15,10 @@ import type {
 } from "../types.js";
 import { scanPhotosPrefix } from "./paths.js";
 import { isValidBodyFatPercent } from "./contract.js";
+import {
+  PHYSIQUE_SCORE_MODEL_INSTRUCTION,
+  sanitizePhysiqueScores,
+} from "./physiqueScores.js";
 
 const storage = getStorage();
 const POSES = ["front", "back", "left", "right"] as const;
@@ -137,6 +141,9 @@ function sanitizeEstimate(
   const visualObservations = sanitizeVisualObservations(
     source?.visualObservations ?? source?.visual_observations
   );
+  const physiqueScores = sanitizePhysiqueScores(
+    source?.physiqueScores ?? source?.physique_scores
+  );
   return {
     bodyFatPercent: Number(bodyFatPercent.toFixed(1)),
     bmi,
@@ -155,6 +162,7 @@ function sanitizeEstimate(
     ...(Object.keys(visualObservations).length > 0
       ? { visualObservations }
       : {}),
+    ...(Object.keys(physiqueScores).length > 0 ? { physiqueScores } : {}),
   };
 }
 
@@ -434,6 +442,14 @@ export async function callOpenAI(
       '      "torsoCore": string,',
       '      "hips": string,',
       '      "legs": string',
+      "    },",
+      '    "physiqueScores": {',
+      '      "chest": number,',
+      '      "back": number,',
+      '      "shoulders": number,',
+      '      "arms": number,',
+      '      "core": number,',
+      '      "legs": number',
       "    }",
       "  },",
       '  "recommendations": string[],',
@@ -454,6 +470,7 @@ export async function callOpenAI(
     "Key observations should capture posture/muscle balance/general notes (no medical diagnosis).",
     "For visualObservations, describe only what is visibly apparent with cautious qualitative wording.",
     "Region values may describe visible development, visual balance, or training priority; never give regional fat or muscle amounts.",
+    PHYSIQUE_SCORE_MODEL_INSTRUCTION,
     "Do not infer injuries, health conditions, internal tissue, or exact regional composition from photos.",
     "Provide improvementAreas as 3-5 short bullets on what to work on first.",
     "Goal recommendations should give actionable habit changes (bullets).",
@@ -463,8 +480,9 @@ export async function callOpenAI(
 
   const imageParts: ChatContentPart[] = images.map(({ dataUrl }) => ({
     type: "image_url" as const,
-    // Speed-first: "low" significantly reduces latency/cost for 4-image inputs.
-    image_url: { url: dataUrl, detail: "low" as const },
+    // Regional development scoring needs enough detail to distinguish visible
+    // shape from compression artifacts across all four prepared photos.
+    image_url: { url: dataUrl, detail: "high" as const },
   }));
   const userContent: ChatContentPart[] = [
     { type: "text", text: userText },

--- a/functions/src/scan/physiqueScores.ts
+++ b/functions/src/scan/physiqueScores.ts
@@ -1,0 +1,38 @@
+export const PHYSIQUE_SCORE_KEYS = [
+  "chest",
+  "back",
+  "shoulders",
+  "arms",
+  "core",
+  "legs",
+] as const;
+
+export type PhysiqueScoreKey = (typeof PHYSIQUE_SCORE_KEYS)[number];
+export type PhysiqueScores = Partial<Record<PhysiqueScoreKey, number>>;
+
+/**
+ * Accept explicit visual-development scores only. The scan model may omit any
+ * region it cannot assess reliably. This helper never manufactures a score
+ * from prose or from another body-composition measurement.
+ */
+export function sanitizePhysiqueScores(value: unknown): PhysiqueScores {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const source = value as Record<string, unknown>;
+  const result: PhysiqueScores = {};
+
+  for (const key of PHYSIQUE_SCORE_KEYS) {
+    const raw = source[key];
+    if (typeof raw !== "number") continue;
+    if (!Number.isFinite(raw)) continue;
+    result[key] = Math.round(Math.min(100, Math.max(0, raw)));
+  }
+
+  return result;
+}
+
+export const PHYSIQUE_SCORE_MODEL_INSTRUCTION = [
+  "Optionally score visible muscular development for chest, back, shoulders, arms, core, and legs from 0 to 100.",
+  "Scores describe only visible development and balance in these four photos; they are not strength, health, diagnosis, body-fat distribution, or exact muscle-mass measurements.",
+  "Use all four views. Omit a region when clothing, pose, crop, or image quality makes it unreliable.",
+  "Apply the same conservative visual rubric across scans so the score is useful mainly as a personal progress trend.",
+].join(" ");

--- a/functions/src/scan/worker.ts
+++ b/functions/src/scan/worker.ts
@@ -29,6 +29,7 @@ import {
   isSaneWeightKg,
   normalizeScanStatus,
 } from "./contract.js";
+import type { PhysiqueScores } from "./physiqueScores.js";
 
 const db = getFirestore();
 const serverTimestamp = (): FirebaseFirestore.Timestamp =>
@@ -51,7 +52,31 @@ function bmiCategory(bmi: number): string | null {
   return "Obesity III";
 }
 
-export function deriveDeterministicWorkoutPlan(profile: any): ScanWorkoutPlan {
+export function deriveDeterministicWorkoutPlan(
+  profile: any,
+  physiqueScores: PhysiqueScores = {}
+): ScanWorkoutPlan {
+  const scoreLabels: Record<keyof PhysiqueScores, string> = {
+    chest: "chest",
+    back: "back",
+    shoulders: "shoulders",
+    arms: "arms",
+    core: "core",
+    legs: "legs",
+  };
+  const scoredRegions = Object.entries(physiqueScores)
+    .filter(
+      (entry): entry is [keyof PhysiqueScores, number] =>
+        typeof entry[1] === "number" && Number.isFinite(entry[1])
+    )
+    .sort((a, b) => a[1] - b[1]);
+  // A sparse score is too easy to over-interpret. Only adapt a plan when at
+  // least four regions were visible enough for a balanced comparison.
+  const priorityRegions =
+    scoredRegions.length >= 4 ? scoredRegions.slice(0, 2) : [];
+  const prioritySummary = priorityRegions.length
+    ? priorityRegions.map(([key]) => scoreLabels[key]).join(" and ")
+    : null;
   const requested = Number(
     profile?.training_days_per_week ??
       profile?.trainingDaysPerWeek ??
@@ -188,7 +213,7 @@ export function deriveDeterministicWorkoutPlan(profile: any): ScanWorkoutPlan {
         ? "full-body plan"
         : "upper/lower balanced split";
   return {
-    summary: `${daysPerWeek}-day ${structureName} based on your available training frequency${goal ? ` and ${goal.replace(/_/g, " ")} goal` : ""} (${experience} level)${equipment.size ? " using your available equipment" : ""}.`,
+    summary: `${daysPerWeek}-day ${structureName} based on your available training frequency${goal ? ` and ${goal.replace(/_/g, " ")} goal` : ""} (${experience} level)${equipment.size ? " using your available equipment" : ""}${prioritySummary ? `, with modest extra volume for ${prioritySummary}` : ""}.`,
     progressionRules: [
       "Leave 2-3 repetitions in reserve while learning each movement.",
       "Add repetitions before increasing load by 2-5%.",
@@ -196,6 +221,11 @@ export function deriveDeterministicWorkoutPlan(profile: any): ScanWorkoutPlan {
       ...(injuries.length
         ? [
             "Use conservative exercise selection around the limitations listed in your profile.",
+          ]
+        : []),
+      ...(prioritySummary
+        ? [
+            `Use the photo-based development profile only to prioritize a small amount of additional ${prioritySummary} training volume; reassess with consistent future scans.`,
           ]
         : []),
     ],
@@ -573,7 +603,10 @@ export const processQueuedScan = onDocumentWritten(
         bodyFatPercent: analysis.estimate.bodyFatPercent,
         profile,
       });
-      const workoutPlan = deriveDeterministicWorkoutPlan(profile);
+      const workoutPlan = deriveDeterministicWorkoutPlan(
+        profile,
+        analysis.estimate.physiqueScores ?? {}
+      );
 
       await scanRef.set(
         {
@@ -616,6 +649,7 @@ export const processQueuedScan = onDocumentWritten(
             heightCm: heightOk,
             bodyFatEstimate: bfRange,
             ...(analysis.estimate.visualObservations ?? {}),
+            physiqueScores: analysis.estimate.physiqueScores ?? null,
           },
           usedFallback: false,
           resultSource: "ai",

--- a/functions/src/types.ts
+++ b/functions/src/types.ts
@@ -9,6 +9,10 @@ export interface ScanEstimate {
   bmiCategory?: string | null;
   keyObservations?: string[];
   goalRecommendations?: string[];
+  /** Optional photo-based development scores; omitted when a region is unclear. */
+  physiqueScores?: Partial<
+    Record<"chest" | "back" | "shoulders" | "arms" | "core" | "legs", number>
+  >;
   /** Cautious, photo-based qualitative observations. Never numeric or diagnostic. */
   visualObservations?: {
     muscularDevelopment?: string;

--- a/functions/test/apiRoutes.test.js
+++ b/functions/test/apiRoutes.test.js
@@ -106,7 +106,7 @@ test("api preflight allows every header sent by the native client", async () => 
   }
 });
 
-test("WHOOP callback remains reachable when App Check is strict", async () => {
+test("deferred WHOOP callback is not publicly exposed", async () => {
   const previous = process.env.APP_CHECK_MODE;
   process.env.APP_CHECK_MODE = "strict";
   const server = http.createServer(apiAppForTest);
@@ -119,11 +119,7 @@ test("WHOOP callback remains reachable when App Check is strict", async () => {
       `${base}/api/health/whoop/callback?error=access_denied&state=12345678`,
       { redirect: "manual" }
     );
-    assert.equal(res.status, 302);
-    const location = new URL(res.headers.get("location"));
-    assert.equal(location.origin, "https://mybodyscanapp.com");
-    assert.equal(location.pathname, "/settings/health");
-    assert.equal(location.searchParams.get("whoop"), "error");
+    assert.equal(res.status, 403);
   } finally {
     if (previous == null) delete process.env.APP_CHECK_MODE;
     else process.env.APP_CHECK_MODE = previous;

--- a/functions/test/apiRoutes.test.js
+++ b/functions/test/apiRoutes.test.js
@@ -105,3 +105,28 @@ test("api preflight allows every header sent by the native client", async () => 
     await new Promise((resolve) => server.close(resolve));
   }
 });
+
+test("WHOOP callback remains reachable when App Check is strict", async () => {
+  const previous = process.env.APP_CHECK_MODE;
+  process.env.APP_CHECK_MODE = "strict";
+  const server = http.createServer(apiAppForTest);
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const base = `http://127.0.0.1:${address.port}`;
+
+  try {
+    const res = await fetch(
+      `${base}/api/health/whoop/callback?error=access_denied&state=12345678`,
+      { redirect: "manual" }
+    );
+    assert.equal(res.status, 302);
+    const location = new URL(res.headers.get("location"));
+    assert.equal(location.origin, "https://mybodyscanapp.com");
+    assert.equal(location.pathname, "/settings/health");
+    assert.equal(location.searchParams.get("whoop"), "error");
+  } finally {
+    if (previous == null) delete process.env.APP_CHECK_MODE;
+    else process.env.APP_CHECK_MODE = previous;
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/functions/test/apiSecrets.test.js
+++ b/functions/test/apiSecrets.test.js
@@ -3,7 +3,7 @@ import test from "node:test";
 
 import { api } from "../lib/index.js";
 
-test("aggregate API binds every router runtime secret", () => {
+test("aggregate API binds only launch-enabled router secrets", () => {
   const secretKeys = (api.__endpoint?.secretEnvironmentVariables ?? [])
     .map((entry) => entry.key)
     .sort();
@@ -13,7 +13,5 @@ test("aggregate API binds every router runtime secret", () => {
     "STRIPE_SECRET",
     "STRIPE_SECRET_KEY",
     "USDA_FDC_API_KEY",
-    "WHOOP_CLIENT_ID",
-    "WHOOP_CLIENT_SECRET",
   ]);
 });

--- a/functions/test/apiSecrets.test.js
+++ b/functions/test/apiSecrets.test.js
@@ -13,5 +13,7 @@ test("aggregate API binds every router runtime secret", () => {
     "STRIPE_SECRET",
     "STRIPE_SECRET_KEY",
     "USDA_FDC_API_KEY",
+    "WHOOP_CLIENT_ID",
+    "WHOOP_CLIENT_SECRET",
   ]);
 });

--- a/functions/test/physiqueScores.test.js
+++ b/functions/test/physiqueScores.test.js
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { sanitizePhysiqueScores } from "../lib/scan/physiqueScores.js";
+
+test("server accepts only explicit numeric first-party physique scores", () => {
+  assert.deepEqual(
+    sanitizePhysiqueScores({
+      chest: 71.6,
+      back: 79,
+      shoulders: 101,
+      arms: -2,
+      core: "strong",
+      legs: null,
+      bodyFat: 12,
+    }),
+    { chest: 72, back: 79, shoulders: 100, arms: 0 }
+  );
+});
+
+test("server never converts qualitative observations into numeric scores", () => {
+  assert.deepEqual(
+    sanitizePhysiqueScores({
+      chest: "priority",
+      back: "well developed",
+      shoulders: "balanced",
+    }),
+    {}
+  );
+});

--- a/functions/test/scanAnalysisDeterministic.test.js
+++ b/functions/test/scanAnalysisDeterministic.test.js
@@ -98,7 +98,10 @@ test("unsafe legacy observation fields cannot leak into saved plan text", () => 
     ],
   });
 
-  assert.equal(analysis.estimate.notes, "Visual estimate only. Not medical advice.");
+  assert.equal(
+    analysis.estimate.notes,
+    "Visual estimate only. Not medical advice."
+  );
   assert.deepEqual(analysis.estimate.keyObservations, [
     "Balanced upper-body development is visible.",
   ]);
@@ -194,6 +197,28 @@ test("five-day beginners receive a balanced strength and recovery schedule", () 
     ]
   );
   assert.match(plan.summary, /mixed strength, conditioning, and recovery/i);
+});
+
+test("physique scores add conservative priorities only when the scan is sufficiently complete", () => {
+  const complete = deriveDeterministicWorkoutPlan(
+    { training_days_per_week: 3 },
+    { chest: 62, back: 58, shoulders: 71, arms: 67, core: 49, legs: 74 }
+  );
+  assert.match(complete.summary, /core and back/i);
+  assert.match(
+    complete.progressionRules.join(" "),
+    /additional core and back/i
+  );
+
+  const sparse = deriveDeterministicWorkoutPlan(
+    { training_days_per_week: 3 },
+    { chest: 42, legs: 70 }
+  );
+  assert.doesNotMatch(sparse.summary, /priority/i);
+  assert.doesNotMatch(
+    sparse.progressionRules.join(" "),
+    /additional .* volume/i
+  );
 });
 
 test("successful plan markdown never labels the estimate as fallback", () => {

--- a/functions/test/whoopFoundation.test.js
+++ b/functions/test/whoopFoundation.test.js
@@ -15,7 +15,6 @@ test("WHOOP remains unavailable until every server credential is present", () =>
     getWhoopReadiness({
       WHOOP_CLIENT_ID: "client",
       WHOOP_CLIENT_SECRET: "secret",
-      WHOOP_REDIRECT_URI: "https://mybodyscanapp.com/api/health/whoop/callback",
     }),
     { configured: true, reason: "ready" }
   );

--- a/functions/test/whoopFoundation.test.js
+++ b/functions/test/whoopFoundation.test.js
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildWhoopAuthorizationUrl,
+  getWhoopReadiness,
+  normalizeWhoopRecovery,
+} from "../lib/health/whoop.js";
+
+test("WHOOP remains unavailable until every server credential is present", () => {
+  assert.deepEqual(getWhoopReadiness({}), {
+    configured: false,
+    reason: "missing_client_id",
+  });
+  assert.deepEqual(
+    getWhoopReadiness({
+      WHOOP_CLIENT_ID: "client",
+      WHOOP_CLIENT_SECRET: "secret",
+      WHOOP_REDIRECT_URI: "https://mybodyscanapp.com/api/health/whoop/callback",
+    }),
+    { configured: true, reason: "ready" }
+  );
+});
+
+test("WHOOP authorization uses read-only recovery scopes and CSRF state", () => {
+  const url = new URL(
+    buildWhoopAuthorizationUrl({
+      clientId: "client-id",
+      redirectUri: "https://mybodyscanapp.com/api/health/whoop/callback",
+      state: "12345678",
+    })
+  );
+  assert.equal(url.searchParams.get("response_type"), "code");
+  assert.equal(url.searchParams.get("state"), "12345678");
+  const scope = url.searchParams.get("scope") || "";
+  assert.match(scope, /offline/);
+  assert.match(scope, /read:recovery/);
+  assert.match(scope, /read:sleep/);
+  assert.doesNotMatch(scope, /write:/);
+});
+
+test("WHOOP recovery normalization keeps only coaching-relevant numeric fields", () => {
+  assert.deepEqual(
+    normalizeWhoopRecovery(
+      {
+        score: {
+          recovery_score: 82,
+          resting_heart_rate: 51,
+          hrv_rmssd_milli: 67.4,
+          skin_temp_celsius: 33.2,
+        },
+      },
+      "2026-08-09"
+    ),
+    {
+      date: "2026-08-09",
+      recoveryScore: 82,
+      restingHeartRate: 51,
+      hrvRmssdMs: 67.4,
+      source: "whoop",
+    }
+  );
+});

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -66,6 +66,12 @@
         optional transformation-preview images.
       </li>
       <li>
+        <strong>Connected health-provider information:</strong> when you choose
+        to connect a supported provider, the limited activity, sleep, workout,
+        heart-rate, and recovery fields you authorize, plus connection and sync
+        status. Provider access and refresh tokens are kept server-side.
+      </li>
+      <li>
         <strong>Device and usage information:</strong> app version,
         device/browser type, IP-derived security information, crash and
         performance diagnostics, feature interactions, and push-notification
@@ -110,6 +116,11 @@
       <li>
         Send service notices and, only when you opt in, progress or plateau
         notifications.
+      </li>
+      <li>
+        Use health-provider data you explicitly connect to add recovery and
+        activity context to your plan. Health-provider data is not used for
+        advertising.
       </li>
       <li>Comply with law and enforce our Terms of Service.</li>
     </ul>
@@ -166,6 +177,11 @@
       <li>
         Control optional notifications in Settings and your browser or device
         settings.
+      </li>
+      <li>
+        Connect or disconnect supported health providers in Health settings.
+        Disconnecting revokes provider access where supported and removes
+        MyBodyScan's stored provider token.
       </li>
       <li>
         Contact us to request access, correction, deletion, or export where

--- a/src/components/scan/PhysiqueDevelopmentScores.tsx
+++ b/src/components/scan/PhysiqueDevelopmentScores.tsx
@@ -15,9 +15,14 @@ export function PhysiqueDevelopmentScores({ scores }: Props) {
   const items = physiqueScoreItems(scores);
   if (!items.length) return null;
 
-  const overall = physiqueOverallScore(scores);
-  const priorities = physiquePriorityAreas(scores, 2);
-  const strengths = physiqueStrengthAreas(scores, 2);
+  const hasBalancedComparison = items.length >= 4;
+  const overall = hasBalancedComparison ? physiqueOverallScore(scores) : null;
+  const priorities = hasBalancedComparison
+    ? physiquePriorityAreas(scores, 2)
+    : [];
+  const strengths = hasBalancedComparison
+    ? physiqueStrengthAreas(scores, 2)
+    : [];
 
   return (
     <section
@@ -28,29 +33,44 @@ export function PhysiqueDevelopmentScores({ scores }: Props) {
         <div>
           <div className="flex items-center gap-2 text-cyan-300">
             <Target className="h-4 w-4" aria-hidden="true" />
-            <p className="text-xs uppercase tracking-widest">Development profile</p>
+            <p className="text-xs uppercase tracking-widest">
+              Development profile
+            </p>
           </div>
-          <h2 id="physique-development-heading" className="mt-2 text-xl font-semibold">
+          <h2
+            id="physique-development-heading"
+            className="mt-2 text-xl font-semibold"
+          >
             Physique development
           </h2>
           <p className="mt-1 max-w-2xl text-sm text-zinc-400">
-            A consistent visual rubric across your scan photos helps highlight relative strengths and training priorities over time.
+            A consistent visual rubric across your scan photos helps highlight
+            relative strengths and training priorities over time.
           </p>
         </div>
         {overall != null ? (
           <div className="min-w-20 rounded-2xl border border-white/10 bg-black/20 p-3 text-center">
-            <div className="text-2xl font-semibold text-cyan-200">{overall}</div>
-            <div className="text-[10px] uppercase tracking-wider text-zinc-500">Overall</div>
+            <div className="text-2xl font-semibold text-cyan-200">
+              {overall}
+            </div>
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">
+              Overall
+            </div>
           </div>
         ) : null}
       </div>
 
       <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {items.map((item) => (
-          <div key={item.key} className="rounded-2xl border border-white/10 bg-black/10 p-4">
+          <div
+            key={item.key}
+            className="rounded-2xl border border-white/10 bg-black/10 p-4"
+          >
             <div className="flex items-center justify-between gap-3 text-sm">
               <span className="font-medium">{item.label}</span>
-              <span className="font-semibold tabular-nums text-cyan-200">{item.score}</span>
+              <span className="font-semibold tabular-nums text-cyan-200">
+                {item.score}
+              </span>
             </div>
             <div
               className="mt-3 h-2 overflow-hidden rounded-full bg-white/10"
@@ -72,19 +92,29 @@ export function PhysiqueDevelopmentScores({ scores }: Props) {
       <div className="mt-5 grid gap-3 sm:grid-cols-2">
         {strengths.length ? (
           <div className="rounded-xl border border-white/10 p-3 text-sm">
-            <p className="text-xs uppercase tracking-wider text-zinc-500">Current strengths</p>
-            <p className="mt-1">{strengths.map((item) => item.label).join(" · ")}</p>
+            <p className="text-xs uppercase tracking-wider text-zinc-500">
+              Current strengths
+            </p>
+            <p className="mt-1">
+              {strengths.map((item) => item.label).join(" · ")}
+            </p>
           </div>
         ) : null}
         {priorities.length ? (
           <div className="rounded-xl border border-white/10 p-3 text-sm">
-            <p className="text-xs uppercase tracking-wider text-zinc-500">Training priorities</p>
-            <p className="mt-1">{priorities.map((item) => item.label).join(" · ")}</p>
+            <p className="text-xs uppercase tracking-wider text-zinc-500">
+              Training priorities
+            </p>
+            <p className="mt-1">
+              {priorities.map((item) => item.label).join(" · ")}
+            </p>
           </div>
         ) : null}
       </div>
 
-      <p className="mt-4 text-xs leading-5 text-zinc-500">{PHYSIQUE_SCORE_DISCLOSURE}</p>
+      <p className="mt-4 text-xs leading-5 text-zinc-500">
+        {PHYSIQUE_SCORE_DISCLOSURE}
+      </p>
     </section>
   );
 }

--- a/src/components/scan/PhysiqueDevelopmentScores.tsx
+++ b/src/components/scan/PhysiqueDevelopmentScores.tsx
@@ -1,0 +1,90 @@
+import { Target } from "lucide-react";
+import {
+  PHYSIQUE_SCORE_DISCLOSURE,
+  physiqueOverallScore,
+  physiquePriorityAreas,
+  physiqueScoreItems,
+  physiqueStrengthAreas,
+} from "@/lib/physiqueScores";
+
+type Props = {
+  scores: unknown;
+};
+
+export function PhysiqueDevelopmentScores({ scores }: Props) {
+  const items = physiqueScoreItems(scores);
+  if (!items.length) return null;
+
+  const overall = physiqueOverallScore(scores);
+  const priorities = physiquePriorityAreas(scores, 2);
+  const strengths = physiqueStrengthAreas(scores, 2);
+
+  return (
+    <section
+      className="rounded-3xl border border-cyan-400/20 bg-cyan-400/[0.04] p-5 md:p-6"
+      aria-labelledby="physique-development-heading"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2 text-cyan-300">
+            <Target className="h-4 w-4" aria-hidden="true" />
+            <p className="text-xs uppercase tracking-widest">Development profile</p>
+          </div>
+          <h2 id="physique-development-heading" className="mt-2 text-xl font-semibold">
+            Physique development
+          </h2>
+          <p className="mt-1 max-w-2xl text-sm text-zinc-400">
+            A consistent visual rubric across your scan photos helps highlight relative strengths and training priorities over time.
+          </p>
+        </div>
+        {overall != null ? (
+          <div className="min-w-20 rounded-2xl border border-white/10 bg-black/20 p-3 text-center">
+            <div className="text-2xl font-semibold text-cyan-200">{overall}</div>
+            <div className="text-[10px] uppercase tracking-wider text-zinc-500">Overall</div>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((item) => (
+          <div key={item.key} className="rounded-2xl border border-white/10 bg-black/10 p-4">
+            <div className="flex items-center justify-between gap-3 text-sm">
+              <span className="font-medium">{item.label}</span>
+              <span className="font-semibold tabular-nums text-cyan-200">{item.score}</span>
+            </div>
+            <div
+              className="mt-3 h-2 overflow-hidden rounded-full bg-white/10"
+              role="progressbar"
+              aria-label={`${item.label} development score`}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-valuenow={item.score}
+            >
+              <div
+                className="h-full rounded-full bg-cyan-300"
+                style={{ width: `${item.score}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-5 grid gap-3 sm:grid-cols-2">
+        {strengths.length ? (
+          <div className="rounded-xl border border-white/10 p-3 text-sm">
+            <p className="text-xs uppercase tracking-wider text-zinc-500">Current strengths</p>
+            <p className="mt-1">{strengths.map((item) => item.label).join(" · ")}</p>
+          </div>
+        ) : null}
+        {priorities.length ? (
+          <div className="rounded-xl border border-white/10 p-3 text-sm">
+            <p className="text-xs uppercase tracking-wider text-zinc-500">Training priorities</p>
+            <p className="mt-1">{priorities.map((item) => item.label).join(" · ")}</p>
+          </div>
+        ) : null}
+      </div>
+
+      <p className="mt-4 text-xs leading-5 text-zinc-500">{PHYSIQUE_SCORE_DISCLOSURE}</p>
+    </section>
+  );
+}

--- a/src/content/legal/privacy.md
+++ b/src/content/legal/privacy.md
@@ -9,6 +9,7 @@ MyBodyScan is operated by ADLR Labs ("MyBodyScan," "we," "us," or "our"). This P
 - **Account and contact information:** your email address, display name, authentication provider, and messages you send to support.
 - **Scan media and wellness information you provide:** body photos, goals, preferences, equipment, allergy and dietary-restriction selections, workout and meal logs, weekly recovery check-ins, custom foods and recipes, and other information you choose to enter.
 - **Results and generated content:** scan estimates, visual observations, calculated values, plans, check-ins, food insights, and optional transformation-preview images.
+- **Connected health-provider information:** when you choose to connect a supported provider, the limited activity, sleep, workout, heart-rate, and recovery fields you authorize, along with connection and sync status. Provider access and refresh tokens are kept server-side.
 - **Device and usage information:** app version, device/browser type, IP-derived security information, crash and performance diagnostics, feature interactions, and push-notification tokens when you opt in.
 - **Purchase information:** products purchased, subscription status, credit balance, transaction identifiers, and limited billing metadata. Payment processors handle full payment-card details; MyBodyScan does not store full card numbers.
 
@@ -18,6 +19,7 @@ MyBodyScan is operated by ADLR Labs ("MyBodyScan," "we," "us," or "our"). This P
 - Process purchases, maintain credits and subscriptions, and prevent duplicate charges or credit use.
 - Secure, troubleshoot, measure, and improve the service, including fraud and abuse prevention.
 - Send service notices and, only when you opt in, progress or plateau notifications. You can turn optional notifications off in Settings or your device settings.
+- Use health-provider data you explicitly connect to add recovery and activity context to your plan. Health-provider data is not used for advertising.
 - Comply with law and enforce our Terms of Service.
 
 Allergy preferences and weekly recovery check-ins are treated as sensitive wellness information. They are used to personalize your experience and safety notices, not for targeted advertising.
@@ -52,6 +54,7 @@ Before deleting your account, export any history you want to keep. Deletion is i
 - Review or update available profile, plan, scan, meal, and workout information in the app.
 - Delete scans or your account using the available Settings controls.
 - Control optional notifications in Settings and your browser or device settings.
+- Connect or disconnect supported health providers in Health settings. Disconnecting revokes provider access where supported and removes MyBodyScan's stored provider token.
 - Contact support@mybodyscanapp.com to request access, correction, deletion, or export where applicable.
 
 Depending on where you live, privacy law may provide additional rights, including rights to object to or restrict processing and to appeal or complain to a regulator. We may need to verify your identity before completing a request.

--- a/src/features/workouts/VoiceWorkoutLogger.tsx
+++ b/src/features/workouts/VoiceWorkoutLogger.tsx
@@ -88,11 +88,15 @@ export function VoiceWorkoutLogger({
 
   const apply = async () => {
     if (!parsed) {
-      setMessage('Try “bench press 225 for 8” or “squat 3 sets of 5 at 315 pounds.”');
+      setMessage(
+        "Try “bench press 225 for 8” or “squat 3 sets of 5 at 315 pounds.”"
+      );
       return;
     }
     if (!match) {
-      setMessage(`I heard “${parsed.exercise},” but it does not uniquely match today’s exercises.`);
+      setMessage(
+        `I heard “${parsed.exercise},” but it does not uniquely match today’s exercises.`
+      );
       return;
     }
     const load =
@@ -102,9 +106,22 @@ export function VoiceWorkoutLogger({
     await onApply({
       exerciseId: match.id,
       load,
-      repsDone: parsed.reps == null ? null : String(parsed.reps),
+      repsDone:
+        parsed.reps == null
+          ? null
+          : parsed.sets == null
+            ? String(parsed.reps)
+            : `${parsed.sets}×${parsed.reps}`,
     });
-    setMessage(`Logged ${match.name || parsed.exercise}${load ? ` · ${load}` : ""}${parsed.reps ? ` · ${parsed.reps} reps` : ""}.`);
+    const completed =
+      parsed.reps == null
+        ? ""
+        : parsed.sets == null
+          ? `${parsed.reps} reps`
+          : `${parsed.sets}×${parsed.reps}`;
+    setMessage(
+      `Logged ${match.name || parsed.exercise}${load ? ` · ${load}` : ""}${completed ? ` · ${completed}` : ""}.`
+    );
     setTranscript("");
   };
 
@@ -139,7 +156,11 @@ export function VoiceWorkoutLogger({
               disabled={disabled}
               aria-label={listening ? "Stop listening" : "Log set by voice"}
             >
-              {listening ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+              {listening ? (
+                <MicOff className="h-4 w-4" />
+              ) : (
+                <Mic className="h-4 w-4" />
+              )}
             </Button>
           ) : null}
         </div>
@@ -147,9 +168,11 @@ export function VoiceWorkoutLogger({
           <div className="rounded-lg border bg-background/70 p-3 text-sm">
             <p className="font-medium">{match.name || parsed.exercise}</p>
             <p className="text-muted-foreground">
-              {parsed.weight != null ? `${parsed.weight} ${parsed.unit ?? defaultUnit}` : "Bodyweight / no load"}
+              {parsed.weight != null
+                ? `${parsed.weight} ${parsed.unit ?? defaultUnit}`
+                : "Bodyweight / no load"}
               {parsed.reps != null ? ` · ${parsed.reps} reps` : ""}
-              {parsed.sets != null ? ` · ${parsed.sets} sets mentioned` : ""}
+              {parsed.sets != null ? ` · ${parsed.sets} sets` : ""}
             </p>
           </div>
         ) : null}
@@ -163,10 +186,15 @@ export function VoiceWorkoutLogger({
         </Button>
         {!speechSupported ? (
           <p className="text-xs text-muted-foreground">
-            Voice recognition is not available in this browser. The same quick-log phrase can still be typed.
+            Voice recognition is not available in this browser. The same
+            quick-log phrase can still be typed.
           </p>
         ) : null}
-        {message ? <p className="text-xs text-muted-foreground" aria-live="polite">{message}</p> : null}
+        {message ? (
+          <p className="text-xs text-muted-foreground" aria-live="polite">
+            {message}
+          </p>
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/src/features/workouts/VoiceWorkoutLogger.tsx
+++ b/src/features/workouts/VoiceWorkoutLogger.tsx
@@ -1,0 +1,173 @@
+import { useMemo, useRef, useState } from "react";
+import { Check, Mic, MicOff } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import {
+  matchVoiceExercise,
+  parseVoiceWorkoutEntry,
+  type VoiceWorkoutUnit,
+} from "@/lib/voiceWorkout";
+
+type Exercise = { id: string; name?: string };
+
+type Props = {
+  exercises: Exercise[];
+  defaultUnit: VoiceWorkoutUnit;
+  disabled?: boolean;
+  onApply: (args: {
+    exerciseId: string;
+    load: string | null;
+    repsDone: string | null;
+  }) => void | Promise<void>;
+};
+
+type RecognitionLike = {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  start: () => void;
+  stop: () => void;
+  onresult: ((event: any) => void) | null;
+  onerror: ((event: any) => void) | null;
+  onend: (() => void) | null;
+};
+
+export function VoiceWorkoutLogger({
+  exercises,
+  defaultUnit,
+  disabled = false,
+  onApply,
+}: Props) {
+  const [transcript, setTranscript] = useState("");
+  const [listening, setListening] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const recognitionRef = useRef<RecognitionLike | null>(null);
+
+  const speechSupported = useMemo(() => {
+    if (typeof window === "undefined") return false;
+    const w = window as any;
+    return Boolean(w.SpeechRecognition || w.webkitSpeechRecognition);
+  }, []);
+
+  const parsed = useMemo(
+    () => parseVoiceWorkoutEntry(transcript, defaultUnit),
+    [defaultUnit, transcript]
+  );
+  const match = useMemo(
+    () => (parsed ? matchVoiceExercise(parsed, exercises) : null),
+    [exercises, parsed]
+  );
+
+  const beginListening = () => {
+    setMessage(null);
+    if (!speechSupported || disabled || typeof window === "undefined") return;
+    const w = window as any;
+    const Recognition = w.SpeechRecognition || w.webkitSpeechRecognition;
+    const recognition = new Recognition() as RecognitionLike;
+    recognition.lang = "en-US";
+    recognition.interimResults = false;
+    recognition.continuous = false;
+    recognition.onresult = (event: any) => {
+      const next = event?.results?.[0]?.[0]?.transcript;
+      if (typeof next === "string") setTranscript(next.trim());
+    };
+    recognition.onerror = () => {
+      setMessage("Voice input was not captured. Type the set instead.");
+      setListening(false);
+    };
+    recognition.onend = () => setListening(false);
+    recognitionRef.current = recognition;
+    setListening(true);
+    recognition.start();
+  };
+
+  const stopListening = () => {
+    recognitionRef.current?.stop();
+    setListening(false);
+  };
+
+  const apply = async () => {
+    if (!parsed) {
+      setMessage('Try “bench press 225 for 8” or “squat 3 sets of 5 at 315 pounds.”');
+      return;
+    }
+    if (!match) {
+      setMessage(`I heard “${parsed.exercise},” but it does not uniquely match today’s exercises.`);
+      return;
+    }
+    const load =
+      parsed.weight == null
+        ? null
+        : `${parsed.weight}${parsed.unit ? ` ${parsed.unit}` : ""}`;
+    await onApply({
+      exerciseId: match.id,
+      load,
+      repsDone: parsed.reps == null ? null : String(parsed.reps),
+    });
+    setMessage(`Logged ${match.name || parsed.exercise}${load ? ` · ${load}` : ""}${parsed.reps ? ` · ${parsed.reps} reps` : ""}.`);
+    setTranscript("");
+  };
+
+  return (
+    <Card className="border-primary/20 bg-card/60">
+      <CardContent className="space-y-3 p-4">
+        <div>
+          <p className="font-medium">Voice log</p>
+          <p className="text-xs text-muted-foreground">
+            Say a working set, then confirm it before it is saved.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <input
+            className="min-h-11 min-w-0 flex-1 rounded-md border bg-background px-3 text-sm"
+            value={transcript}
+            onChange={(event) => {
+              setTranscript(event.target.value);
+              setMessage(null);
+            }}
+            placeholder={`e.g. bench press ${defaultUnit === "kg" ? "80 kg" : "185 lb"} for 8`}
+            aria-label="Workout voice transcript"
+            disabled={disabled}
+          />
+          {speechSupported ? (
+            <Button
+              type="button"
+              variant={listening ? "destructive" : "outline"}
+              size="icon"
+              className="h-11 w-11 shrink-0"
+              onClick={listening ? stopListening : beginListening}
+              disabled={disabled}
+              aria-label={listening ? "Stop listening" : "Log set by voice"}
+            >
+              {listening ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+            </Button>
+          ) : null}
+        </div>
+        {parsed && match ? (
+          <div className="rounded-lg border bg-background/70 p-3 text-sm">
+            <p className="font-medium">{match.name || parsed.exercise}</p>
+            <p className="text-muted-foreground">
+              {parsed.weight != null ? `${parsed.weight} ${parsed.unit ?? defaultUnit}` : "Bodyweight / no load"}
+              {parsed.reps != null ? ` · ${parsed.reps} reps` : ""}
+              {parsed.sets != null ? ` · ${parsed.sets} sets mentioned` : ""}
+            </p>
+          </div>
+        ) : null}
+        <Button
+          type="button"
+          className="w-full"
+          onClick={() => void apply()}
+          disabled={disabled || !transcript.trim()}
+        >
+          <Check className="mr-2 h-4 w-4" /> Confirm log
+        </Button>
+        {!speechSupported ? (
+          <p className="text-xs text-muted-foreground">
+            Voice recognition is not available in this browser. The same quick-log phrase can still be typed.
+          </p>
+        ) : null}
+        {message ? <p className="text-xs text-muted-foreground" aria-live="polite">{message}</p> : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/api/scan.ts
+++ b/src/lib/api/scan.ts
@@ -28,6 +28,9 @@ export type ScanEstimate = {
   bmiCategory?: string | null;
   keyObservations?: string[];
   goalRecommendations?: string[];
+  physiqueScores?: Partial<
+    Record<"chest" | "back" | "shoulders" | "arms" | "core" | "legs", number>
+  >;
   visualObservations?: {
     muscularDevelopment?: string;
     upperBodyDevelopment?: string;

--- a/src/lib/health/whoop.ts
+++ b/src/lib/health/whoop.ts
@@ -1,0 +1,44 @@
+import { apiFetchJson } from "@/lib/apiFetch";
+
+export type WhoopConnectionStatus = {
+  ok: true;
+  configured: boolean;
+  connected: boolean;
+  connectedAtMs: number | null;
+  lastSyncedAtMs: number | null;
+};
+
+export type WhoopRecovery = {
+  date: string;
+  recoveryScore: number | null;
+  restingHeartRate: number | null;
+  hrvRmssdMs: number | null;
+  source: "whoop";
+};
+
+export function getWhoopStatus(): Promise<WhoopConnectionStatus> {
+  return apiFetchJson("/health/whoop/status", { method: "GET" });
+}
+
+export async function startWhoopConnection(): Promise<string> {
+  const response = await apiFetchJson<{
+    ok: true;
+    authorizationUrl: string;
+  }>("/health/whoop/start", { method: "POST" });
+  if (!response.authorizationUrl.startsWith("https://api.prod.whoop.com/")) {
+    throw new Error("Invalid WHOOP authorization URL.");
+  }
+  return response.authorizationUrl;
+}
+
+export function syncWhoopRecovery(): Promise<{
+  ok: true;
+  recovery: WhoopRecovery | null;
+  lastSyncedAtMs: number;
+}> {
+  return apiFetchJson("/health/whoop/sync", { method: "POST" });
+}
+
+export function disconnectWhoop(): Promise<{ ok: true; connected: false }> {
+  return apiFetchJson("/health/whoop/disconnect", { method: "POST" });
+}

--- a/src/lib/healthShim.ts
+++ b/src/lib/healthShim.ts
@@ -1,7 +1,7 @@
 const TODO_LINK = "https://linear.app/mybodyscan/issue/HEALTH-SHIM";
 
 const NOT_AVAILABLE_ERROR =
-  "Health integrations are not live yet. This screen is gated until Apple Health/Google Fit connectors ship.";
+  "Health integrations are not live yet. This screen is gated until Apple Health, Health Connect, and approved direct connectors are ready.";
 
 function logShim(method: string) {
   console.info(
@@ -12,6 +12,7 @@ function logShim(method: string) {
 export type HealthProvider =
   | "apple-health"
   | "google-health-connect"
+  | "whoop"
   | "manual";
 
 /**

--- a/src/lib/physiqueScores.ts
+++ b/src/lib/physiqueScores.ts
@@ -1,0 +1,93 @@
+export const PHYSIQUE_SCORE_KEYS = [
+  "chest",
+  "back",
+  "shoulders",
+  "arms",
+  "core",
+  "legs",
+] as const;
+
+export type PhysiqueScoreKey = (typeof PHYSIQUE_SCORE_KEYS)[number];
+
+export type PhysiqueScores = Partial<Record<PhysiqueScoreKey, number>>;
+
+export type PhysiqueScoreItem = {
+  key: PhysiqueScoreKey;
+  label: string;
+  score: number;
+};
+
+export const PHYSIQUE_SCORE_LABELS: Record<PhysiqueScoreKey, string> = {
+  chest: "Chest",
+  back: "Back",
+  shoulders: "Shoulders",
+  arms: "Arms",
+  core: "Core",
+  legs: "Legs",
+};
+
+function finiteScore(value: unknown): number | null {
+  if (typeof value !== "number" && typeof value !== "string") return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.round(Math.min(100, Math.max(0, parsed)));
+}
+
+/**
+ * Normalizes explicit photo-based development scores only.
+ *
+ * This deliberately does not infer a numeric score from qualitative prose. A
+ * score must come from an explicit scoring field produced by the scan pipeline.
+ */
+export function normalizePhysiqueScores(value: unknown): PhysiqueScores {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const source = value as Record<string, unknown>;
+  const normalized: PhysiqueScores = {};
+
+  for (const key of PHYSIQUE_SCORE_KEYS) {
+    const score = finiteScore(source[key]);
+    if (score != null) normalized[key] = score;
+  }
+
+  return normalized;
+}
+
+export function physiqueScoreItems(value: unknown): PhysiqueScoreItem[] {
+  const scores = normalizePhysiqueScores(value);
+  return PHYSIQUE_SCORE_KEYS.flatMap((key) => {
+    const score = scores[key];
+    return score == null
+      ? []
+      : [{ key, label: PHYSIQUE_SCORE_LABELS[key], score }];
+  });
+}
+
+export function physiquePriorityAreas(
+  value: unknown,
+  limit = 2
+): PhysiqueScoreItem[] {
+  return physiqueScoreItems(value)
+    .sort((a, b) => a.score - b.score || a.label.localeCompare(b.label))
+    .slice(0, Math.max(0, limit));
+}
+
+export function physiqueStrengthAreas(
+  value: unknown,
+  limit = 2
+): PhysiqueScoreItem[] {
+  return physiqueScoreItems(value)
+    .sort((a, b) => b.score - a.score || a.label.localeCompare(b.label))
+    .slice(0, Math.max(0, limit));
+}
+
+export function physiqueOverallScore(value: unknown): number | null {
+  const items = physiqueScoreItems(value);
+  // Avoid presenting an overall score from a sparse scan.
+  if (items.length < 4) return null;
+  return Math.round(
+    items.reduce((sum, item) => sum + item.score, 0) / items.length
+  );
+}
+
+export const PHYSIQUE_SCORE_DISCLOSURE =
+  "Photo-based development score for progress tracking. It is not a strength, medical, or diagnostic measurement.";

--- a/src/lib/voiceWorkout.ts
+++ b/src/lib/voiceWorkout.ts
@@ -1,0 +1,153 @@
+export type VoiceWorkoutUnit = "lb" | "kg";
+
+export type VoiceWorkoutEntry = {
+  exercise: string;
+  weight: number | null;
+  reps: number | null;
+  sets: number | null;
+  unit: VoiceWorkoutUnit | null;
+  confidence: "high" | "medium" | "low";
+  transcript: string;
+};
+
+const UNIT_ALIASES: Record<string, VoiceWorkoutUnit> = {
+  lb: "lb",
+  lbs: "lb",
+  pound: "lb",
+  pounds: "lb",
+  kg: "kg",
+  kgs: "kg",
+  kilogram: "kg",
+  kilograms: "kg",
+};
+
+function cleanExercise(value: string): string {
+  return value
+    .replace(/\b(?:at|with|for|x)\b\s*$/i, "")
+    .replace(/[,:;-]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function finitePositive(value: string | undefined): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function parseUnit(value: string | undefined): VoiceWorkoutUnit | null {
+  if (!value) return null;
+  return UNIT_ALIASES[value.toLowerCase()] ?? null;
+}
+
+/**
+ * Parses common gym phrases without calling a model, so voice logging remains
+ * fast, predictable, and cheap. Speech-to-text can feed this function on any
+ * supported platform.
+ *
+ * Examples:
+ * - "bench press 225 for 8"
+ * - "bench press 225 pounds for 8 reps"
+ * - "squat 3 sets of 5 at 315 pounds"
+ * - "deadlift 180 kg x 5"
+ */
+export function parseVoiceWorkoutEntry(
+  transcript: string,
+  defaultUnit?: VoiceWorkoutUnit
+): VoiceWorkoutEntry | null {
+  const raw = transcript.replace(/\s+/g, " ").trim();
+  if (!raw) return null;
+
+  const setFirst = raw.match(
+    /^(.+?)\s+(\d+)\s+sets?\s+(?:of\s+)?(\d+)\s+(?:reps?\s+)?(?:at|with)\s+(\d+(?:\.\d+)?)\s*(lb|lbs|pounds?|kg|kgs|kilograms?)?$/i
+  );
+  if (setFirst) {
+    const exercise = cleanExercise(setFirst[1]);
+    if (!exercise) return null;
+    return {
+      exercise,
+      sets: finitePositive(setFirst[2]),
+      reps: finitePositive(setFirst[3]),
+      weight: finitePositive(setFirst[4]),
+      unit: parseUnit(setFirst[5]) ?? defaultUnit ?? null,
+      confidence: "high",
+      transcript: raw,
+    };
+  }
+
+  const weightThenReps = raw.match(
+    /^(.+?)\s+(\d+(?:\.\d+)?)\s*(lb|lbs|pounds?|kg|kgs|kilograms?)?\s+(?:for|x)\s+(\d+)\s*(?:reps?)?$/i
+  );
+  if (weightThenReps) {
+    const exercise = cleanExercise(weightThenReps[1]);
+    if (!exercise) return null;
+    return {
+      exercise,
+      sets: null,
+      reps: finitePositive(weightThenReps[4]),
+      weight: finitePositive(weightThenReps[2]),
+      unit: parseUnit(weightThenReps[3]) ?? defaultUnit ?? null,
+      confidence: "high",
+      transcript: raw,
+    };
+  }
+
+  const repsAtWeight = raw.match(
+    /^(.+?)\s+(\d+)\s+reps?\s+(?:at|with)\s+(\d+(?:\.\d+)?)\s*(lb|lbs|pounds?|kg|kgs|kilograms?)?$/i
+  );
+  if (repsAtWeight) {
+    const exercise = cleanExercise(repsAtWeight[1]);
+    if (!exercise) return null;
+    return {
+      exercise,
+      sets: null,
+      reps: finitePositive(repsAtWeight[2]),
+      weight: finitePositive(repsAtWeight[3]),
+      unit: parseUnit(repsAtWeight[4]) ?? defaultUnit ?? null,
+      confidence: "high",
+      transcript: raw,
+    };
+  }
+
+  const repsOnly = raw.match(/^(.+?)\s+(?:for\s+)?(\d+)\s+reps?$/i);
+  if (repsOnly) {
+    const exercise = cleanExercise(repsOnly[1]);
+    if (!exercise) return null;
+    return {
+      exercise,
+      sets: null,
+      reps: finitePositive(repsOnly[2]),
+      weight: null,
+      unit: defaultUnit ?? null,
+      confidence: "medium",
+      transcript: raw,
+    };
+  }
+
+  return null;
+}
+
+function normalizeName(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/** Finds the best existing workout exercise rather than creating duplicates. */
+export function matchVoiceExercise<T extends { id: string; name?: string }>(
+  entry: VoiceWorkoutEntry,
+  exercises: T[]
+): T | null {
+  const wanted = normalizeName(entry.exercise);
+  if (!wanted) return null;
+
+  const exact = exercises.find((item) => normalizeName(item.name ?? "") === wanted);
+  if (exact) return exact;
+
+  const contained = exercises.filter((item) => {
+    const candidate = normalizeName(item.name ?? "");
+    return candidate && (candidate.includes(wanted) || wanted.includes(candidate));
+  });
+  return contained.length === 1 ? contained[0] : null;
+}

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -48,6 +48,7 @@ import { formatHeightFromCm, kgToLb } from "@/lib/units";
 import { useEntitlements } from "@/lib/entitlements/store";
 import { hasPro } from "@/lib/entitlements/pro";
 import { isNative } from "@/lib/platform";
+import { PhysiqueDevelopmentScores } from "@/components/scan/PhysiqueDevelopmentScores";
 
 const formatDate = (timestamp: any) => {
   if (!timestamp) return "—";
@@ -693,6 +694,12 @@ const Results = () => {
               </section>
             )}
 
+            {activeScan?.estimate?.physiqueScores ? (
+              <PhysiqueDevelopmentScores
+                scores={activeScan.estimate.physiqueScores}
+              />
+            ) : null}
+
             <section>
               <div className="flex items-center gap-2">
                 <Utensils className="h-5 w-5 text-cyan-300" />
@@ -902,9 +909,9 @@ const Results = () => {
                   calculations.
                 </li>
                 <li>
-                  Body-fat percentage is a photo-based visual wellness
-                  estimate. Lean and fat mass are calculated from weight and
-                  that estimate.
+                  Body-fat percentage is a photo-based visual wellness estimate.
+                  Lean and fat mass are calculated from weight and that
+                  estimate.
                 </li>
                 <li>
                   Nutrition and training guidance come from deterministic app

--- a/src/pages/SettingsHealth.test.tsx
+++ b/src/pages/SettingsHealth.test.tsx
@@ -1,69 +1,15 @@
 // @vitest-environment jsdom
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
 import SettingsHealth from "./SettingsHealth";
 
-const healthMocks = vi.hoisted(() => ({
-  status: vi.fn(),
-  start: vi.fn(),
-  sync: vi.fn(),
-  disconnect: vi.fn(),
-  open: vi.fn(),
-}));
-
-vi.mock("@/lib/health/whoop", () => ({
-  getWhoopStatus: healthMocks.status,
-  startWhoopConnection: healthMocks.start,
-  syncWhoopRecovery: healthMocks.sync,
-  disconnectWhoop: healthMocks.disconnect,
-}));
-
-vi.mock("@/lib/platform", () => ({
-  openExternalUrl: healthMocks.open,
-}));
-
 describe("Health settings", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    window.history.replaceState({}, "", "/settings/health");
-  });
-
-  it("does not offer WHOOP until server configuration is ready", async () => {
-    healthMocks.status.mockResolvedValue({
-      ok: true,
-      configured: false,
-      connected: false,
-      connectedAtMs: null,
-      lastSyncedAtMs: null,
-    });
+  it("shows only the health sources planned for a later release", () => {
     render(<SettingsHealth />);
-    expect(
-      await screen.findByText(/approved WHOOP OAuth client/i)
-    ).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /connect WHOOP/i })).toBeNull();
-  });
-
-  it("opens only the server-issued WHOOP authorization URL", async () => {
-    healthMocks.status.mockResolvedValue({
-      ok: true,
-      configured: true,
-      connected: false,
-      connectedAtMs: null,
-      lastSyncedAtMs: null,
-    });
-    healthMocks.start.mockResolvedValue(
-      "https://api.prod.whoop.com/oauth/oauth2/auth?state=safe-state"
-    );
-    healthMocks.open.mockResolvedValue(undefined);
-    render(<SettingsHealth />);
-    fireEvent.click(
-      await screen.findByRole("button", { name: /connect WHOOP/i })
-    );
-    await waitFor(() =>
-      expect(healthMocks.open).toHaveBeenCalledWith(
-        "https://api.prod.whoop.com/oauth/oauth2/auth?state=safe-state"
-      )
-    );
+    expect(screen.getByText("Apple Health")).toBeTruthy();
+    expect(screen.getByText("Health Connect")).toBeTruthy();
+    expect(screen.queryByText("WHOOP")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
   });
 });

--- a/src/pages/SettingsHealth.test.tsx
+++ b/src/pages/SettingsHealth.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import React from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import SettingsHealth from "./SettingsHealth";
+
+const healthMocks = vi.hoisted(() => ({
+  status: vi.fn(),
+  start: vi.fn(),
+  sync: vi.fn(),
+  disconnect: vi.fn(),
+  open: vi.fn(),
+}));
+
+vi.mock("@/lib/health/whoop", () => ({
+  getWhoopStatus: healthMocks.status,
+  startWhoopConnection: healthMocks.start,
+  syncWhoopRecovery: healthMocks.sync,
+  disconnectWhoop: healthMocks.disconnect,
+}));
+
+vi.mock("@/lib/platform", () => ({
+  openExternalUrl: healthMocks.open,
+}));
+
+describe("Health settings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.history.replaceState({}, "", "/settings/health");
+  });
+
+  it("does not offer WHOOP until server configuration is ready", async () => {
+    healthMocks.status.mockResolvedValue({
+      ok: true,
+      configured: false,
+      connected: false,
+      connectedAtMs: null,
+      lastSyncedAtMs: null,
+    });
+    render(<SettingsHealth />);
+    expect(
+      await screen.findByText(/approved WHOOP OAuth client/i)
+    ).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /connect WHOOP/i })).toBeNull();
+  });
+
+  it("opens only the server-issued WHOOP authorization URL", async () => {
+    healthMocks.status.mockResolvedValue({
+      ok: true,
+      configured: true,
+      connected: false,
+      connectedAtMs: null,
+      lastSyncedAtMs: null,
+    });
+    healthMocks.start.mockResolvedValue(
+      "https://api.prod.whoop.com/oauth/oauth2/auth?state=safe-state"
+    );
+    healthMocks.open.mockResolvedValue(undefined);
+    render(<SettingsHealth />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /connect WHOOP/i })
+    );
+    await waitFor(() =>
+      expect(healthMocks.open).toHaveBeenCalledWith(
+        "https://api.prod.whoop.com/oauth/oauth2/auth?state=safe-state"
+      )
+    );
+  });
+});

--- a/src/pages/SettingsHealth.tsx
+++ b/src/pages/SettingsHealth.tsx
@@ -1,111 +1,8 @@
-import { useCallback, useEffect, useState } from "react";
-import {
-  HeartPulse,
-  Loader2,
-  RefreshCw,
-  Shield,
-  Smartphone,
-  Unplug,
-  Watch,
-} from "lucide-react";
+import { HeartPulse, Shield, Smartphone } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import {
-  disconnectWhoop,
-  getWhoopStatus,
-  startWhoopConnection,
-  syncWhoopRecovery,
-  type WhoopConnectionStatus,
-  type WhoopRecovery,
-} from "@/lib/health/whoop";
-import { openExternalUrl } from "@/lib/platform";
 
 const SettingsHealth = () => {
-  const [whoop, setWhoop] = useState<WhoopConnectionStatus | null>(null);
-  const [whoopBusy, setWhoopBusy] = useState(false);
-  const [whoopError, setWhoopError] = useState<string | null>(null);
-  const [latestRecovery, setLatestRecovery] = useState<WhoopRecovery | null>(
-    null
-  );
-
-  const refreshWhoop = useCallback(async () => {
-    try {
-      const next = await getWhoopStatus();
-      setWhoop(next);
-      setWhoopError(null);
-    } catch {
-      setWhoopError("WHOOP status could not be loaded. Try again shortly.");
-    }
-  }, []);
-
-  useEffect(() => {
-    void refreshWhoop();
-    const onVisible = () => {
-      if (document.visibilityState === "visible") void refreshWhoop();
-    };
-    document.addEventListener("visibilitychange", onVisible);
-    return () => document.removeEventListener("visibilitychange", onVisible);
-  }, [refreshWhoop]);
-
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const result = params.get("whoop");
-    if (result === "connected") {
-      setWhoopError(null);
-      void refreshWhoop();
-    } else if (result === "error") {
-      setWhoopError(
-        "WHOOP authorization was not completed. You can try again."
-      );
-    }
-  }, [refreshWhoop]);
-
-  const connect = async () => {
-    setWhoopBusy(true);
-    setWhoopError(null);
-    try {
-      const authorizationUrl = await startWhoopConnection();
-      await openExternalUrl(authorizationUrl);
-    } catch (error) {
-      setWhoopError(
-        error instanceof Error
-          ? error.message
-          : "WHOOP connection could not be started."
-      );
-    } finally {
-      setWhoopBusy(false);
-    }
-  };
-
-  const sync = async () => {
-    setWhoopBusy(true);
-    setWhoopError(null);
-    try {
-      const result = await syncWhoopRecovery();
-      setLatestRecovery(result.recovery);
-      await refreshWhoop();
-    } catch {
-      setWhoopError("WHOOP recovery could not be synced. Try again shortly.");
-    } finally {
-      setWhoopBusy(false);
-    }
-  };
-
-  const disconnect = async () => {
-    setWhoopBusy(true);
-    setWhoopError(null);
-    try {
-      await disconnectWhoop();
-      setLatestRecovery(null);
-      await refreshWhoop();
-    } catch {
-      setWhoopError("WHOOP could not be disconnected. Try again shortly.");
-    } finally {
-      setWhoopBusy(false);
-    }
-  };
-
   return (
     <div className="space-y-6">
       <div>
@@ -129,96 +26,14 @@ const SettingsHealth = () => {
               <div>
                 <p className="font-medium">Apple Health</p>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Planned primary iPhone health source for activity, heart-rate,
-                  sleep, and recovery context when supported by the device.
+                  Planned iPhone health source for activity, heart-rate, sleep,
+                  and recovery context in a future release.
                 </p>
               </div>
             </div>
-            <Badge variant="secondary" className="shrink-0">
-              Priority
+            <Badge variant="outline" className="shrink-0">
+              Planned
             </Badge>
-          </div>
-
-          <div className="rounded-xl border p-4">
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex min-w-0 items-start gap-3">
-                <Watch className="mt-0.5 h-5 w-5 shrink-0" />
-                <div>
-                  <p className="font-medium">WHOOP</p>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    Add recovery, resting heart rate, and HRV context after you
-                    explicitly authorize read-only access. Provider credentials
-                    and refresh tokens remain on the server.
-                  </p>
-                </div>
-              </div>
-              <Badge
-                variant={whoop?.connected ? "default" : "outline"}
-                className="shrink-0"
-              >
-                {whoop?.connected
-                  ? "Connected"
-                  : whoop?.configured
-                    ? "Available"
-                    : "Planned"}
-              </Badge>
-            </div>
-            <div className="mt-4 flex flex-wrap gap-2 pl-0 sm:pl-8">
-              {!whoop ? (
-                <Button variant="outline" disabled>
-                  <Loader2 className="animate-spin" /> Checking availability
-                </Button>
-              ) : whoop.connected ? (
-                <>
-                  <Button onClick={() => void sync()} disabled={whoopBusy}>
-                    {whoopBusy ? (
-                      <Loader2 className="animate-spin" />
-                    ) : (
-                      <RefreshCw />
-                    )}
-                    Sync recovery
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() => void disconnect()}
-                    disabled={whoopBusy}
-                  >
-                    <Unplug /> Disconnect
-                  </Button>
-                </>
-              ) : whoop.configured ? (
-                <Button onClick={() => void connect()} disabled={whoopBusy}>
-                  {whoopBusy ? <Loader2 className="animate-spin" /> : <Watch />}
-                  Connect WHOOP
-                </Button>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  Connection will appear after the approved WHOOP OAuth client
-                  is configured for MyBodyScan.
-                </p>
-              )}
-            </div>
-            {whoop?.lastSyncedAtMs ? (
-              <p className="mt-3 pl-0 text-xs text-muted-foreground sm:pl-8">
-                Last synced {new Date(whoop.lastSyncedAtMs).toLocaleString()}
-              </p>
-            ) : null}
-            {latestRecovery ? (
-              <p className="mt-2 pl-0 text-sm text-muted-foreground sm:pl-8">
-                Latest recovery: {latestRecovery.recoveryScore ?? "not scored"}
-                {latestRecovery.restingHeartRate != null
-                  ? ` · Resting HR ${latestRecovery.restingHeartRate} bpm`
-                  : ""}
-                {latestRecovery.hrvRmssdMs != null
-                  ? ` · HRV ${Math.round(latestRecovery.hrvRmssdMs)} ms`
-                  : ""}
-              </p>
-            ) : null}
-            {whoopError ? (
-              <p className="mt-3 text-sm text-destructive" role="alert">
-                {whoopError}
-              </p>
-            ) : null}
           </div>
 
           <div className="flex items-start justify-between gap-4 rounded-xl border p-4">
@@ -242,9 +57,8 @@ const SettingsHealth = () => {
             <div>
               <p className="font-medium text-foreground">Privacy first</p>
               <p>
-                MyBodyScan requests only the permissions needed for features you
-                choose to enable. A provider is never shown as connected until
-                authorization succeeds, and you can disconnect it here.
+                Connections appear only after their native permissions and
+                privacy controls are ready for a production release.
               </p>
             </div>
           </div>

--- a/src/pages/SettingsHealth.tsx
+++ b/src/pages/SettingsHealth.tsx
@@ -1,4 +1,5 @@
-import { HeartPulse, Shield } from "lucide-react";
+import { HeartPulse, Shield, Smartphone, Watch } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 const SettingsHealth = () => {
@@ -7,40 +8,78 @@ const SettingsHealth = () => {
       <div>
         <h1 className="text-2xl font-bold">Health data</h1>
         <p className="text-muted-foreground">
-          Health sync is coming soon. Until native connectors ship, we do not
-          read or write any data from Apple Health or Google Fit.
+          Bring recovery and activity context into MyBodyScan without turning
+          your health data into another feed to manage.
         </p>
       </div>
 
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <HeartPulse className="h-5 w-5" />
-            Health integrations are disabled
+            <HeartPulse className="h-5 w-5" /> Health integrations
           </CardTitle>
         </CardHeader>
-        <CardContent className="space-y-4 text-sm text-muted-foreground">
-          <p>
-            We are intentionally holding back health imports until the native
-            connectors are ready and privacy reviews are complete. You may see
-            banners elsewhere noting that health data is unavailable—this is
-            expected.
-          </p>
-          <div className="flex items-start gap-2 rounded-lg bg-muted/50 p-3">
-            <Shield className="mt-0.5 h-4 w-4 text-muted-foreground" />
+        <CardContent className="space-y-3">
+          <div className="flex items-start justify-between gap-4 rounded-xl border p-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <Smartphone className="mt-0.5 h-5 w-5 shrink-0" />
+              <div>
+                <p className="font-medium">Apple Health</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Planned primary iPhone health source for activity, heart-rate,
+                  sleep, and recovery context when supported by the device.
+                </p>
+              </div>
+            </div>
+            <Badge variant="secondary" className="shrink-0">
+              Priority
+            </Badge>
+          </div>
+
+          <div className="flex items-start justify-between gap-4 rounded-xl border p-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <Watch className="mt-0.5 h-5 w-5 shrink-0" />
+              <div>
+                <p className="font-medium">WHOOP</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Direct recovery integration is prepared as a separate source.
+                  Connection stays disabled until approved OAuth credentials are
+                  configured and the privacy review is complete.
+                </p>
+              </div>
+            </div>
+            <Badge variant="outline" className="shrink-0">
+              Planned
+            </Badge>
+          </div>
+
+          <div className="flex items-start justify-between gap-4 rounded-xl border p-4">
+            <div className="flex min-w-0 items-start gap-3">
+              <Smartphone className="mt-0.5 h-5 w-5 shrink-0" />
+              <div>
+                <p className="font-medium">Health Connect</p>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Planned Android health source for compatible activity and
+                  wellness data.
+                </p>
+              </div>
+            </div>
+            <Badge variant="outline" className="shrink-0">
+              Planned
+            </Badge>
+          </div>
+
+          <div className="flex items-start gap-2 rounded-lg bg-muted/50 p-3 text-sm text-muted-foreground">
+            <Shield className="mt-0.5 h-4 w-4 shrink-0" />
             <div>
-              <p className="font-medium text-foreground">
-                Privacy-first stance
-              </p>
+              <p className="font-medium text-foreground">Privacy first</p>
               <p>
-                We will only request health permissions once the connectors are
-                live and audited. No data is pulled from your device today.
+                No health provider is connected by this screen today. MyBodyScan
+                will request only the permissions needed for features the user
+                chooses to enable, and a provider will never be shown as
+                connected until authorization succeeds.
               </p>
             </div>
-          </div>
-          <div className="rounded-md border border-dashed p-3 text-xs">
-            Coming soon: step counts, active energy, and resting heart rate
-            summaries routed into your Today dashboard.
           </div>
         </CardContent>
       </Card>

--- a/src/pages/SettingsHealth.tsx
+++ b/src/pages/SettingsHealth.tsx
@@ -1,8 +1,111 @@
-import { HeartPulse, Shield, Smartphone, Watch } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  HeartPulse,
+  Loader2,
+  RefreshCw,
+  Shield,
+  Smartphone,
+  Unplug,
+  Watch,
+} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  disconnectWhoop,
+  getWhoopStatus,
+  startWhoopConnection,
+  syncWhoopRecovery,
+  type WhoopConnectionStatus,
+  type WhoopRecovery,
+} from "@/lib/health/whoop";
+import { openExternalUrl } from "@/lib/platform";
 
 const SettingsHealth = () => {
+  const [whoop, setWhoop] = useState<WhoopConnectionStatus | null>(null);
+  const [whoopBusy, setWhoopBusy] = useState(false);
+  const [whoopError, setWhoopError] = useState<string | null>(null);
+  const [latestRecovery, setLatestRecovery] = useState<WhoopRecovery | null>(
+    null
+  );
+
+  const refreshWhoop = useCallback(async () => {
+    try {
+      const next = await getWhoopStatus();
+      setWhoop(next);
+      setWhoopError(null);
+    } catch {
+      setWhoopError("WHOOP status could not be loaded. Try again shortly.");
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshWhoop();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") void refreshWhoop();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [refreshWhoop]);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const result = params.get("whoop");
+    if (result === "connected") {
+      setWhoopError(null);
+      void refreshWhoop();
+    } else if (result === "error") {
+      setWhoopError(
+        "WHOOP authorization was not completed. You can try again."
+      );
+    }
+  }, [refreshWhoop]);
+
+  const connect = async () => {
+    setWhoopBusy(true);
+    setWhoopError(null);
+    try {
+      const authorizationUrl = await startWhoopConnection();
+      await openExternalUrl(authorizationUrl);
+    } catch (error) {
+      setWhoopError(
+        error instanceof Error
+          ? error.message
+          : "WHOOP connection could not be started."
+      );
+    } finally {
+      setWhoopBusy(false);
+    }
+  };
+
+  const sync = async () => {
+    setWhoopBusy(true);
+    setWhoopError(null);
+    try {
+      const result = await syncWhoopRecovery();
+      setLatestRecovery(result.recovery);
+      await refreshWhoop();
+    } catch {
+      setWhoopError("WHOOP recovery could not be synced. Try again shortly.");
+    } finally {
+      setWhoopBusy(false);
+    }
+  };
+
+  const disconnect = async () => {
+    setWhoopBusy(true);
+    setWhoopError(null);
+    try {
+      await disconnectWhoop();
+      setLatestRecovery(null);
+      await refreshWhoop();
+    } catch {
+      setWhoopError("WHOOP could not be disconnected. Try again shortly.");
+    } finally {
+      setWhoopBusy(false);
+    }
+  };
+
   return (
     <div className="space-y-6">
       <div>
@@ -36,21 +139,86 @@ const SettingsHealth = () => {
             </Badge>
           </div>
 
-          <div className="flex items-start justify-between gap-4 rounded-xl border p-4">
-            <div className="flex min-w-0 items-start gap-3">
-              <Watch className="mt-0.5 h-5 w-5 shrink-0" />
-              <div>
-                <p className="font-medium">WHOOP</p>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  Direct recovery integration is prepared as a separate source.
-                  Connection stays disabled until approved OAuth credentials are
-                  configured and the privacy review is complete.
-                </p>
+          <div className="rounded-xl border p-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="flex min-w-0 items-start gap-3">
+                <Watch className="mt-0.5 h-5 w-5 shrink-0" />
+                <div>
+                  <p className="font-medium">WHOOP</p>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    Add recovery, resting heart rate, and HRV context after you
+                    explicitly authorize read-only access. Provider credentials
+                    and refresh tokens remain on the server.
+                  </p>
+                </div>
               </div>
+              <Badge
+                variant={whoop?.connected ? "default" : "outline"}
+                className="shrink-0"
+              >
+                {whoop?.connected
+                  ? "Connected"
+                  : whoop?.configured
+                    ? "Available"
+                    : "Planned"}
+              </Badge>
             </div>
-            <Badge variant="outline" className="shrink-0">
-              Planned
-            </Badge>
+            <div className="mt-4 flex flex-wrap gap-2 pl-0 sm:pl-8">
+              {!whoop ? (
+                <Button variant="outline" disabled>
+                  <Loader2 className="animate-spin" /> Checking availability
+                </Button>
+              ) : whoop.connected ? (
+                <>
+                  <Button onClick={() => void sync()} disabled={whoopBusy}>
+                    {whoopBusy ? (
+                      <Loader2 className="animate-spin" />
+                    ) : (
+                      <RefreshCw />
+                    )}
+                    Sync recovery
+                  </Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => void disconnect()}
+                    disabled={whoopBusy}
+                  >
+                    <Unplug /> Disconnect
+                  </Button>
+                </>
+              ) : whoop.configured ? (
+                <Button onClick={() => void connect()} disabled={whoopBusy}>
+                  {whoopBusy ? <Loader2 className="animate-spin" /> : <Watch />}
+                  Connect WHOOP
+                </Button>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Connection will appear after the approved WHOOP OAuth client
+                  is configured for MyBodyScan.
+                </p>
+              )}
+            </div>
+            {whoop?.lastSyncedAtMs ? (
+              <p className="mt-3 pl-0 text-xs text-muted-foreground sm:pl-8">
+                Last synced {new Date(whoop.lastSyncedAtMs).toLocaleString()}
+              </p>
+            ) : null}
+            {latestRecovery ? (
+              <p className="mt-2 pl-0 text-sm text-muted-foreground sm:pl-8">
+                Latest recovery: {latestRecovery.recoveryScore ?? "not scored"}
+                {latestRecovery.restingHeartRate != null
+                  ? ` · Resting HR ${latestRecovery.restingHeartRate} bpm`
+                  : ""}
+                {latestRecovery.hrvRmssdMs != null
+                  ? ` · HRV ${Math.round(latestRecovery.hrvRmssdMs)} ms`
+                  : ""}
+              </p>
+            ) : null}
+            {whoopError ? (
+              <p className="mt-3 text-sm text-destructive" role="alert">
+                {whoopError}
+              </p>
+            ) : null}
           </div>
 
           <div className="flex items-start justify-between gap-4 rounded-xl border p-4">
@@ -74,10 +242,9 @@ const SettingsHealth = () => {
             <div>
               <p className="font-medium text-foreground">Privacy first</p>
               <p>
-                No health provider is connected by this screen today. MyBodyScan
-                will request only the permissions needed for features the user
-                chooses to enable, and a provider will never be shown as
-                connected until authorization succeeds.
+                MyBodyScan requests only the permissions needed for features you
+                choose to enable. A provider is never shown as connected until
+                authorization succeeds, and you can disconnect it here.
               </p>
             </div>
           </div>

--- a/src/pages/Workouts.tsx
+++ b/src/pages/Workouts.tsx
@@ -57,6 +57,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { VoiceWorkoutLogger } from "@/features/workouts/VoiceWorkoutLogger";
 
 const dayNames = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 
@@ -1086,6 +1087,21 @@ export default function Workouts() {
                 <AlertDescription>{today.coachGuidance}</AlertDescription>
               </Alert>
             ) : null}
+            <VoiceWorkoutLogger
+              exercises={todayExercises.map((exercise) => ({
+                id: exercise.id,
+                name: exercise.name,
+              }))}
+              defaultUnit={units === "metric" ? "kg" : "lb"}
+              disabled={!plan || demo}
+              onApply={async ({ exerciseId, load, repsDone }) => {
+                await saveExerciseLog(exerciseId, { load, repsDone });
+                toast({
+                  title: "Workout log saved",
+                  description: "Review the exercise card to confirm the entry.",
+                });
+              }}
+            />
             {todayExercises.map((ex) => {
               const serverLog = exerciseLogs?.[ex.id] ?? null;
               const localLog = getLocalLog(ex.id);

--- a/tests/physique-scores.test.ts
+++ b/tests/physique-scores.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizePhysiqueScores,
+  physiqueOverallScore,
+  physiquePriorityAreas,
+  physiqueStrengthAreas,
+} from "@/lib/physiqueScores";
+
+describe("physique development scores", () => {
+  it("keeps only explicit supported numeric scores and clamps them safely", () => {
+    expect(
+      normalizePhysiqueScores({
+        chest: 72.4,
+        back: "81",
+        shoulders: 104,
+        arms: -4,
+        core: null,
+        legs: "not-a-score",
+        inventedRegion: 99,
+      })
+    ).toEqual({ chest: 72, back: 81, shoulders: 100, arms: 0 });
+  });
+
+  it("never turns qualitative prose into a score", () => {
+    expect(
+      normalizePhysiqueScores({
+        chest: "well developed",
+        back: "priority area",
+      })
+    ).toEqual({});
+  });
+
+  it("identifies lowest and strongest explicit development areas", () => {
+    const scores = {
+      chest: 63,
+      back: 78,
+      shoulders: 81,
+      arms: 69,
+      core: 72,
+      legs: 75,
+    };
+    expect(physiquePriorityAreas(scores, 2).map((item) => item.key)).toEqual([
+      "chest",
+      "arms",
+    ]);
+    expect(physiqueStrengthAreas(scores, 2).map((item) => item.key)).toEqual([
+      "shoulders",
+      "back",
+    ]);
+    expect(physiqueOverallScore(scores)).toBe(73);
+  });
+
+  it("does not publish an overall score from sparse data", () => {
+    expect(physiqueOverallScore({ chest: 80, back: 70, legs: 75 })).toBeNull();
+  });
+});

--- a/tests/rules/src/rules.test.ts
+++ b/tests/rules/src/rules.test.ts
@@ -224,6 +224,24 @@ d("Firestore security rules", () => {
     await assertFails(previewRef.delete());
   });
 
+  it("never exposes OAuth state or provider tokens to clients", async () => {
+    const uid = "health-owner";
+    await testEnv.withSecurityRulesDisabled(async (ctx: any) => {
+      const admin = ctx.firestore();
+      await admin.doc(`users/${uid}/serverHealth/whoop`).set({
+        accessToken: "server-only",
+        refreshToken: "server-only",
+      });
+      await admin.doc("oauthStates/state-hash").set({ uid, provider: "whoop" });
+    });
+    const owner = testEnv.authenticatedContext(uid).firestore();
+    await assertFails(owner.doc(`users/${uid}/serverHealth/whoop`).get());
+    await assertFails(
+      owner.doc(`users/${uid}/serverHealth/whoop`).set({ connected: true })
+    );
+    await assertFails(owner.doc("oauthStates/state-hash").get());
+  });
+
   it("blocks cross-user access", async () => {
     const uid1 = "alice";
     const uid2 = "bob";

--- a/tests/voice-workout.test.ts
+++ b/tests/voice-workout.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { matchVoiceExercise, parseVoiceWorkoutEntry } from "@/lib/voiceWorkout";
+
+describe("voice workout logging", () => {
+  it("parses a common weight-for-reps phrase", () => {
+    expect(parseVoiceWorkoutEntry("bench press 225 for 8", "lb")).toEqual({
+      exercise: "bench press",
+      weight: 225,
+      reps: 8,
+      sets: null,
+      unit: "lb",
+      confidence: "high",
+      transcript: "bench press 225 for 8",
+    });
+  });
+
+  it("parses sets, reps, load, and explicit units", () => {
+    expect(parseVoiceWorkoutEntry("squat 3 sets of 5 at 315 pounds")).toEqual({
+      exercise: "squat",
+      weight: 315,
+      reps: 5,
+      sets: 3,
+      unit: "lb",
+      confidence: "high",
+      transcript: "squat 3 sets of 5 at 315 pounds",
+    });
+  });
+
+  it("supports metric gym logging", () => {
+    expect(parseVoiceWorkoutEntry("deadlift 180 kg x 5")).toMatchObject({
+      exercise: "deadlift",
+      weight: 180,
+      reps: 5,
+      unit: "kg",
+    });
+  });
+
+  it("rejects ambiguous free-form speech instead of guessing", () => {
+    expect(parseVoiceWorkoutEntry("bench felt pretty good today")).toBeNull();
+  });
+
+  it("matches a parsed phrase to the existing workout exercise", () => {
+    const entry = parseVoiceWorkoutEntry("barbell bench press 225 for 8", "lb");
+    expect(entry).not.toBeNull();
+    const match = matchVoiceExercise(entry!, [
+      { id: "bench", name: "Barbell Bench Press" },
+      { id: "row", name: "Chest-Supported Row" },
+    ]);
+    expect(match?.id).toBe("bench");
+  });
+});


### PR DESCRIPTION
## Summary

- connect the original six-region physique development score contract to the four-photo scan, full Results report, and conservative workout priorities
- mount confirmation-first voice and typed quick logging in the active workout session through the existing workout history path
- implement WHOOP OAuth authorization, one-time state, server-only token storage and refresh, recovery sync, disconnect/revocation, and account-deletion cleanup
- keep Apple Health and Health Connect accurately labeled as planned until their separate native privacy and device review
- align App Check, Firebase secret bindings, Firestore rules, privacy disclosures, and the production runbook with the implemented behavior
- resolve the Functions high-severity dependency advisory without a breaking framework migration

## Safety and privacy boundaries

- physique scores describe visible development only; they are not strength, medical, diagnostic, or regional body-composition measurements
- sparse scans do not receive overall, strength, or priority comparisons
- ambiguous workout phrases fail closed and require confirmation before saving
- WHOOP access and refresh tokens remain under server-only Firestore paths denied by client rules
- WHOOP connect and sync require the canonical Pro entitlement; signed-in users can still disconnect after entitlement expiry
- the provider callback is exempt only from strict App Check because WHOOP cannot supply an App Check token; signed, expiring, one-time OAuth state remains mandatory

## Verification

- web: 120 files / 357 tests passed
- Functions on Node 22: 105 / 105 tests passed
- lint: 0 errors (historical warnings remain)
- web and Functions type-checks passed
- production build, bundle-size safeguard, Storage REST safeguard, native release guards, and rules parity passed
- iOS native bundle verification passed
- GitHub Web and Functions jobs passed, including Java 21 Firestore emulator rule tests

## Release boundary

This change does not alter mobile build numbers or submit Apple/Google releases. Before Firebase deployment, create the WHOOP developer application, register `https://mybodyscanapp.com/api/health/whoop/callback`, and create enabled `WHOOP_CLIENT_ID` and `WHOOP_CLIENT_SECRET` secret versions in Firebase project `mybodyscan-f3daf`. Keep WHOOP unavailable until a physical-device OAuth, refresh, recovery-sync, disconnect, and account-deletion smoke test passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added physique development scores to scan results, including strength areas and training priorities.
  - Workout plans can prioritize lower-scoring body regions when scan data is sufficient.
  - Added voice or typed workout logging with exercise matching, load, reps, sets, and unit support.
  - Added prepared WHOOP connection, recovery sync, and disconnect capabilities.

- **Documentation**
  - Updated privacy and release guidance for health-provider connections and deferred integrations.

- **Security**
  - Strengthened protection for health-provider credentials and authorization data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->