### PR TITLE
Fix deferred WHOOP secret discovery

### DIFF
--- a/functions/src/account.ts
+++ b/functions/src/account.ts
@@ -8,7 +8,6 @@ import { onCallWithOptionalAppCheck } from "./util/callable.js";
 import { deletePushTokenOwnershipForUser } from "./pushTokenOwnership.js";
 import { deleteStripeCustomerForUser } from "./accountDeletion.js";
 import { stripeSecretKeyParam, stripeSecretParam } from "./stripe/keys.js";
-import { deleteWhoopDataForAccount } from "./health/whoopRouter.js";
 
 const auth = getAuth();
 const db = getFirestore();
@@ -41,7 +40,6 @@ async function deleteFirestoreUser(
   const ref = db.doc(`users/${uid}`);
   console.log("account_delete_firestore_begin", { uid, requestId });
   await deletePushTokenOwnershipForUser(db, uid);
-  await deleteWhoopDataForAccount(uid);
   await db.recursiveDelete(ref);
   console.log("account_delete_firestore_complete", { uid, requestId });
 }

--- a/functions/src/http/deleteAccount.ts
+++ b/functions/src/http/deleteAccount.ts
@@ -7,7 +7,6 @@ import { verifyAppCheck } from "../http.js";
 import { deletePushTokenOwnershipForUser } from "../pushTokenOwnership.js";
 import { deleteStripeCustomerForUser } from "../accountDeletion.js";
 import { stripeSecretKeyParam, stripeSecretParam } from "../stripe/keys.js";
-import { deleteWhoopDataForAccount } from "../health/whoopRouter.js";
 
 export const deleteAccount = onRequest(
   {
@@ -69,6 +68,5 @@ async function deleteUserData(uid: string) {
   await bucket.deleteFiles({ prefix: `user_uploads/${uid}/` });
   await bucket.deleteFiles({ prefix: `transformation-previews/${uid}/` });
   await deletePushTokenOwnershipForUser(db, uid);
-  await deleteWhoopDataForAccount(uid);
   await db.recursiveDelete(db.doc(`users/${uid}`));
 }


### PR DESCRIPTION
## Summary

- remove the final WHOOP cleanup imports from launch account-deletion handlers
- prevent Firebase source analysis from discovering deferred WHOOP secrets
- keep the provider foundation isolated for a later approved release

## Verification

- Functions build and tests: 105/105 passed on Node 22
- compiled launch handlers contain no WHOOP import/reference
- production deployment previously failed closed before changing Functions, proving this is the remaining discovery path
